### PR TITLE
Add Masterduel banlist

### DIFF
--- a/Masterduel.Iflist.conf
+++ b/Masterduel.Iflist.conf
@@ -1,0 +1,175 @@
+#[2022-1-18 Master Duel]
+!2022-1-18 Master Duel
+#Forbidden Master Duel
+91869203 0 --Amazoness Archer
+25862681 0 --Ancient Fairy Dragon
+9929398 0 --Blackwing - Gofu the Vague Shadow
+9047460 0 --Blackwing - Steam the Cloak
+53804307 0 --Blaster, Dragon Ruler of Infernos
+11384280 0 --Cannon Soldier
+14702066 0 --Cannon Soldier MK-2
+15341821 0 --Dandylion
+8903700 0 --Djinn Releaser of Rituals
+51858306 0 --Eclipse Wyvern
+17412721 0 --Elder Entity Norden
+78706415 0 --Fiber Jar
+93369354 0 --Fishborg Blaster
+71525232 0 --Gandora-X the Dragon of Demolition
+67441435 0 --Glow-Up Blub
+75732622 0 --Grinder Golem
+59537380 0 --Guardragon Agarpain
+86148577 0 --Guardragon Elpy
+94677445 0 --Ib the World Chalice Justiciar
+39064822 0 --Knightmare Goblin
+3679218 0 --Knightmare Mermaid
+34086406 0 --Lavalval Chain
+57421866 0 --Level Eater
+85243784 0 --Linkross
+4423206 0 --M-X-Saber Invoker
+34206604 0 --Magical Scientist
+31178212 0 --Majespecter Unicorn - Kirin
+21377582 0 --Master Peace, the True Dracoslaying King
+96782886 0 --Mind Master
+54719828 0 --Number 16: Shock Master
+58820923 0 --Number 95: Galaxy-Eyes Dark Matter Dragon
+52653092 0 --Number S0: Utopic ZEXAL
+34945480 0 --Outer Entity Azathot
+7563579 0 --Performage Plushfire
+17330916 0 --Performapal Monkeyboard
+23558733 0 --Phoenixian Cluster Amaryllis
+37818794 0 --Red-Eyes Dark Dragoon
+90411554 0 --Redox, Dragon Ruler of Boulders
+20663556 0 --Substitoad
+61665245 0 --Summon Sorceress
+18326736 0 --Tellarknight Ptolemaeus
+63101919 0 --Tempest Magician
+88071625 0 --The Tyrant Neptune
+26400609 0 --Tidal, Dragon Ruler of Waterfalls
+79875176 0 --Toon Cannon Soldier
+22593417 0 --Topologic Gumblar Dragon
+44910027 0 --Victory Dragon
+16923472 0 --Wind-Up Hunter
+3078576 0 --Yata-Garasu
+85115440 0 --Zoodiac Broadbull
+78872731 0 --Zoodiac Ratpier
+69243953 0 --Butterfly Dagger - Elma
+57953380 0 --Card of Safe Return
+4031928 0 --Change of Heart
+60682203 0 --Cold Wave
+17375316 0 --Confiscation
+44763025 0 --Delinquent Duo
+23557835 0 --Dimension Fusion
+31423101 0 --Divine Sword - Phoenix Blade
+42703248 0 --Giant Trunade
+19613556 0 --Heavy Storm
+85602018 0 --Last will
+34906152 0 --Mass Driver
+46411259 0 --Metamorphosis
+41482598 0 --Mirage of Nightmare
+76375976 0 --Mystic Mine
+74191942 0 --Painful Choice
+55144522 0 --Pot of Greed
+70828912 0 --Premature Burial
+73468603 0 --Set Rotation
+45986603 0 --Snatch Steal
+54447022 0 --Soul Charge
+46448938 0 --Spellbook of Judgment
+42829885 0 --The Forceful Sentry
+46060017 0 --Zoodiac Barrage
+28566710 0 --Last Turn
+17178486 0 --Life Equalizer
+32723153 0 --Magical Explosion
+27174286 0 --Return from the different Dimension
+93016201 0 --Royal Oppression
+57585212 0 --Self-Destruct Button
+3280747 0 --Sixth Sense
+35316708 0 --Time Seal
+64697231 0 --Trap Dustshoot
+80604091 0 --Ultimate Offering
+#Limited
+1561110 1 --ABC-Dragon Buster
+42790071 1 --Altergeist Mutifaker
+28985331 1 --Armageddon Knight
+76794549 1 --Astrograph Sorcerer
+6602300 1 --Blaze Fenix, the Burning Bombardment Bird
+12289247 1 --Chronograph Sorcerer
+50588353 1 --Crystron Halqifibrax
+69015963 1 --Cyber-Stein
+82385847 1 --Dinowrestler Prankratops
+90448279 1 --Divine Arsenal AA-ZEUS - Sky Tunder
+49684352 1 --Double Iris Magician
+33396948 1 --Exodia the Forbidden One
+30741503 1 --Galatea, the Orcust Automaton
+64034255 1 --Genex Ally Birdman
+69811710 1 --Girsu, the Orcust Mekk-Knight
+24094258 1 --Heavymetalfoes Electrumite
+7902349 1 --Left Arm of the Forbidden One
+44519536 1 --Left Leg of the Forbidden One
+92746535 1 --Luster Pendulum, the Dracoslayer
+33508719 1 --Morphing Jar
+16226786 1 --Night Assailant
+57835716 1 --Orcust Harp Horror
+35272499 1 --Predaplant Ophrys Scorpio
+70369116 1 --Predaplant Verte Anaconda
+74586817 1 --PSY-Framelord Omega
+70903634 1 --Right Arm of the Forbidden One
+8124921 1 --Right Leg of the Forbidden One
+26889158 1 --Salamangreat Gazelle
+74997493 1 --Saryuja Skull Dread
+63288573 1 --Sky Striker Ace - Kagari
+81275020 1 --Speedroid Terrortop
+78080961 1 --SPYRAL Quik-Fix
+69610326 1 --Supreme King Dragon Darkwurm
+90953320 1 --T.G. Hyper Librarian
+89399912 1 --Tempest, Dragon Ruler of Storms
+15291624 1 --Thunder Dragon Colossus
+83107873 1 --Thunder Dragonhawk
+90809975 1 --Toadally Awesome
+52687916 1 --Trishula, Dragon of the Ice Barrier
+88581108 1 --True King of All Calamities
+81122844 1 --Wind-Up Carrier Zenmaity
+48905153 1 --Zoodiac Drident
+7394770 1 --Brilliant Fusion
+72892473 1 --Card Destruction
+15854426 1 --Divine Wind of Mist Valley
+13035077 1 --Dragonic Diagram
+81439173 1 --Foolish Burial
+27970830 1 --Gateway of the Six
+75500286 1 --Gold Sarcophagus
+18144506 1 --Harpie's Feather Duster
+66957584 1 --Infernity Launcher
+83764718 1 --Monster Reborn
+1984618 1 --Nadir Servant
+33782437 1 --One Day of Peace
+2295440 1 --One for One
+12580477 1 --Raigeki
+32807846 1 --Reinforcement of the Army
+52340444 1 --Sky Striker Mecha - Horent Drones
+73628505 1 --Terraforming
+35371948 1 --Trickstar Light Stage
+61740673 1 --Imperial Order
+89208725 1 --Metaverse
+23002292 1 --Red Reboot
+21076084 1 --Trickstar Reincarnation
+5851097 1 --Vanity's Emptiness
+#Semi-Limited
+43694650 2 --Danger!? Jackalope?
+9411399 2 --Destiny HERO - Malicious
+73941492 2 --Harmonizing Magician
+48686504 2 --Lonefire Blossom
+38814750 2 --PSY-Framegear Gamma
+88264978 2 --Red-Eyes Darkness Metal Dragon
+44335251 2 --Souleating Oviraptor
+29596581 2 --Thunder Dragonroar
+24224830 2 --Called by the Grave
+31434645 2 --Cursed Eldland
+67723438 2 --Emergency Teleport
+47679935 2 --Magical Meltdown
+93600443 2 --Mask Change 2
+84731222 2 --Memories of Hope
+37520316 2 --Mind Control
+73915051 2 --ScapeGoat
+98338152 2 --Sky Striker Mecha - Widow Anchor
+63166095 2 --Sky Striker Mobilize - Engage!
+48130397 2 --Super Polymerization
+73680966 2 --The Beginning of the End


### PR DESCRIPTION
Doesn't account for the entire master duel card pool for cards like air neos or past the newest pack. Just the banned / limited cards.