### PR TITLE
YCS Niagra Speed Duel F/L List

### DIFF
--- a/Speed.lflist.conf
+++ b/Speed.lflist.conf
@@ -1,16 +1,23 @@
-#[2020.05 Speed Duel]
-!2020.05 Speed Duel
+#[2022.10.07 Speed Duel Midterm Paradox Box]
+!2022.10.07 Speed Duel Midterm Paradox Box
 $whitelist
 #unlimited
 86198326 3 --7 Completed
 24140059 3 --A Cat of Ill Omen
+21597117 3 --A Hero Emerges
 32207100 3 --A Major Upset
+3900605 3 --Absorbing Jar
+41356845 3 --Acid Trap Hole
 62325062 3 --Adhesion Trap Hole
+12644061 3 --Advanced Dark
 46052429 3 --Advanced Ritual Art
+18036057 3 --Airknight Parshath
 70924884 3 --Alinsection
 64428736 3 --Alligator's Sword
 3366982 3 --Alligator's Sword Dragon
+89386122 3 --Ally of Justice Clausolas
 36629203 3 --Ally of Justice Core Destroyer
+99785935 3 --Alpha The Magnet Warrior
 67987611 3 --Amazoness Archers
 29654737 3 --Amazoness Chain Master
 79965360 3 --Amazoness Heirloom
@@ -19,86 +26,240 @@ $whitelist
 94004268 3 --Amazoness Swords Woman
 89567993 3 --Amazoness Trainee
 712559 3 --Amazoness Village
+303660 3 --Amplifier
 5183693 3 --Amulet of Ambition
 42431843 3 --Ancient Brain
+34487429 3 --Ancient City - Rainbow Ruins
+300302022 3 --Ancient Fusion
+31557782 3 --Ancient Gear
+10509340 3 --Ancient Gear Beast
+92001300 3 --Ancient Gear Castle
+1953925 3 --Ancient Gear Engineer
+18486927 3 --Ancient Gear Gadget
+83104731 3 --Ancient Gear Golem
+39303359 3 --Ancient Gear Knight
+56094445 3 --Ancient Gear Soldier
+56784842 3 --Angel O7
 89904598 3 --Anthrosaurus
 9156135 3 --Apprentice Magician
+85639257 3 --Aqua Madoor
 6150044 3 --Arcana Knight Joker
 17896384 3 --Arcane Barrier
+50287060 3 --Archfiend of Gilfer
+22796548 3 --Archfiend's Oath
+300302023 3 --Armed and Ready!
+980973 3 --Armed Dragon LV3
+46384672 3 --Armed Dragon LV5
+73879377 3 --Armed Dragon LV7
 20277860 3 --Armored Zombie
 300202007 3 --Aroma Strategy
 62633180 3 --Assault on GHQ
+83715234 3 --Attack the Moon!
 48305365 3 --Axe Raider
 88819587 3 --Baby Dragon
+28486799 3 --Backup Squad
 300103003 3 --Bandit
-81480460 3 --Barrel Dragon
+61528025 3 --Banisher of the Light
+94853057 3 --Banisher of the Radiance
+41925941 3 --Bark of Dark Ruler
+81480461 3 --Barrel Dragon
 88610708 3 --Bashing Shield
 89091579 3 --Basic Insect
 5053103 3 --Battle Ox
+42233477 3 --Battleguard Rage
+40133511 3 --Bazoo the Soul-Eater
+11761845 3 --Beast of Talwar
+300302006 3 --Beasts of Phantom
 300202002 3 --Beatdown!
+32452818 3 --Beaver Warrior
 1474910 3 --Bee List Soldier
 30587695 3 --Beetron
+22996376 3 --Behemoth the King of All Animals
+300302043 3 --Behold, Gate Guardian!
+300302044 3 --Believe in your Bro
+77207191 3 --Berfomet
+52497105 3 --Berserk Scales
+39256679 3 --Beta The Magnet Warrior
+300302045 3 --Beware the Brothers Paradox!
 53606874 3 --Big Insect
+42129512 3 --Big Koala
 51562916 3 --Big Wave Small Wave
 45547649 3 --Birdface
+50896944 3 --Black Brachios
 41426869 3 --Black Illusion Ritual
+55761792 3 --Black Luster Ritual
+5405694 3 --Black Luster Soldier
 76792184 3 --Black Magic Ritual
 90654356 3 --Black Ptera
 79409334 3 --Black Stego
 38670435 3 --Black Tyranno
 39507162 3 --Blade Knight
+97023549 3 --Blade Skater
 89041555 3 --Blast Held by a Tribute
 26302522 3 --Blast Sphere
+69537999 3 --Blaze Accelerator
+300302024 3 --Blaze Accelerator Deployment (Skill Card)
+5464695 3 --Blazing Inpachi
 25880422 3 --Block Attack
+72580321 3 --Block Golem
 97783659 3 --Blood Sucker
+25551951 3 --Blowback Dragon
 55969226 3 --Blue Dragon Summoner
 35282433 3 --Blue-Eyed Silver Zombie
 23995346 3 --Blue-Eyes Ultimate Dragon
 89631139 3 --Blue-Eyes White Dragon
 8715625 3 --Bokoichi the Freightening Car
+263926 3 --Bonze Alone
 2204140 3 --Book of Life
+52090844 3 --Bowganian
+74277583 3 --Brave Scizzar
 63851864 3 --Break! Draw!
 17655904 3 --Burst Stream of Destruction
 78193831 3 --Buster Blader
+3428069 3 --Buster Blader, the Destruction Swordmaster
+17597059 3 --Byser Shock
 300101003 3 --Call of the Haunted (Skill Card)
 52112003 3 --Card Advance
 300102003 3 --Catch of the Day
+91152256 3 --Celtic Guardian
+28106077 3 --Cestus of Dagla
 82382815 3 --Champion's Vigilance
 18914778 3 --Change Slime
+13179332 3 --Charcoal Inpachi
+7841921 3 --Charging Gaia the Fierce Knight
+300302046 3 --Chemistry in Motion
+300302047 3 --Chillin' Outback
+4796100 3 --Chimera the Flying Mythical Beast
+64599569 3 --Chimeratech Overdragon
+16956455 3 --Chiron the Mage
 92667214 3 --Clown Zombie
 40240595 3 --Cocoon of Evolution
-300104004 3 --Cocoon of Ultra Evolution (Skill Card)
+65830223 3 --Coffin Seller
 10375182 3 --Command Knight
+43417563 3 --Commencement Dance
 40465719 3 --Common Charity
 31000575 3 --Conscription
+300302025 3 --Consumed By Darkness
+21843307 3 --Copy Knight
 26376390 3 --Copycat
 13235258 3 --Corrosive Scales
 23265313 3 --Cost Down
+74458486 3 --Covering Fire
 38289717 3 --Crawling Dragon #2
 53713014 3 --Crazy Fish
+15305240 3 --Creature Seizure
+31036355 3 --Creature Swap
+78811937 3 --Creeping Darkness
+95326659 3 --Crystal Beacon
+69937550 3 --Crystal Beast Amber Mammoth
+32933942 3 --Crystal Beast Amethyst Cat
+21698716 3 --Crystal Beast Cobalt Eagle
+68215963 3 --Crystal Beast Emerald Tortoise
+32710364 3 --Crystal Beast Ruby Carbuncle
+7093411 3 --Crystal Beast Sapphire Pegasus
+95600067 3 --Crystal Beast Topaz Tiger
+35486099 3 --Crystal Blessing
+87259933 3 --Crystal Conclave
+8275702 3 --Crystal Promise
+96331676 3 --Crystal Raigeki
+10004783 3 --Crystal Release
 82099401 3 --Crystal Seer
+300302026 3 --Crystal Transcendence
+47408488 3 --Crystal Tree
+28279543 3 --Curse of Dragon
+94377247 3 --Curse of the Masked Beast
+77235086 3 --Cyber Angel Benten
+3629090 3 --Cyber Angel Idaten
+91668401 3 --Cyber Angel Izana
+300302027 3 --Cyber Blade Fusion
+10248389 3 --Cyber Blader
+70095154 3 --Cyber Dragon
+1546123 3 --Cyber End Dragon
+76763417 3 --Cyber Gymnast
+80316585 3 --Cyber Harpie Lady
+12670770 3 --Cyber Network
+3370104 3 --Cyber Phoenix
+2158562 3 --Cyber Prima
 39978267 3 --Cyber Raider
+90440725 3 --Cyber Shadow Gardna
 63224564 3 --Cyber Shield
+49375719 3 --Cyber Tutu
+3657444 3 --Cyber Valley
+82562802 3 --Cyberdark Claw
+40418351 3 --Cyberdark Dragon
+77625948 3 --Cyberdark Edge
+41230939 3 --Cyberdark Horn
+80033124 3 --Cyberdark Impact!
+3019642 3 --Cyberdark Keel
+300302028 3 --Cyberdark Style (Skill Card)
+43405287 3 --D - Chain
+8698851 3 --D - Counter
+89899996 3 --D - Spirit
+24508238 3 --D.D. Crow
+28378427 3 --Damage Condenser
 48588176 3 --Danipon
+11321183 3 --Dark Blade
+53527835 3 --Dark City
 65287621 3 --Dark Driceratops
+674561 3 --Dark Eruption
 90928333 3 --Dark Factory of Mass Production
+90980792 3 --Dark Jeroid
+85313220 3 --Dark Lucius LV4
+12817939 3 --Dark Lucius LV6
+58206034 3 --Dark Lucius LV8
 2314238 3 --Dark Magic Attack
+99789342 3 --Dark Magic Curtain
 46986414 3 --Dark Magician
 38033121 3 --Dark Magician Girl
+74713516 3 --Dark Mimic LV1
+1102515 3 --Dark Mimic LV3
+31829185 3 --Dark Necrofear
+98502113 3 --Dark Paladin
+89558090 3 --Dark Prisoner
 99261403 3 --Dark Rabbit
 45462639 3 --Dark Red Enchanter
+53982768 3 --Dark Ruler Ha Des
+48768179 3 --Dark Scorpion - Gorg the Strong
+74153887 3 --Dark Scorpion - Meanae the Thorn
+41930553 3 --Dark Smog
+29876529 3 --Darklight
+95286165 3 --De-Fusion
 19159413 3 --De-Spell
 10209545 3 --Decayed Commander
 87621407 3 --Dekoichi the Battlechanted Locomotive
+12262393 3 --Delta The Magnet Warrior
+12079734 3 --Delta Tri
+78613627 3 --Des Kangaroo
+2326738 3 --Des Lacooda
 81977953 3 --Desert Twister
 71200730 3 --Despair from the Dark
 300201002 3 --Destiny Draw (Skill Card)
+76263644 3 --Destiny End Dragoon
+55461064 3 --Destiny HERO - Blade Master
+30757127 3 --Destiny HERO - Dangerous
+26964762 3 --Destiny HERO - Dark Angel
+81866673 3 --Destiny HERO - Dasher
+13093792 3 --Destiny HERO - Diamond Dude
+17132130 3 --Destiny HERO - Dogma
+41613948 3 --Destiny HERO - Doom Lord
+80744121 3 --Destiny HERO - Fear Monger
+9411399 3 --Destiny HERO - Malicious
+83965310 3 --Destiny HERO - Plasma
+35464895 3 --Destiny Signal
+73481154 3 --Destroyer Golem
+41940225 3 --Destruction Swordsman Fusion
 3493058 3 --Dicephoon
+11961740 3 --Different Dimension Capsule
 87880531 3 --Diffusion Wave-Motion
 300302004 3 --Digging for Gold
+36733451 3 --Dimensional Alchemist
 300104003 3 --Dino Destruction
 300203001 3 --Dinosaur Kingdom
 30492798 3 --Djinn Disserere of Rituals
+4141820 3 --Djinn Prognosticator of Rituals
+79997591 3 --Doble Passe
+99721536 3 --Dokurorider
+30325729 3 --Dokuroyaiba
 76922029 3 --Don Zaloog
 44436472 3 --Double Coston
 75652080 3 --Double Cyclone
@@ -106,21 +267,57 @@ $whitelist
 300202003 3 --Dragon Caller
 66672569 3 --Dragon Zombie
 20638610 3 --Dragon's Rebirth
+43250041 3 --Draining Shield
+99050989 3 --Drillago
+55773067 3 --Drop Off
+14506878 3 --DUCKER Mobile Cannon
+12493482 3 --Dunames Dark Witch
 60082869 3 --Dust Tornado
 46508640 3 --Dweller in the Depths
-24508238 3 --D.D. Crow
+67105242 3 --Earthbound Spirit
+82828051 3 --Earthquake
 300101001 3 --Ectoplasmic Fortification!
 90219263 3 --Elegant Egotist
 92755808 3 --Element Saurus
+21844576 3 --Elemental HERO Avian
+59793705 3 --Elemental HERO Bladedge
+79979666 3 --Elemental HERO Bubbleman
+58932615 3 --Elemental HERO Burstinatrix
+84327329 3 --Elemental HERO Clayman
+41517968 3 --Elemental HERO Darkbright
+35809262 3 --Elemental HERO Flame Wingman
+89252153 3 --Elemental HERO Necroshade
+60493189 3 --Elemental HERO Plasma Vice
+47737087 3 --Elemental HERO Rampart Blaster
+20721928 3 --Elemental HERO Sparkman
+81197327 3 --Elemental HERO Steam Healer
+61204971 3 --Elemental HERO Thunder Giant
+86188410 3 --Elemental HERO Wildheart
+300302048 3 --Elements of Thunder, Water, and Wind
+73872164 3 --Eliminating the League
+6390406 3 --Emblem of Dragon Destroyer
+28649820 3 --Embodiment of Apophis
 58818411 3 --Empress Mantis
 30531525 3 --Enchanting Fitting Room
+300302007 3 --Endless Traps
+300302029 3 --Energizing Elements
 56916805 3 --Energy Drain
+76909279 3 --Enraged Battle Ox
 94716515 3 --Eradicating Aerosol
 95051344 3 --Eternal Rest
+11460577 3 --Etoile Cyber
+74131780 3 --Exiled Force
+20586572 3 --Exploder Dragon
+73507661 3 --Fairy Wind
+68396778 3 --Faustian Bargain
 41392891 3 --Feral Imp
+24874630 3 --Fiend's Sanctuary
 6178850 3 --Fighting Spirit
+52503575 3 --Final Attack Orders
 300201003 3 --Final Draw
+57103969 3 --Fire Formation - Tenki
 53581214 3 --Fire Reaper
+94804055 3 --Firewall
 51282878 3 --Fishborg Planter
 34460851 3 --Flame Manipulator
 45231177 3 --Flame Swordsman
@@ -128,26 +325,50 @@ $whitelist
 75560629 3 --Flint
 83812099 3 --Flint Lock
 69599136 3 --Floodgate Trap Hole
+300302030 3 --Forbidden Cyber Style Technique
 87430998 3 --Forest
+26931058 3 --Formation Union
 62337487 3 --Fortress Whale
 77454922 3 --Fortress Whale's Oath
+49681811 3 --Freed the Matchless General
+46181000 3 --Frontline Base
 48206762 3 --Fulfillment of the Contract
+300302005 3 --Fury of Thunder
 33550694 3 --Fusion Gate
 300302001 3 --Fusion Party!
 18511384 3 --Fusion Recovery
+22829942 3 --Fusion Recycling Plant
+26902560 3 --Fusion Sage
+37684215 3 --Fusion Sword Murasame Blade
+27967615 3 --Fusion Weapon
+77565204 3 --Future Fusion
+37955049 3 --Gaap the Divine Soldier
+66889139 3 --Gaia the Dragon Champion
+6368038 3 --Gaia The Fierce Knight
 77491079 3 --Gale Lizard
+11549357 3 --Gamma the Magnet Warrior
 19737320 3 --Gatekeeper
+5818798 3 --Gazelle the King of Mythical Beasts
 423705 3 --Gearfried the Iron Knight
 57046845 3 --Gearfried the Swordmaster
+37694547 3 --Geartown
 54635862 3 --Gentlemander
+13386503 3 --Ghost Knight of Jackal
 72299832 3 --Giant Mech-Soldier
+97017120 3 --Giant Rat
+13039848 3 --Giant Soldier of Stone
+38445524 3 --Gil Garth
 45894482 3 --Gilasaurus
 36354007 3 --Gilford the Lightning
 84620194 3 --Girochin Kuwagata
+18658572 3 --Goblin Circus
 63665875 3 --Goblin Zombie
+53493204 3 --Goddess with the Third Eye
 14472500 3 --Gokipon
 87102774 3 --Golden Ladybug
 74137509 3 --Graceful Dice
+13676474 3 --Grand Tiki Elder
+60229110 3 --Granmarg the Rock Monarch
 22134079 3 --Gravekeeper's Ambusher
 25262697 3 --Gravekeeper's Assailant
 99877698 3 --Gravekeeper's Cannonholder
@@ -161,12 +382,20 @@ $whitelist
 63695531 3 --Gravekeeper's Spear Soldier
 99523325 3 --Gravekeeper's Stele
 99690140 3 --Gravekeeper's Vassal
+48135190 3 --Gravelstorm
 32022366 3 --Gravity Axe - Grarl
 54622031 3 --Great Mammoth of Goldfine
 10809984 3 --Great Phantom Thief
 13429800 3 --Great White
+46668237 3 --Green Baboon, Defender of the Forest
 300202004 3 --Grit
+68007326 3 --Guardian Angel Joan
+300302008 3 --Guardians of the Tomb
+18325492 3 --Gyroid
 73048641 3 --Half Shut
+88789641 3 --Hallowed Life Barrier
+26412047 3 --Hammer Shot
+5640330 3 --Hannibal Necromancer
 91932350 3 --Harpie Lady 1
 27927359 3 --Harpie Lady 2
 54415063 3 --Harpie Lady 3
@@ -174,126 +403,273 @@ $whitelist
 52040216 3 --Harpie's Pet Dragon
 75782277 3 --Harpies' Hunting Ground
 39033131 3 --Haunted Shrine
+5434080 3 --Headless Knight
 45141013 3 --Heat Wave
+23265594 3 --Heavy Mech Support Platform
 300103001 3 --Heavy Metal Raiders (Skill Card)
 47025270 3 --Helping Robo for Combat
+76052811 3 --Helpoemer
+300302031 3 --Here Goes Something!
+22020907 3 --Hero Signal
+300302049 3 --HERO World
+300302050 3 --HEROES UNITE - FUSION!!
+52105192 3 --Hidden Armory
 300203004 3 --Hidden Parasite
 70000776 3 --Hidden Temples of Necrovalley
+300302009 3 --Hieratic Chant
 54579801 3 --High Tide Gyojin
+21350571 3 --Horn of the Phantom Beast
+8783685 3 --Hourglass of Life
+97922283 3 --Howl of the Wild
+96005454 3 --Hunter Dragon
 11925569 3 --Hunting Instinct
+22587018 3 --Hydrogeddon
 2671330 3 --Hyper Hammerhead
 300203003 3 --Hyper Metamorphosis
+300302010 3 --I'm Just Gonna Attack!
+300302032 3 --I've Got Dino DNA!
+28546905 3 --Illusionist Faceless Mage
+15173384 3 --Illusionist Faceless Magician
 41952656 3 --Imairuka
 7264861 3 --Infernity Beast
 25171661 3 --Infernity Dwarf
+300205001 3 --Inner Conflict
 3492538 3 --Insect Armor with Laser Cannon
 22991179 3 --Insect Neglect
 37957847 3 --Insect Princess
 91512835 3 --Insect Queen
+25005816 3 --Inspiration
 36261276 3 --Interdimensional Matter Transporter
+300205002 3 --Into the Darkness Below
 73431236 3 --Iron Blacksmith Kotetsu
 34559295 3 --Iron Draw
 300201007 3 --It's a Toon World!
+300302011 3 --It's Jinzo!
 300102004 3 --It's My Lucky Day!
+300302012 3 --It's No Monster, It's a God!
 90876561 3 --Jack's Knight
+44364207 3 --Jade Knight
 98954106 3 --Jar of Avarice
 83968380 3 --Jar of Greed
+55256016 3 --Judgment of Anubis
 16111820 3 --Jurrac Herra
 44689688 3 --Jurrac Spinos
 48411996 3 --Jurrac Stauriko
 62701967 3 --Jurrac Tyrannus
+62271284 3 --Justi-Break
 51934376 3 --Kabazauls
 34627841 3 --Kaibaman
 76634149 3 --Kairyu-Shin
+52824910 3 --Kaiser Glider
+54878498 3 --Kelbek
+80441106 3 --Keldo
 36021814 3 --King of the Skull Servants
 64788463 3 --King's Knight
+300204002 3 --Knight of Legend
 56283725 3 --Kumootoko
 37390589 3 --Kunai with Chain
+40640057 3 --Kuriboh
+88240808 3 --Kycoo the Ghost Destroyer
+97590747 3 --La Jinn the Mystical Genie of the Lamp
+90147755 3 --Lady Assailant of Flames
+79418153 3 --Lancer Archfiend
+300302033 3 --Land of the Ojamas (Skill Card)
 77007920 3 --Laser Cannon Armor
 300202005 3 --Last Gamble
 87322377 3 --Launcher Spider
+102380 3 --Lava Golem
+99747800 3 --Legendary Fiend
 61854111 3 --Legendary Sword
 25280974 3 --Legion the Fiend Jester
+16475472 3 --Lesser Fiend
+25290459 3 --Level Up!
 37721209 3 --Levia-Dragon - Daedalus
 49587034 3 --Lightforce Sword
+55226821 3 --Lightning Blade
 82324105 3 --Limit Impulse
 90790253 3 --Little-Winguard
+300302034 3 --Looking into the Future
 17985575 3 --Lord of D.
 95231062 3 --Lost Blue Breaker
+74003290 3 --Lost Wind
 300302003 3 --Low Blow
 17658803 3 --Luster Dragon #2
+42940404 3 --Machina Gearframe
+78349103 3 --Machina Peacekeeper
+300302035 3 --Machine Angel Ascension
+39996157 3 --Machine Angel Ritual
+25518020 3 --Machine Assembly Line
 25769732 3 --Machine Conversion Factory
+70406920 3 --Machine King - 3000 B.C.
+31034919 3 --Mad Reloader
 79870141 3 --Mad Sword Beast
+83746708 3 --Mage Power
+59344077 3 --Magic Drain
+67227834 3 --Magic Formula
 77414722 3 --Magic Jammer
 46474915 3 --Magical Ghost
+81210420 3 --Magical Hats
 7802006 3 --Magical Plant Mandragola
 98494543 3 --Magical Stone Excavation
 30608985 3 --Magical Undertaker
 30208479 3 --Magician of Black Chaos
 31560081 3 --Magician of Faith
+300302013 3 --Magician's Act
 50755 3 --Magician's Circle
 36045450 3 --Magicians Unite
+77133792 3 --Magnet Conversion
+17841166 3 --Magnet Force
+300302014 3 --Magnetic Attraction
+4740489 3 --Magnetic Field
+93013676 3 --Maha Vailo
 54652250 3 --Man-Eater Bug
+38369349 3 --Manga Ryu-Ran
+77121851 3 --Manticore of Darkness
 71466592 3 --Maryokutai
 44287299 3 --Masaki the Legendary Swordsman
+82432018 3 --Mask of Brutality
 28933734 3 --Mask of Darkness
 56948373 3 --Mask of the Accursed
+57882509 3 --Mask of Weakness
+48948935 3 --Masked Beast Des Gardius
 25727454 3 --Master Craftsman Gamil
+27134689 3 --Master of Oz
+7359741 3 --Mechanicalchaser
+46820049 3 --Mefist the Infernal General
+86569121 3 --Melchid the Four-Face Beast
+71098407 3 --Memory Loss
 65957473 3 --Metal Armored Bug
+26905245 3 --Metal Reflect Slime
 68540059 3 --Metalmorph
-90660762 3 --Meteor B. Dragon
+90660762 3 --Meteor Black Dragon
 64271667 3 --Meteor Dragon
 37580756 3 --Michizure
+300302036 3 --Middle Age Mechs (Skill Card)
 300201009 3 --Millennium Eye (Skill Card)
 300201006 3 --Millennium Necklace (Skill Card)
 88032456 3 --Mimicat
+15800838 3 --Mind Crush
 300201008 3 --Mind Scan (Skill Card)
+34815282 3 --Miniaturize
+22359980 3 --Mirror Wall
+75285069 3 --Moisture Creature
+27288416 3 --Mokey Mokey
+1965724 3 --Mokey Mokey Smackdown
 22123627 3 --Moray of Greed
 50913601 3 --Mountain
+82108372 3 --Mudora
+1347977 3 --Mysterious Guard
 68516705 3 --Mystic Horseman
 15025844 3 --Mystical Elf
 300102002 3 --Mythic Depths
+70084224 3 --Neck Hunter
+14315573 3 --Negate Attack
+4335645 3 --Newdoria
+16226786 3 --Night Assailant
 89882100 3 --Night Beam
 300203002 3 --Nightmare Sonic Blast!
+300302015 3 --No More Mrs. Nice Mai!
+71044499 3 --Nobleman of Crossout
+17449108 3 --Nobleman of Extermination
+10000000 3 --Obelisk the Tormentor
+19230408 3 --Offerings to the Doomed
+79335209 3 --Ojama Black
+64627453 3 --Ojama Blue
+90011152 3 --Ojama Country
+8251996 3 --Ojama Delta Hurricane!!
+12482652 3 --Ojama Green
+90140980 3 --Ojama King
+40391316 3 --Ojama Knight
+37132349 3 --Ojama Red
+42941100 3 --Ojama Yellow
+24643836 3 --Ojamagic
+38395123 3 --Ojamatch
+45141844 3 --Old Vindictive Magician
+14531242 3 --Opticlops
 78986941 3 --Order to Charge
 39019325 3 --Order to Smash
+72204747 3 --Over Destiny
+3659803 3 --Overload Fusion
 300202006 3 --Pal-O'Mine-zation!
-14457896 3 --Parasite Paranoid
+73398797 3 --Paladin of White Dragon
 62762898 3 --Parrot Dragon
 19153634 3 --Patrician of Darkness
 300202001 3 --Peak Performance
 24433920 3 --Pendulum Machine
 48579379 3 --Perfectly Ultimate Great Moth
+4849037 3 --Performance of Sword
 58192742 3 --Petit Moth
+71181155 3 --Phantom Beast Cross-Wing
+34961968 3 --Phantom Beast Thunder-Pegasus
+7576264 3 --Phantom Beast Wild-Horn
 63571750 3 --Pharaoh's Treasure
 26185991 3 --Pinch Hopper
+88975532 3 --Pitch-Black Warwolf
 24094653 3 --Polymerization
 52860176 3 --Possessed Dark Soul
+300302051 3 --Power Bond (Skill Card)
 300201001 3 --Power of Dark
+300302016 3 --Power of Friendship
 77027445 3 --Power of Kaishin
-300301001 3 --Power Up! (Skill Card)
+300302021 3 --Power Up!
+300302037 3 --Powerful Group of Guys
+13048472 3 --Pre-Preparation of Rites
 300201004 3 --Prescience
+66518841 3 --Prideful Roar
+82213171 3 --Prometheus, King of the Shadows
+26439287 3 --Proto-Cyber Dragon
+72563071 3 --Psychic Shockwave
+41442341 3 --Puppet Master
 66835946 3 --Pyramid of Wonders
+87772572 3 --Quantum Cat
 25652259 3 --Queen's Knight
+37318031 3 --R - Righteous Justice
 94905343 3 --Rabid Horseman
+90810762 3 --Raging Flame Sprite
+300302038 3 --Rainbow Crystal Collection
+79407975 3 --Rainbow Dark Dragon
+79856792 3 --Rainbow Dragon
+63806265 3 --Rainbow Gravity
+34002992 3 --Rainbow Life
+37440988 3 --Rainbow Overdragon
 51267887 3 --Raise Body Heat
+12503902 3 --Rare Metalmorph
+60876124 3 --Rare Value
 31785398 3 --Ready for Intercepting
-74677422 3 --Red-Eyes B. Dragon
+65570596 3 --Red Archery Girl
+74677422 3 --Red-Eyes Black Dragon
 44397496 3 --Red-Eyes Spirit
+70821187 3 --Regenerating Mummy
 17814387 3 --Reinforcements
 75417459 3 --Release Restraint
 64631466 3 --Relinquished
+31066283 3 --Revival of Dokurorider
 34016756 3 --Riryoku
+70344351 3 --Riryoku Field
+300302017 3 --Rise of the Fallen
+78211862 3 --Rising Energy
 30450531 3 --Rite of Spirit
 300302002 3 --Ritual Ceremony
+300204001 3 --Ritual of Black Mastery
+34334692 3 --Ritual Raven
+54351224 3 --Ritual Weapon
 83258273 3 --Robbin' Zombie
+20781762 3 --Rock Bombardment
+30860696 3 --Rocket Warrior
 91939608 3 --Rogue Doll
+91597389 3 --Roll Out!
+300302039 3 --Room for Growth
+93382620 3 --Rope of Life
+54040221 3 --Royal Firestorm Guards
 300101004 3 --Royal Flush
 49868263 3 --Ryu Senshi
 24611934 3 --Ryu-Kishin Powered
 13604200 3 --Sage's Stone
+66602787 3 --Saggi the Dark Clown
+32268901 3 --Salamandra
 46565218 3 --Santa Claws
 16222645 3 --Sasuke Samurai
+1802450 3 --Sealing Ceremony of Mokuton
 81443745 3 --Sealing Ceremony of Suiton
 22537443 3 --Sebek's Blessing
 26533075 3 --Security Orb
@@ -302,414 +678,241 @@ $whitelist
 300103004 3 --Servants of the Fallen King
 3819470 3 --Seven Tools of the Bandit
 58621589 3 --Shadow of Eyes
+300205003 3 --Shadow Reborn
+40575313 3 --Shadow Specter
 33904024 3 --Shard of Greed
 56830749 3 --Share the Pain
 52097679 3 --Shield & Sword
+3244563 3 --Shield Spear
+87303357 3 --Shining Abyss
 14771222 3 --Shore Knight
+55713623 3 --Shrink
+42534368 3 --Silent Doom
+90357090 3 --Silver Fang
 8131171 3 --Sinister Serpent
+60694662 3 --Skelengel
+73729209 3 --Skill Successor
+88901771 3 --Skilled Blue Magician
+65338781 3 --Skilled Red Magician
+46363422 3 --Skilled White Magician
 27655513 3 --Skreech
 126218 3 --Skull Dice
 2504891 3 --Skull Knight
 32274490 3 --Skull Servant
+63035430 3 --Skyscraper
+10000020 3 --Slifer the Sky Dragon
 3797883 3 --Slot Machine
 84650463 3 --Slushy
+300302052 3 --Small Roid Big City
 86318356 3 --Sogen
+93377803 3 --Solitary Sword of Poison
 57617178 3 --Sonic Bird
 84696266 3 --Sonic Duck
 40384720 3 --Sonic Shooter
+76297408 3 --Soul Demolition
+68005187 3 --Soul Exchange
+5758500 3 --Soul Release
 39041729 3 --Spacetime Transcendence
+31553716 3 --Spear Dragon
+84636823 3 --Spell Canceller
+300302018 3 --Spell of Mask
+300302053 3 --Spell of Mask (Skill Card)
 75014062 3 --Spell Power Grasp
 300103002 3 --Spell Proof Armor
+1669772 3 --Spell Purification
+93260132 3 --Spell Shattering Arrow
 18807109 3 --Spellbinding Circle
 33245030 3 --Sphere Kuriboh
 56051648 3 --Spider Egg
+6691855 3 --Spikeshield with Chain
+49328340 3 --Spiral Spear Strike
+13522325 3 --Spirit of Flames
 67957315 3 --Spirit Ryu
+69112325 3 --Spiritual Forest
 81385346 3 --Stamping Destruction
+65810489 3 --Statue of the Wicked
+13210191 3 --Storm
+25173686 3 --Straight Flush
 300101002 3 --Straight to the Grave
 60764581 3 --Stray Lambs
+41006930 3 --Strike Ninja
 79816536 3 --Summoner's Art
+32854013 3 --Super Rush Recklessly
 33951077 3 --Super War-Lion
 6849042 3 --Super-Ancient Dinobeast
+17626381 3 --Supply Squad
 33057951 3 --Surface
+50277973 3 --Swamp Mirrorer
+41872150 3 --Swarm of Locusts
+15383415 3 --Swarm of Scarabs
+16589042 3 --Swift Gaia the Fierce Knight
 300104005 3 --Switcheroo
 37120512 3 --Sword of Dark Destruction
 98495314 3 --Sword of Deep-Seated
 61405855 3 --Sword of Dragon's Soul
+50005633 3 --Swordstalker
 83682725 3 --Tail Swipe
 28725004 3 --Tainted Wisdom
 300104002 3 --Terror from the Deep!
+52367652 3 --That Which Feeds on Life
 73680966 3 --The Beginning of the End
+82386016 3 --The Big Cattle Drive
+1689516 3 --The Big March of Animals
+66989694 3 --The Earl of Demise
 34694160 3 --The Eye of Truth
+66362965 3 --The Fiend Megacyber
 43973174 3 --The Flute of Summoning Dragon
 94861297 3 --The Forceful Checkpoint
 42671151 3 --The Golden Apples
+84136000 3 --The Grave of Enkindling
+68049471 3 --The Gross Ghost of Fled Dreams
 3643300 3 --The Legendary Fisherman
 19801646 3 --The Legendary Fisherman II
+22610082 3 --The Mask of Remnants
+49064413 3 --The Masked Beast
+300302019 3 --The Psychic Duelist
+40703393 3 --The Puppet Magic of Dark Ruler
+300302041 3 --The Right Hero for the Job
+76305638 3 --The Rock Spirit
+300302054 3 --The Roids are Alright
+63125616 3 --The Shadow Who Controls the Dark
 43434803 3 --The Shallow Grave
 29491031 3 --The Snake Hair
 87557188 3 --The Stern Mystic
+38479725 3 --The Trojan Horse
+95281259 3 --The Warrior Returning Alive
+10000010 3 --The Winged Dragon of Ra
 300102001 3 --The World's Greatest Fisherman
 51838385 3 --Theban Nightmare
 41462083 3 --Thousand Dragon
 63391643 3 --Thousand Knives
+27125110 3 --Thousand-Eyes Idol
+63519819 3 --Thousand-Eyes Restrict
+300204003 3 --Thousand-Eyes Spell
 80987696 3 --Time Machine
 71625222 3 --Time Wizard
 300101005 3 --Tomb of the Pharaoh
 46457856 3 --Tomozaurus
 59383041 3 --Toon Alligator
+7171149 3 --Toon Ancient Gear Golem
+28112535 3 --Toon Barrel Dragon
+61190918 3 --Toon Buster Blader
+21296502 3 --Toon Dark Magician
 43509019 3 --Toon Defense
+42386471 3 --Toon Gemini Elf
+79447365 3 --Toon Mask
 16392422 3 --Toon Masked Sorcerer
+300204004 3 --Toon Mayhem!
 65458948 3 --Toon Mermaid
 70560957 3 --Toon Rollback
 91842653 3 --Toon Summoned Skull
 89997728 3 --Toon Table of Contents
 15259703 3 --Toon World
 19252988 3 --Trap Jammer
+21420702 3 --Tri-Blaze Accelerator
+96383838 3 --Tri-Wight
 12181376 3 --Triangle Ecstasy Spark
 300202009 3 --Tribal Synergy
 2903036 3 --Tribute Doll
+79759861 3 --Tribute to the Doomed
 55013285 3 --Troop Dragon
 3149764 3 --Tutan Mask
+70050374 3 --Twin-Barrel Dragon
 43586926 3 --Twin-Headed Behemoth
+88132637 3 --Twin-Headed Wolf
+300205004 3 --Twisted Personality
 45939841 3 --Twister
 94119974 3 --Two-Headed King Rex
 94568601 3 --Tyrant Dragon
+60806437 3 --UFO Turtle
+12652643 3 --Ultimate Ancient Gear Golem
 22431243 3 --Ultra Evolution Pill
 22702055 3 --Umi
+88494120 3 --Unbreakable Spirit
+300302055 3 --Under Pressure
+300302020 3 --Union Combination
+39778366 3 --Union Scramble
+56747793 3 --United We Stand
 1784619 3 --Uraby
+51638941 3 --V-Tiger Jet
+1353770 3 --Valhalla, Hall of the Fallen
+75347539 3 --Valkyrion the Magna Warrior
 53839837 3 --Vampire Lord
 90434926 3 --Veil of Darkness
 80402389 3 --Verdant Sanctuary
+93130021 3 --Victory Viper XX03
 15052462 3 --Violet Crystal
 300102005 3 --Viral Infection
+56043447 3 --Viser Des
+81020140 3 --Volcanic Blaster
+300302042 3 --Volcanic Cannon
+32543380 3 --Volcanic Doomfire
+54514594 3 --Volcanic Hammerer
+76459806 3 --Volcanic Rocket
+33365932 3 --Volcanic Shell
+14898066 3 --Vorse Raider
+58859575 3 --VW-Tiger Catapult
+84243274 3 --VWXYZ-Dragon Catapult Cannon
+96300057 3 --W-Wing Catapult
+12607053 3 --Waboku
 10813327 3 --Waking the Dragon
+58169731 3 --Wall of Disruption
+13945283 3 --Wall of Illusion
 54539105 3 --War-Lion Ritual
 75953262 3 --Warrior Dai Grepher
 90873992 3 --Warrior Elimination
+5438492 3 --Warrior Lady of the Wasteland
 23424603 3 --Wasteland
 49669730 3 --Water Hazard
 96643568 3 --Wetha
 91996584 3 --Whiptail Crow
+9786492 3 --White Dragon Ritual
 18756904 3 --White Elephant's Gift
 68427465 3 --Wicked-Breaking Flamberge - Baou
+77754944 3 --Widespread Ruin
+68815401 3 --Wild Fire
+61166988 3 --Wild Nature's Release
 47766694 3 --Wild Tornado
 59744639 3 --Windstorm of Etaqua
 39175982 3 --Winged Cleaver
+87796900 3 --Winged Dragon, Guardian of the Fortress #1
+57116033 3 --Winged Kuriboh
 67775894 3 --Wonder Wand
 43140791 3 --Worm Bait
+6480253 3 --Wroughtweiler
+62651957 3 --X-Head Cannon
+2111707 3 --XY-Dragon Cannon
+91998119 3 --XYZ-Dragon Cannon
+99724761 3 --XZ-Tank Cannon
+65622692 3 --Y-Dragon Head
+10315429 3 --Yaiba Robo
 59197169 3 --Yami
 51534754 3 --Yomi Ship
+25119460 3 --YZ-Tank Dragon
+64500000 3 --Z-Metal Tank
+83133491 3 --Zero Gravity
+16268841 3 --Zolga
 300104001 3 --Zombie Master (Skill Card)
 47693640 3 --Zombie Tiger
 81616639 3 --Zombina
---SS05 Bakura
-70084224 3 --Neck Hunter
-66989694 3 --The Earl of Demise
-5434080 3 --Headless Knight
-68049471 3 --The Gross Ghost of Fled Dreams
-52367652 3 --That Which Feeds on Life
-67105242 3 --Earthbound Spirit
-63125616 3 --The Shadow Who Controls the Dark
-31829185 3 --Dark Necrofear
-53982768 3 --Dark Ruler Ha Des
-37955049 3 --Gaap the Divine Soldier
-41442341 3 --Puppet Master
-16475472 3 --Lesser Fiend
-79418153 3 --Lancer Archfiend
-88132637 3 --Twin-Headed Wolf
-82213171 3 --Prometheus, King of the Shadows
-1102515 3 --Dark Mimic LV3
-74713516 3 --Dark Mimic LV1
-31034919 3 --Mad Reloader
-674561 3 --Dark Eruption
-1475311 3 --Allure of Darkness
-78811937 3 --Creeping Darkness
-19230408 3 --Offerings to the Doomed
-79852326 3 --Zoma the Spirit
-300205001 3 --Inner Conflict (Skill Card)
-300205002 3 --Into the Darkness Below (Skill Card)
---SS05 Marik
-38445524 3 --Gil Garth
-86569121 3 --Melchid the Four-Face Beast
-74277583 3 --Brave Scizzar
-10315429 3 --Yaiba Robo
-30325729 3 --Dokuroyaiba
-89558090 3 --Dark Prisoner
-102380 3 --Lava Golem
-58206034 3 --Dark Lucius LV8
-12817939 3 --Dark Lucius LV6
-99747800 3 --Legendary Fiend
-76052811 3 --Helpoemer
-46820049 3 --Mefist the Infernal General
-17597059 3 --Byser Shock
-99050989 3 --Drillago
-90147755 3 --Lady Assailant of Flames
-90980792 3 --Dark Jeroid
-4335645 3 --Newdoria
-85313220 3 --Dark Lucius LV4
-56043446 3 --Viser Des
-52090844 3 --Bowganian
-15305240 3 --Creature Seizure
-25290459 3 --Level Up!
-68396778 3 --Faustian Bargain
-79759861 3 --Tribute to The Doomed
-17626381 3 --Supply Squad
-66518841 3 --Prideful Roar
-93382620 3 --Rope of Life
-26905245 3 --Metal Reflect Slime
-54704216 3 --Nightmare Wheel
-65830223 3 --Coffin Seller
-300205003 3 --Shadow Reborn (Skill Card)
-300205004 3 --Twisted Personality (Skill Card)
---SS05 Pegasus
-28546905 3 --Illusionist Faceless Mage
-65570596 3 --Red Archery Girl
-27125110 3 --Thousand-Eyes Idol
-61190918 3 --Toon Buster Blader
-28112535 3 --Toon Barrel Dragon
-21296502 3 --Toon Dark Magician
-38369349 3 --Manga Ryu-Ran
-15173384 3 --Illusionist Faceless Magician
-42386471 3 --Toon Gemini Elf
-4141820 3 --Djinn Prognosticator of Rituals
-3244563 3 --Shield Spear
-73729209 3 --Skill Successor
-79447365 3 --Toon Mask
-63519819 3 --Thousand-Eyes Restrict
-300204003 3 --Thousand-Eyes Spell (Skill Card)
-300204004 3 --Toon Mayhem! (Skill Card)
---SS05 Yugi
-6368038 3 --Gaia The Fierce Knight
-28279543 3 --Curse of Dragon
-87796900 3 --Winged Dragon, Guardian of the Fortress #1
-91152256 3 --Celtic Guardian
-32452818 3 --Beaver Warrior
-13039848 3 --Giant Soldier of Stone
-90357090 3 --Silver Fang
-40575313 3 --Shadow Specter
-7841921 3 --Charging Gaia the Fierce Knight
-45141844 3 --Old Vindictive Magician
-40640057 3 --Kuriboh
-5405694 3 --Black Luster Soldier
-5758500 3 --Soul Release
-55761792 3 --Black Luster Ritual
-93260132 3 --Spell Shattering Arrow
-18658572 3 --Goblin Circus
-28486799 3 --Backup Squad
-49328340 3 --Spiral Spear Strike
-73872164 3 --Eliminating the League
-66889139 3 --Gaia the Dragon Champion
-300204001 3 --Ritual of Black Mastery (Skill Card)
-300204002 3 --Knight of Legend (Skill Card)
---Speed Duel Box
-85639257 3 --Aqua Madoor
-50287060 3 --Archfiend of Gilfer
-16589042 3 --Swift Gaia the Fierce Knight
-88240808 3 --Kycoo the Ghost Destroyer
-46363422 3 --Skilled White Magician
-71413901 3 --Breaker the Magical Warrior
-65338781 3 --Skilled Red Magician
-99789342 3 --Dark Magic Curtain
-95286165 3 --De-Fusion
-14087893 3 --Book of Moon
-6390406 3 --Emblem of Dragon Destroyer
-41940225 3 --Destruction Swordsman Fusion
-22829942 3 --Fusion Recycling Plant
-81210420 3 --Magical Hats
-73507661 3 --Fairy Wind 
-29876529 3 --Darklight
-89208725 3 --Metaverse
-98502113 3 --Dark Paladin
-75347539 3 --Valkyrion the Magna Warrior
-99785935 3 --Alpha The Magnet Warrior
-39256679 3 --Beta The Magnet Warrior
-11549357 3 --Gamma The Magnet Warrior
-12262393 3 --Delta The Magnet Warrior
-73481154 3 --Destroyer Golem
-76305638 3 --The Rock Spirit
-60229110 3 --Granmarg the Rock Monarch
-3900605 3 --Absorbing Jar	
-72580321 3 --Block Golem
-83715234 3 --Attack the Moon!
-4740489 3 --Magnetic Field
-83133491 3 --Zero Gravity
-15800838 3 --Mind Crush 
-20781762 3 --Rock Bombardment
-1802450 3 --Sealing Ceremony of Mokuton
-88494120 3 --Unbreakable Spirit
-17841166 3 --Magnet Force
-77133792 3 --Magnet Conversion
-5818798 3 --Gazelle the King of Mythical Beasts
-77207191 3 --Berfomet
-71181155 3 --Phantom Beast Cross-Wing
-7576264 3 --Phantom Beast Wild-Horn
-34961968 3 --Phantom Beast Thunder-Pegasus
-97017120 3 --Giant Rat
-40133511 3 --Bazoo the Soul-Eater
-77121851 3 --Manticore of Darkness
-76909279 3 --Enraged Battle Ox	
-13386503 3 --Ghost Knight of Jackal	
-22996376 3 --Behemoth the King of All Animals
-46668237 3 --Green Baboon, Defender of the Forest
-61166988 3 --Wild Nature's Release
-1689516 3 --The Big March of Animals	
-69112325 3 --Spiritual Forest
-57103969 3 --Fire Formation - Tenki	
-82386016 3 --The Big Cattle Drive
-70344351 3 --Riryoku Field	
-97922283 3 --Howl of the Wild	
-21350571 3 --Horn of the Phantom Beast
-4796100 3 --Chimera the Flying Mythical Beast	
-62651957 3 --X-Head Cannon	
-65622692 3 --Y-Dragon Head	
-64500000 3 --Z-Metal Tank	
-23265594 3 --Heavy Mech Support Platform
-93130021 3 --Victory Viper XX03
-14506878 3 --DUCKER Mobile Cannon
-44364207 3 --Jade Knight
-86170989 3 --Falchionβ	
-42940404 3 --Machina Gearframe
-78349103 3 --Machina Peacekeeper
-12079734 3 --Delta Tri
-56747793 3 --United We Stand
-46181000 3 --Frontline Base	
-25518020 3 --Machine Assembly Line
-66399653 3 --Union Hangar
-93377803 3 --Solitary Sword of Poison
-26931058 3 --Formation Union
-12503902 3 --Rare Metalmorph	
-91597389 3 --Roll Out!	
-39778366 3 --Union Scramble
-2111707 3 --XY-Dragon Cannon
-91998119 3 --XYZ-Dragon Cannon	
-99724761 3 --XZ-Tank Cannon	
-25119460 3 --YZ-Tank Dragon	
-66602787 3 --Saggi the Dark Clown	
-50005633 3 --Swordstalker
-97590747 3 --La Jinn the Mystical Genie of the Lamp
-14898066 3 --Vorse Raider
-11321183 3 --Dark Blade	
-93013676 3 --Maha Vailo	
 88472456 3 --Zombyra the Dark
-31553716 3 --Spear Dragon
-52824910 3 --Kaiser Glider
-24874630 3 --Fiend's Sanctuary
-68005187 3 --Soul Exchange
-55713623 3 --Shrink
-83746708 3 --Mage Power
-42534368 3 --Silent Doom	
-41356845 3 --Acid Trap Hole	
-14315573 3 --Negate Attack	
-59344077 3 --Magic Drain
-52503575 3 --Final Attack Orders
-25005816 3 --Inspiration
-48948935 3 --Masked Beast Des Gardius
-87303357 3 --Shining Abyss
-13676474 3 --Grand Tiki Elder
-11761845 3 --Beast of Talwar
-14531242 3 --Opticlops	
-13945283 3 --Wall of Illusion
-16226786 3 --Night Assailant	
-34334692 3 --Ritual Raven
-49064413 3 --The Masked Beast	
-17449108 3 --Nobleman of Extermination	
-82432018 3 --Mask of Brutality
-22610082 3 --The Mask of Remnant
-94377247 3 --Curse of the Masked Beast
-13048472 3 --Pre-Preparation of Rites	
-77754944 3 --Widespread Ruin	
-57882509 3 --Mask of Weakness
-41925941 3 --Bark of Dark Ruler	
-76297408 3 --Soul Demolition
-41930553 3 --Dark Smog
-80441106 3 --Keldo
-82108372 3 --Mudora
-16268841 3 --Zolga
-54878498 3 --Kelbek
-60694662 3 --Skelengel
-18036057 3 --Airknight Parshath
-75285069 3 --Moisture Creature
-68007326 3 --Guardian Angel Joan	
-56784842 3 --Angel O7
-36733451 3 --Dimensional Alchemist
-263926 3 --Bonze Alone
-71044499 3 --Nobleman of Crossout
-28106077 3 --Cestus of Dagla
-1353770 3 --Valhalla, Hall of the Fallen
+
+#Limited 3 (Currently Unsupported)
+71413901 3 --Breaker the Magical Warrior
+7572887 3 --D.D. Warrior Lady
+14087893 3 --Book of Moon
 8267140 3 --Cosmic Cyclone
-12607053 3 --Waboku
-55773067 3 --Drop off
-74003290 3 --Lost Wind	
-77585513 3 --Jinzo
-66362965 3 --The Fiend Megacyber
-49681811 3 --Freed the Matchless General
-1347977 3 --Mysterious Guard
-74131780 3 --Exiled Force
-15383415 3 --Swarm of Scarabs	
-41872150 3 --Swarm of Locusts	
-2326738 3 --Des Lacooda
-48768179 3 --Dark Scorpion - Gorg the Strong
-74153887 3 --Dark Scorpion - Meanae the Thorn
-303660 3 --Amplifier
-55226821 3 --Lightning Blade
-31036355 3 --Creature Swap
-32807846 3 --Reinforcement of the Army	
-95281259 3 --The Warrior Returning Alive
-26412047 3 --Hammer Shot
-52105192 3 --Hidden Armory	
-43250041 3 --Draining Shield	
-72563071 3 --Psychic Shockwave	
-42233477 3 --Battleguard Rage	
-12493482 3 --Dunames Dark Witch	
-89386122 3 --Ally of Justice Clausolas
-5640330 3 --Hannibal Necromancer
-61528025 3 --Banisher of the Light	
-30860696 3 --Rocket Warrior
-80316585 3 --Cyber Harpie Lady
-84636823 3 --Spell Canceller
-41006930 3 --Strike Ninja	
-25551951 3 --Blowback Dragon
-70821187 3 --Regenerating Mummy	
-88975532 3 --Pitch-Black Warwolf	
-94853057 3 --Banisher of the Radiance	
-70050374 3 --Twin-Barrel Dragon
-88901771 3 --Skilled Blue Magician
-3428069 3 --Buster Blader, the Destruction Swordmaster
-4849037 3 --Performance of Sword	
-99721536 3 --Dokurorider
-73398797 3 --Paladin of White Dragon
-43417563 3 --Commencement Dance
-31066283 3 --Revival of Dokurorider
-67227834 3 --Magic Formula
-9786492 3 --White Dragon Ritual
-22796548 3 --Archfiend's Oath
-13210191 3 --Storm
-40703393 3 --The Puppet Magic of Dark Ruler
-22359980 3 --Mirror Wall	
-55256016 3 --Judgment of Anubis	
-28649820 3 --Embodiment of Apophis
-1669772 3 --Spell Purification
-70406920 3 --Machine King - 3000 B.C.
-21843307 3 --Copy Knight
-50277973 3 --Swamp Mirrorer
-87772572 3 --Quantum Cat
-81439173 3 --Foolish Burial
-10000020 3 --Slifer the Sky Dragon
-10000000 3 --Obelisk the Tormentor
-10000010 3 --The Winged Dragon of Ra
-300303001 3 --Fury of Thunder
-300303002 3 --It's No Monster, It's a God!
-300303003 3 --Hieratic Chant
-300303004 3 --It's Jinzo!
-300303005 3 --The Psychic Duelist
-300303006 3 --Guardians of the Tomb
-300303007 3 --Union Combination
-300303008 3 --Spell of Mask
-300303009 3 --Magician's Act
-300303010 3 --Guardians of the Tomb
-300303011 3 --No More Mrs. Nice Mai!
-300303012 3 --I'm Just Gonna Attack!
-300303013 3 --Rise of the Fallen
-300303014 3 --Beasts of Phantom
-300303015 3 --Magnetic Attraction
-300303016 3 --Power of Friendship
+89208725 3 --Metaverse
+
+#Semi-Limited
+300104004 2 --Cocoon of Ultra Evolution (Skill Card)
+14457896 2 --Parasite Paranoid
+1475311 2 --Allure of Darkness
+66399653 2 --Union Hangar
+54704216 2 --Nightmare Wheel
+
+#Limited
+77585513 1 --Jinzo
+32807846 1 --Reinforcement of the Army
+81439173 1 --Foolish Burial
+79852326 1 --Zoma the Spirit


### PR DESCRIPTION
Updates the Speed Duel F/L List to the one from YCS Niagra. Includes cards from Midterm Paradox Box. Ids from YgoProDeck.com. F/L list originally in Duel Links format (1 limited card total vs 1 of each limited card, also includes limited 3), but Duel Links F/L list format unsupported by EdoPro.