### PR TITLE
Edison format banlist

### DIFF
--- a/Edison.iflist.conf
+++ b/Edison.iflist.conf
@@ -1,0 +1,3793 @@
+#[2010.04 Edison]
+!2010.04 Edison
+$whitelist
+#Forbidden Edison
+##Main deck monsters
+72989439 0 -- Black Luster Soldier - Envoy of the Beginning
+82301904 0 -- Chaos Emperor Dragon - Envoy of the End
+34124316 0 -- Cyber Jar
+69015963 0 -- Cyber-Stein
+40737112 0 -- Dark Magician of Chaos
+56570271 0 -- Destiny HERO - Disk Commander
+78706415 0 -- Fiber Jar
+34206604 0 -- Magical Scientist
+31560081 0 -- Magician of Faith
+21593977 0 -- Makyura the Destructor
+8131171 0 -- Sinister Serpent
+33184167 0 -- Tribe-Infecting Virus
+34853266 0 -- Tsukuyomi
+44910027 0 -- Victory Dragon
+78010363 0 -- Witch of the Black Forest
+3078576 0 -- Yata-Garasu
+##Extra deck monsters
+32646477 0 -- Dark Strike Fighter
+63519819 0 -- Thousand-Eyes Restrict
+##Spells
+69243953 0 -- Butterfly Dagger - Elma
+57953380 0 -- Card of Safe Return
+4031928 0 -- Change of Heart
+17375316 0 -- Confiscation
+53129443 0 -- Dark Hole
+44763025 0 -- Delinquent Duo
+23557835 0 -- Dimension Fusion
+79571449 0 -- Graceful Charity
+18144507 0 -- Harpie's Feather Duster
+18144506 0 -- Harpie's Feather Duster
+85602018 0 -- Last Will
+46411259 0 -- Metamorphosis
+41482598 0 -- Mirage of Nightmare
+83764719 0 -- Monster Reborn
+83764718 0 -- Monster Reborn
+74191942 0 -- Painful Choice
+55144522 0 -- Pot of Greed
+70828912 0 -- Premature Burial
+12580477 0 -- Raigeki
+45986603 0 -- Snatch Steal
+42829885 0 -- The Forceful Sentry
+##Traps
+57728570 0 -- Crush Card Virus
+57728571 0 -- Crush Card Virus
+17484499 0 -- Exchange of the Spirit
+61740673 0 -- Imperial Order
+28566710 0 -- Last Turn
+83555666 0 -- Ring of Destruction
+83555667 0 -- Ring of Destruction
+35316708 0 -- Time Seal
+#Limited Edison
+##Main deck monsters
+2009101 1 -- Blackwing - Gale the Whirlwind
+85087012 1 -- Card Trooper
+9596126 1 -- Chaos Sorcerer
+65192027 1 -- Dark Armed Dragon
+40044919 1 -- Elemental HERO Stratos
+40044918 1 -- Elemental HERO Stratos
+33396948 1 -- Exodia the Forbidden One
+41470137 1 -- Gladiator Beast Bestiari
+44330098 1 -- Gorz the Emissary of Darkness
+7902349 1 -- Left Arm of the Forbidden One
+44519536 1 -- Left Leg of the Forbidden One
+95503687 1 -- Lumina, Lightsworn Summoner
+31305911 1 -- Marshmallon
+92826944 1 -- Mezuki
+96782886 1 -- Mind Master
+33508719 1 -- Morphing Jar
+4906301 1 -- Necro Gardna
+28297833 1 -- Necroface
+80344569 1 -- Neo-Spacian Grand Mole
+16226786 1 -- Night Assailant
+33420078 1 -- Plaguespreader Zombie
+511002992 1 -- Rescue Cat
+70903634 1 -- Right Arm of the Forbidden One
+8124921 1 -- Right Leg of the Forbidden One
+511002631 1 -- Sangan
+84290642 1 -- Snipe Hunter
+23205979 1 -- Spirit Reaper
+423585 1 -- Summoner Monk
+98777036 1 -- Tragoedia
+##Extra deck monsters
+73580471 1 -- Black Rose Dragon
+73580472 1 -- Black Rose Dragon
+511002993 1 -- Brionac, Dragon of the Ice Barrier
+511002994 1 -- Goyo Guardian
+##Spells
+46052429 1 -- Advanced Ritual Art
+1475311 1 -- Allure of Darkness
+511002995 1 -- Brain Control
+48976825 1 -- Burial from a Different Dimension
+72892473 1 -- Card Destruction
+94886282 1 -- Charge of the Light Brigade
+60682203 1 -- Cold Wave
+45809008 1 -- Destiny Draw
+67723438 1 -- Emergency Teleport
+81439173 1 -- Foolish Burial
+81439174 1 -- Foolish Burial
+511002997 1 -- Future Fusion
+42703248 1 -- Giant Trunade
+19613556 1 -- Heavy Storm
+3136426 1 -- Level Limit - Area B
+23171610 1 -- Limiter Removal
+22046459 1 -- Megamorph
+37520316 1 -- Mind Control
+43040603 1 -- Monster Gate
+5318639 1 -- Mystical Space Typhoon
+2295440 1 -- One for One
+3659803 1 -- Overload Fusion
+58577036 1 -- Reasoning
+32807846 1 -- Reinforcement of the Army
+73915051 1 -- Scapegoat
+72302403 1 -- Swords of Revealing Light
+##Traps
+97077563 1 -- Call of the Haunted
+36468556 1 -- Ceasefire
+85742772 1 -- Gravity Bind
+62279055 1 -- Magic Cylinder
+32723153 1 -- Magical Explosion
+15800838 1 -- Mind Crush
+44095762 1 -- Mirror Force
+29843091 1 -- Ojama Trio
+27174286 1 -- Return from the Different Dimension
+41420027 1 -- Solemn Judgment
+46652477 1 -- The Transmigration Prophecy
+53582587 1 -- Torrential Tribute
+64697231 1 -- Trap Dustshoot
+17078030 1 -- Wall of Revealing Light
+#Semi Limited Edison
+##Main deck monsters
+70095154 2 -- Cyber Dragon
+70095155 2 -- Cyber Dragon
+15341821 2 -- Dandylion
+72426662 2 -- Demise, King of Armageddon
+9411399 2 -- Destiny HERO - Malicious
+63665875 2 -- Goblin Zombie
+37742478 2 -- Honest
+57774843 2 -- Judgment Dragon
+48686504 2 -- Lonefire Blossom
+12538374 2 -- Treeborn Frog
+##Spells
+91351370 2 -- Black Whirlwind
+91623717 2 -- Chain Strike
+75500286 2 -- Gold Sarcophagus
+98494543 2 -- Magical Stone Excavation
+56747793 2 -- United We Stand
+##Traps
+29401950 2 -- Bottomless Trap Hole
+51452091 2 -- Royal Decree
+93016201 2 -- Royal Oppression
+82732705 2 -- Skill Drain
+80604092 2 -- Ultimate Offering
+80604091 2 -- Ultimate Offering
+#Unlimited
+##Main deck monsters
+86988864 3 -- 3-Hump Lacooda
+83994646 3 -- 4-Starred Ladybug of Doom
+23771716 3 -- 7 Colored Fish
+14261867 3 -- 8-Claws Scorpion
+24140059 3 -- A Cat of Ill Omen
+51351302 3 -- A Man with Wdjat
+13026402 3 -- A-Team: Trap Disposal Unit
+12694768 3 -- Abaki
+89718302 3 -- Abare Ushioni
+49771608 3 -- Absorbing Kid from the Sky
+18318842 3 -- Abyss Soldier
+44223284 3 -- Abyssal Kingshark
+47372349 3 -- Acrobat Monkey
+53828396 3 -- Adhesive Explosive
+16135253 3 -- Agido
+18036057 3 -- Airknight Parshath
+48202661 3 -- Aitsu
+78121572 3 -- Alchemist of Black Spells
+652362 3 -- Alien Ammonite
+15475415 3 -- Alien Dog
+62437709 3 -- Alien Grey
+62315111 3 -- Alien Hunter
+38468214 3 -- Alien Hypno
+76573247 3 -- Alien Infiltrator
+64160836 3 -- Alien Kid
+99532708 3 -- Alien Mars
+24104865 3 -- Alien Mother
+63253763 3 -- Alien Overlord
+58012107 3 -- Alien Psychic
+97127906 3 -- Alien Shocktrooper
+25920413 3 -- Alien Skull
+91070115 3 -- Alien Telepath
+98719226 3 -- Alien Warrior
+87257460 3 -- Allure Queen LV3
+23756165 3 -- Allure Queen LV5
+50140163 3 -- Allure Queen LV7
+89386122 3 -- Ally of Justice Clausolas
+25771826 3 -- Ally of Justice Garadholg
+52265835 3 -- Ally of Justice Rudra
+99785935 3 -- Alpha The Magnet Warrior
+17968114 3 -- Amazon of the Seas
+91869203 3 -- Amazoness Archer
+73574678 3 -- Amazoness Blowpiper
+29654737 3 -- Amazoness Chain Master
+55821894 3 -- Amazoness Fighter
+47480070 3 -- Amazoness Paladin
+94004268 3 -- Amazoness Swords Woman
+10979723 3 -- Amazoness Tiger
+36378213 3 -- Ambulanceroid
+95174353 3 -- Ameba
+67371383 3 -- Amphibian Beast
+64342551 3 -- Amphibious Bugroth MK-3
+23927567 3 -- An Owl of Luck
+42431843 3 -- Ancient Brain
+50781944 3 -- Ancient Crimson Ape
+93221206 3 -- Ancient Elf
+31557782 3 -- Ancient Gear
+10509340 3 -- Ancient Gear Beast
+80045583 3 -- Ancient Gear Cannon
+1953925 3 -- Ancient Gear Engineer
+86321248 3 -- Ancient Gear Gadjiltron Chimera
+50933533 3 -- Ancient Gear Gadjiltron Dragon
+83104731 3 -- Ancient Gear Golem
+39303359 3 -- Ancient Gear Knight
+56094445 3 -- Ancient Gear Soldier
+54912977 3 -- Ancient Lamp
+43230671 3 -- Ancient Lizard Warrior
+14015067 3 -- Ancient One of the Deep Forest
+15013468 3 -- Andro Sphinx
+56784842 3 -- Angel O7
+48365709 3 -- Ansatsu
+13250922 3 -- Anteatereatingant
+65064143 3 -- Anti-Aircraft Flower
+41158734 3 -- Apocatequil
+9156135 3 -- Apprentice Magician
+85639257 3 -- Aqua Madoor
+40916023 3 -- Aqua Spirit
+22377815 3 -- Aquarian Alessa
+62892347 3 -- Arcana Force 0 - The Fool
+69831560 3 -- Arcana Force EX - The Dark Ruler
+5861892 3 -- Arcana Force EX - The Light Ruler
+8396952 3 -- Arcana Force I - The Magician
+35781051 3 -- Arcana Force III - The Empress
+61175706 3 -- Arcana Force IV - The Emperor
+97574404 3 -- Arcana Force VI - The Lovers
+34568403 3 -- Arcana Force VII - The Chariot
+60953118 3 -- Arcana Force XIV - Temperance
+97452817 3 -- Arcana Force XVIII - The Moon
+23846921 3 -- Arcana Force XXI - The World
+40048324 3 -- Arcane Apprentice
+55001420 3 -- Arcane Archer of the Forest
+14553285 3 -- Arcanite Magician/Assault Mode
+48675364 3 -- Archfiend General
+75889523 3 -- Archfiend Marmot of Nefariousness
+50287060 3 -- Archfiend of Gilfer
+49881766 3 -- Archfiend Soldier
+59509952 3 -- Archlord Kristya
+18378582 3 -- Archlord Zerato
+28985331 3 -- Armageddon Knight
+53153481 3 -- Armaill
+59464593 3 -- Armed Dragon LV10
+980973 3 -- Armed Dragon LV3
+46384672 3 -- Armed Dragon LV5
+73879377 3 -- Armed Dragon LV7
+9076207 3 -- Armed Ninja
+84430950 3 -- Armed Samurai - Ben Kei
+20470500 3 -- Armed Sea Hunter
+87798440 3 -- Armor Breaker
+7180418 3 -- Armor Exe
+62742651 3 -- Armored Axon Kicker
+67159705 3 -- Armored Cybern
+15480588 3 -- Armored Lizard
+17535588 3 -- Armored Starfish
+20277860 3 -- Armored Zombie
+73333463 3 -- Armoroid
+42364374 3 -- Arsenal Bug
+85489096 3 -- Arsenal Summoner
+3431737 3 -- Assault Beast
+77036039 3 -- Assault Mercenary
+2134346 3 -- Asura Priest
+88236094 3 -- Aswan Apparition
+48964966 3 -- Athena
+26976414 3 -- Atlantean Pikeman
+87340664 3 -- Atomic Firefly
+7183277 3 -- Aurkus, Lightsworn Druid
+37970940 3 -- Aussa the Earth Charmer
+29139104 3 -- Avalanching Aussa
+99284890 3 -- Avatar of The Pot
+48305365 3 -- Axe Raider
+75081613 3 -- Aztekipede, the Worm Warrior
+14148099 3 -- B.E.S. Big Core
+75937826 3 -- B.E.S. Big Core MK-2
+15317640 3 -- B.E.S. Covered Core
+22790789 3 -- B.E.S. Crystal Core
+44954628 3 -- B.E.S. Tetran
+88819587 3 -- Baby Dragon
+36042004 3 -- Babycerasaurus
+39892082 3 -- Balloon Lizard
+61528025 3 -- Banisher of the Light
+94853057 3 -- Banisher of the Radiance
+86325596 3 -- Baron of the Fiend Sword
+81480460 3 -- Barrel Dragon
+81480461 3 -- Barrel Dragon
+84478195 3 -- Barrier Statue of the Abyss
+19740112 3 -- Barrier Statue of the Drought
+46145256 3 -- Barrier Statue of the Heavens
+47961808 3 -- Barrier Statue of the Inferno
+73356503 3 -- Barrier Statue of the Stormwinds
+10963799 3 -- Barrier Statue of the Torrent
+89091579 3 -- Basic Insect
+63142001 3 -- Batteryman AA
+19733961 3 -- Batteryman C
+83446909 3 -- Batteryman Charger
+55401221 3 -- Batteryman D
+19441018 3 -- Batteryman Industrial Strength
+56839613 3 -- Batteryman Micro-Cell
+19665973 3 -- Battle Fader
+48094997 3 -- Battle Footballer
+5053103 3 -- Battle Ox
+18246479 3 -- Battle Steer
+69695704 3 -- Battlestorm
+40133511 3 -- Bazoo the Soul-Eater
+84990171 3 -- Bean Soldier
+78651105 3 -- Beast King Barbaros
+19028307 3 -- Beast Machine King Barbaros Ür
+11761845 3 -- Beast of Talwar
+83903521 3 -- Beast of the Pharaoh
+21362970 3 -- Beast Striker
+99426834 3 -- Beastking of the Swamps
+16899564 3 -- Beautiful Headhuntress
+32452818 3 -- Beaver Warrior
+1474910 3 -- Bee List Soldier
+49522489 3 -- Beelze Frog
+94022093 3 -- Behegon
+22996376 3 -- Behemoth the King of All Animals
+33731070 3 -- Beiige, Vanguard of Dark World
+33655493 3 -- Belial - Marquis of Darkness
+77207191 3 -- Berfomet
+85605684 3 -- Berserk Dragon
+39168895 3 -- Berserk Gorilla
+39256679 3 -- Beta The Magnet Warrior
+83392426 3 -- Bicular
+16768387 3 -- Big Eye
+42129512 3 -- Big Koala
+25247218 3 -- Big Piece Golem
+65240384 3 -- Big Shield Gardna
+59380081 3 -- Big-Tusked Mammoth
+58696829 3 -- Bio-Mage
+45547649 3 -- Birdface
+50122883 3 -- Bite Shoes
+44702857 3 -- Bitelon
+36262024 3 -- Black Dragon's Chick
+5405694 3 -- Black Luster Soldier
+76218643 3 -- Black Potan
+90654356 3 -- Black Ptera
+88671720 3 -- Black Salvo
+79409334 3 -- Black Stego
+38670435 3 -- Black Tyranno
+52319752 3 -- Black Veloci
+87564352 3 -- Blackland Fire Dragon
+22835145 3 -- Blackwing - Blizzard the Far North
+49003716 3 -- Blackwing - Bora the Spear
+11613567 3 -- Blackwing - Elphin the Raven
+9109991 3 -- Blackwing - Fane the Steel Chain
+85215458 3 -- Blackwing - Kalut the Moon Shadow
+46710683 3 -- Blackwing - Mistral the Silver Shield
+58820853 3 -- Blackwing - Shura the Blue Flame
+75498415 3 -- Blackwing - Sirocco the Dawn
+72714392 3 -- Blackwing - Vayu the Emblem of Honor
+39507162 3 -- Blade Knight
+58268433 3 -- Blade Rabbit
+97023549 3 -- Blade Skater
+28470714 3 -- Bladefly
+11685347 3 -- Blast Asmodian
+70138455 3 -- Blast Juggler
+21051146 3 -- Blast Magician
+26302522 3 -- Blast Sphere
+16984449 3 -- Blazewing Butterfly
+92518817 3 -- Blazing Hiita
+5464695 3 -- Blazing Inpachi
+35215622 3 -- Blindly Loyal Goblin
+61802346 3 -- Blizzard Dragon
+96565487 3 -- Blizzard Warrior
+60161788 3 -- Blizzed, Defender of the Ice Barrier
+34743446 3 -- Blocker
+48115277 3 -- Blockman
+25551951 3 -- Blowback Dragon
+14089428 3 -- Blue Thunder T-45
+53347303 3 -- Blue-Eyes Shining Dragon
+53183600 3 -- Blue-Eyes Toon Dragon
+89631139 3 -- Blue-Eyes White Dragon
+89631140 3 -- Blue-Eyes White Dragon
+89631141 3 -- Blue-Eyes White Dragon
+89631142 3 -- Blue-Eyes White Dragon
+89631143 3 -- Blue-Eyes White Dragon
+89631144 3 -- Blue-Eyes White Dragon
+89631145 3 -- Blue-Eyes White Dragon
+89631146 3 -- Blue-Eyes White Dragon
+41396436 3 -- Blue-Winged Crown
+21340051 3 -- Boar Soldier
+8715625 3 -- Bokoichi the Freightening Car
+57409948 3 -- Bombardment Beetle
+37675138 3 -- Bone Crusher
+98456117 3 -- Boneheimer
+13316346 3 -- Boot-Up Soldier - Dread Dynamo
+84824601 3 -- Botanical Girl
+20546916 3 -- Botanical Lion
+81386177 3 -- Bottom Dweller
+32296881 3 -- Bountiful Artemis
+52090844 3 -- Bowganian
+81919143 3 -- Brain Crusher
+17313545 3 -- Brain Golem
+40267580 3 -- Brain Jacker
+71413901 3 -- Breaker the Magical Warrior
+79126789 3 -- Broww, Huntsman of Dark World
+6214884 3 -- Brron, Mad King of Dark World
+6104968 3 -- Bubonic Vermin
+6297941 3 -- Burglar
+41859700 3 -- Burning Algae
+59364406 3 -- Burning Beast
+26293219 3 -- Burning Skull Head
+78193831 3 -- Buster Blader
+78193832 3 -- Buster Blader
+17597059 3 -- Byser Shock
+31615285 3 -- Cactus Bouncer
+74440055 3 -- Cactus Fighter
+9748752 3 -- Caius the Shadow Monarch
+11384280 3 -- Cannon Soldier
+14702066 3 -- Cannon Soldier MK-2
+95614612 3 -- Cannonball Spear Shellfish
+42256406 3 -- Card Blocker
+26701483 3 -- Card Ejector
+4694209 3 -- Card Guard
+46848859 3 -- Carrierroid
+36931229 3 -- Castle Gate
+62121 3 -- Castle of Dark Illusions
+95841282 3 -- Cat's Ear Tribe
+511000228 3 -- Catapult Turtle
+96501677 3 -- Catnipped Kitty
+54360049 3 -- Catoblepas and the Witch of Fate
+93220472 3 -- Cave Dragon
+94381039 3 -- Celestia, Lightsworn Angel
+91152256 3 -- Celtic Guardian
+91152257 3 -- Celtic Guardian
+91152258 3 -- Celtic Guardian
+20228463 3 -- Ceremonial Bell
+88190453 3 -- Chain Thrasher
+77252217 3 -- Chainsaw Insect
+44430454 3 -- Chamberlain of the Six Samurai
+72630549 3 -- Chaos Command Magician
+1434352 3 -- Chaos Necromancer
+46609443 3 -- Chaos-End Master
+47829960 3 -- Chaosrider Gustaph
+13179332 3 -- Charcoal Inpachi
+50412166 3 -- Charm of Shabti
+16956455 3 -- Chiron the Mage
+40884383 3 -- Chopman the Desperate Outlaw
+17363041 3 -- Chrysalis Chicky
+42682609 3 -- Chrysalis Dolphin
+16241441 3 -- Chrysalis Larva
+42239546 3 -- Chrysalis Mole
+43751755 3 -- Chrysalis Pantail
+29246354 3 -- Chrysalis Pinny
+95888876 3 -- Chthonian Emperor Dragon
+50916353 3 -- Chthonian Soldier
+8508055 3 -- Chu-Ske the Mouse Fighter
+79853073 3 -- Cipher Soldier
+41218256 3 -- Claw Reacher
+97811903 3 -- Clear Vice Dragon
+17810268 3 -- Cloudian - Acid Cloud
+79703905 3 -- Cloudian - Altus
+43318266 3 -- Cloudian - Cirrostratus
+57610714 3 -- Cloudian - Eye of the Typhoon
+83604828 3 -- Cloudian - Ghost Fog
+20003527 3 -- Cloudian - Nimbusman
+83982270 3 -- Cloudian - Poison Cloud
+56597272 3 -- Cloudian - Sheep Cloud
+80825553 3 -- Cloudian - Smoke Ball
+13474291 3 -- Cloudian - Storm Dragon
+16197610 3 -- Cloudian - Turbulence
+92667214 3 -- Clown Zombie
+42541548 3 -- Coach Goblin
+86801871 3 -- Cobra Jar
+75109441 3 -- Cobraman Sakuzy
+33413638 3 -- Cockroach Knight
+40240595 3 -- Cocoon of Evolution
+65496056 3 -- Codarus
+24661486 3 -- Cold Enchanter
+38898779 3 -- Colossal Fighter/Assault Mode
+8806072 3 -- Combo Fighter
+44800181 3 -- Combo Master
+10375182 3 -- Command Knight
+22666164 3 -- Commander Covington
+53388413 3 -- Commander Gottoms, Swordmaster
+83602069 3 -- Comrade Swordsman of Landstar
+2980764 3 -- Consecrated Light
+66457407 3 -- Copy Plant
+26376390 3 -- Copycat
+34290067 3 -- Corroding Shark
+51192573 3 -- Cosmic Horror Gangi'el
+38999506 3 -- Cosmo Queen
+5519829 3 -- Counselor Lily
+91782219 3 -- Crab Turtle
+18828179 3 -- Cranium Fish
+93889755 3 -- Crass Clown
+67494157 3 -- Crawling Dragon
+38289717 3 -- Crawling Dragon #2
+52571838 3 -- Creeping Doom Manta
+14618326 3 -- Crimson Ninja
+28358902 3 -- Crimson Sentry
+18654201 3 -- Criosphinx
+73146473 3 -- Cross Porter
+74976215 3 -- Cross-Sword Beetle
+73853830 3 -- Crusader of Endymion
+23950192 3 -- Cryomancer of the Ice Barrier
+69937550 3 -- Crystal Beast Amber Mammoth
+32933942 3 -- Crystal Beast Amethyst Cat
+21698716 3 -- Crystal Beast Cobalt Eagle
+68215963 3 -- Crystal Beast Emerald Tortoise
+32710364 3 -- Crystal Beast Ruby Carbuncle
+7093411 3 -- Crystal Beast Sapphire Pegasus
+95600067 3 -- Crystal Beast Topaz Tiger
+82099401 3 -- Crystal Seer
+10789972 3 -- Cu Chulainn the Awakened
+85802526 3 -- Cure Mermaid
+28279543 3 -- Curse of Dragon
+18489208 3 -- Cursed Fig
+59907935 3 -- Cyber Archfiend
+68774379 3 -- Cyber Barrier Dragon
+39439590 3 -- Cyber Dinosaur
+5373478 3 -- Cyber Dragon Zwei
+33093439 3 -- Cyber Eltanin
+91663373 3 -- Cyber Esper
+30655537 3 -- Cyber Falcon
+76763417 3 -- Cyber Gymnast
+80316585 3 -- Cyber Harpie Lady
+76986005 3 -- Cyber Kirin
+4162088 3 -- Cyber Laser Dragon
+64268668 3 -- Cyber Ogre
+30042158 3 -- Cyber Ouroboros
+3370104 3 -- Cyber Phoenix
+2158562 3 -- Cyber Prima
+39978267 3 -- Cyber Raider
+32393580 3 -- Cyber Shark
+75559356 3 -- Cyber Soldier of Darkworld
+49375719 3 -- Cyber Tutu
+3657444 3 -- Cyber Valley
+48766543 3 -- Cyber-Tech Alligator
+77625948 3 -- Cyberdark Edge
+41230939 3 -- Cyberdark Horn
+3019642 3 -- Cyberdark Keel
+96428622 3 -- Cybernetic Cyclopean
+59023523 3 -- Cybernetic Magician
+51020079 3 -- Cyborg Doctor
+45945685 3 -- Cycroid
+81057959 3 -- D. Human
+70074904 3 -- D.D. Assailant
+48148828 3 -- D.D. Crazy Beast
+24508238 3 -- D.D. Crow
+52702748 3 -- D.D. Guide
+3773196 3 -- D.D. Scout Plane
+48092532 3 -- D.D. Survivor
+86498013 3 -- D.D. Trainer
+37043180 3 -- D.D. Warrior
+7572887 3 -- D.D. Warrior Lady
+82112775 3 -- D.D.M. - Different Dimension Master
+59983499 3 -- Dancing Elf
+90925163 3 -- Dancing Fairy
+41949033 3 -- Dark Assailant
+67049542 3 -- Dark Bat
+11321183 3 -- Dark Blade
+44341034 3 -- Dark Bug
+8634636 3 -- Dark Cat with White Tail
+33875961 3 -- Dark Catapulter
+91596726 3 -- Dark Crusader
+65287621 3 -- Dark Driceratops
+89111398 3 -- Dark Dust Spirit
+81755371 3 -- Dark Effigy
+21417692 3 -- Dark Elf
+29436665 3 -- Dark Eradicator Warlock
+70676581 3 -- Dark General Freed
+9159938 3 -- Dark Gray
+14536035 3 -- Dark Grepher
+66214679 3 -- Dark Horus
+19357125 3 -- Dark Hunter
+90980792 3 -- Dark Jeroid
+53375573 3 -- Dark King of the Abyss
+85313220 3 -- Dark Lucius LV4
+12817939 3 -- Dark Lucius LV6
+58206034 3 -- Dark Lucius LV8
+46986421 3 -- Dark Magician
+46986420 3 -- Dark Magician
+46986414 3 -- Dark Magician
+46986415 3 -- Dark Magician
+46986416 3 -- Dark Magician
+46986417 3 -- Dark Magician
+46986418 3 -- Dark Magician
+46986419 3 -- Dark Magician
+36996508 3 -- Dark Magician
+38033121 3 -- Dark Magician Girl
+38033122 3 -- Dark Magician Girl
+38033123 3 -- Dark Magician Girl
+38033124 3 -- Dark Magician Girl
+38033125 3 -- Dark Magician Girl
+38033126 3 -- Dark Magician Girl
+50725996 3 -- Dark Magician Knight
+97642679 3 -- Dark Master - Zorc
+74713516 3 -- Dark Mimic LV1
+1102515 3 -- Dark Mimic LV3
+31829185 3 -- Dark Necrofear
+38107923 3 -- Dark Nephthys
+99261403 3 -- Dark Rabbit
+45462639 3 -- Dark Red Enchanter
+97021916 3 -- Dark Resonator
+53982768 3 -- Dark Ruler Ha Des
+92377303 3 -- Dark Sage
+61587183 3 -- Dark Scorpion - Chick the Yellow
+6967870 3 -- Dark Scorpion - Cliff the Trap Remover
+48768179 3 -- Dark Scorpion - Gorg the Strong
+74153887 3 -- Dark Scorpion - Meanae the Thorn
+40933924 3 -- Dark Scorpion Burglars
+11366199 3 -- Dark Simorgh
+81759748 3 -- Dark Spider
+76614003 3 -- Dark Tinker
+89494469 3 -- Dark Titan of Terror
+83269557 3 -- Dark Valkyria
+50164989 3 -- Dark Verger
+65282484 3 -- Dark Voltanis
+35565537 3 -- Dark Witch
+59784896 3 -- Dark Zebra
+38247752 3 -- Dark-Eyes Illusionist
+35798491 3 -- Darkbishop Archfiend
+39343610 3 -- Darkblaze Dragon
+5388481 3 -- Darkfire Soldier #1
+78861134 3 -- Darkfire Soldier #2
+57579381 3 -- Darklord Marie
+67316075 3 -- Darklord Nurse Reficule
+40921744 3 -- Darklord Zerato
+93709215 3 -- Darkness Destroyer
+60417395 3 -- Darkness Neosphere
+76925842 3 -- Darknight Parshath
+70054514 3 -- Darksea Float
+34659866 3 -- Darksea Rescue
+43500484 3 -- Darkworld Thorns
+57549932 3 -- Dawnbreak Gardna
+14943837 3 -- Debris Dragon
+10209545 3 -- Decayed Commander
+2732323 3 -- Decoy Dragon
+25034083 3 -- Decoyroid
+17559367 3 -- Deep Diver
+78868119 3 -- Deep Sea Diva
+13314457 3 -- Deepsea Macrotrema
+24128274 3 -- Deepsea Warrior
+2525268 3 -- Defender, the Magical Knight
+87621407 3 -- Dekoichi the Battlechanted Locomotive
+12965761 3 -- Des Dendle
+81985784 3 -- Des Feral Imp
+84451804 3 -- Des Frog
+78613627 3 -- Des Kangaroo
+69579761 3 -- Des Koala
+2326738 3 -- Des Lacooda
+33695750 3 -- Des Mosquito
+81059524 3 -- Des Volstgalph
+9637706 3 -- Des Wombat
+38981606 3 -- Desert Protector
+81977953 3 -- Desert Twister
+13409151 3 -- Desertapir
+71200730 3 -- Despair from the Dark
+72192100 3 -- Desrook Archfiend
+55461064 3 -- Destiny HERO - Blade Master
+77608643 3 -- Destiny HERO - Captain Tenacious
+81866673 3 -- Destiny HERO - Dasher
+54749427 3 -- Destiny HERO - Defender
+39829561 3 -- Destiny HERO - Departed
+13093792 3 -- Destiny HERO - Diamond Dude
+17132130 3 -- Destiny HERO - Dogma
+41613948 3 -- Destiny HERO - Doom Lord
+28355718 3 -- Destiny HERO - Double Dude
+36625827 3 -- Destiny HERO - Dread Servant
+40591390 3 -- Destiny HERO - Dreadmaster
+93431862 3 -- Destiny HERO - Dunker
+80744121 3 -- Destiny HERO - Fear Monger
+83965311 3 -- Destiny HERO - Plasma
+83965310 3 -- Destiny HERO - Plasma
+73481154 3 -- Destroyer Golem
+80186010 3 -- Destroyersaurus
+59235795 3 -- Destruction Cyclone
+11232355 3 -- Destructotron
+19327348 3 -- Dharc the Dark Charmer
+96967123 3 -- Dharma Cannon
+29424328 3 -- Diabolos, King of the Abyss
+3549275 3 -- Dice Jar
+50939127 3 -- Different Dimension Dragon
+29948642 3 -- Dig Beak
+1596508 3 -- Dimension Fortress Weapon
+73414375 3 -- Dimension Jar
+36733451 3 -- Dimensional Alchemist
+19612721 3 -- Disc Fighter
+15595052 3 -- Disciple of the Forbidden Spell
+76137614 3 -- Disenchanter
+76446915 3 -- Disk Magician
+41113025 3 -- Diskblade Rider
+40826495 3 -- Dissolverock
+10032958 3 -- Divine Dragon - Excelion
+67964209 3 -- Divine Dragon Aquabizarre
+62113340 3 -- Divine Dragon Ragnarok
+61757117 3 -- Divine Grace - Northwemko
+57902462 3 -- Divine Knight Ishzark
+77153811 3 -- Djinn Cursenchanter of Rituals
+30492798 3 -- Djinn Disserere of Rituals
+34358408 3 -- Djinn Presider of Rituals
+4141820 3 -- Djinn Prognosticator of Rituals
+8903700 3 -- Djinn Releaser of Rituals
+22171591 3 -- Doctor Cranium
+57062206 3 -- Doitsu
+99721536 3 -- Dokurorider
+30325729 3 -- Dokuroyaiba
+16972957 3 -- Doma The Angel of Silence
+3493978 3 -- Don Turtle
+76922029 3 -- Don Zaloog
+76039636 3 -- Doom Dozer
+94944637 3 -- Doom Shaman
+78700060 3 -- Doomcaliber Knight
+1764972 3 -- Doomkaiser Dragon/Assault Mode
+64379430 3 -- Doomsday Horror
+44436472 3 -- Double Coston
+64262809 3 -- Dragon Ice
+63018132 3 -- Dragon Manipulator
+55763552 3 -- Dragon Piper
+80513550 3 -- Dragon Queen of Tragic Endings
+28563545 3 -- Dragon Seeker
+66672569 3 -- Dragon Zombie
+78009994 3 -- Dragonic Guard
+38109772 3 -- Dragonic Knight
+66973070 3 -- Dreadscythe Harvester
+13215230 3 -- Dream Clown
+8687195 3 -- Dreamsprite
+88733579 3 -- Drill Bug
+56286179 3 -- Drill Synchron
+99050989 3 -- Drillago
+71218746 3 -- Drillroid
+16353197 3 -- Drooling Lizard
+14506878 3 -- DUCKER Mobile Cannon
+13532663 3 -- Dummy Golem
+12493482 3 -- Dunames Dark Witch
+51228280 3 -- Dungeon Worm
+46239604 3 -- Dupe Frog
+46508640 3 -- Dweller in the Depths
+53693416 3 -- Eagle Eye
+53461122 3 -- Earth Effigy
+10875327 3 -- Earthbound Immortal Aslla piscu
+46263076 3 -- Earthbound Immortal Ccapac Apu
+79798060 3 -- Earthbound Immortal Ccarayhua
+69931927 3 -- Earthbound Immortal Chacu Challhua
+33537328 3 -- Earthbound Immortal Cusillu
+15187079 3 -- Earthbound Immortal Uru
+41181774 3 -- Earthbound Immortal Wiraqocha Rasca
+67987302 3 -- Earthbound Linewalker
+67105242 3 -- Earthbound Spirit
+46128076 3 -- Ebon Magician Curran
+16825874 3 -- Eccentric Boy
+44178886 3 -- Ehren, Lightsworn Monk
+55875323 3 -- Electric Lizard
+11324436 3 -- Electric Snake
+24725825 3 -- Electric Virus
+23118924 3 -- Element Doom
+30314994 3 -- Element Dragon
+65260293 3 -- Element Magician
+92755808 3 -- Element Saurus
+66712593 3 -- Element Soldier
+97623219 3 -- Element Valkyrie
+21844576 3 -- Elemental HERO Avian
+21844577 3 -- Elemental HERO Avian
+59793705 3 -- Elemental HERO Bladedge
+79979666 3 -- Elemental HERO Bubbleman
+58932615 3 -- Elemental HERO Burstinatrix
+58932616 3 -- Elemental HERO Burstinatrix
+80908502 3 -- Elemental HERO Captain Gold
+84327329 3 -- Elemental HERO Clayman
+98266377 3 -- Elemental HERO Heat
+62107981 3 -- Elemental HERO Knospe
+95362816 3 -- Elemental HERO Lady Heat
+89252153 3 -- Elemental HERO Necroshade
+5285665 3 -- Elemental HERO Neo Bubbleman
+89943724 3 -- Elemental HERO Neos
+89943723 3 -- Elemental HERO Neos
+69884162 3 -- Elemental HERO Neos Alius
+37195861 3 -- Elemental HERO Ocean
+51085303 3 -- Elemental HERO Poison Rose
+89312388 3 -- Elemental HERO Prisma
+20721928 3 -- Elemental HERO Sparkman
+20721929 3 -- Elemental HERO Sparkman
+9327502 3 -- Elemental HERO Voltic
+86188410 3 -- Elemental HERO Wildheart
+75434695 3 -- Elemental HERO Woodsman
+99414168 3 -- Elemental Mistress Doriado
+85166216 3 -- Elephant Statue of Blessing
+12160911 3 -- Elephant Statue of Disaster
+43580269 3 -- Emes the Infinity
+42685062 3 -- Emissary from Pandemonium
+75043725 3 -- Emissary of the Afterlife
+6103294 3 -- Emissary of the Oasis
+21672573 3 -- Emperor Sem
+58818411 3 -- Empress Mantis
+75376965 3 -- Enchanting Mermaid
+40732515 3 -- Endymion, the Master Magician
+72631243 3 -- Energy Bravery
+38280762 3 -- Enishi, Shien's Chancellor
+76909279 3 -- Enraged Battle Ox
+91862578 3 -- Enraged Muka Muka
+74364659 3 -- Eria the Water Charmer
+11460577 3 -- Etoile Cyber
+8400623 3 -- Evil Dragon Ananta
+95943058 3 -- Evil HERO Infernal Gainer
+50304345 3 -- Evil HERO Infernal Prodigy
+58554959 3 -- Evil HERO Malicious Edge
+85431040 3 -- Evil Thorn
+96872283 3 -- Evocator Chevalier
+63749102 3 -- Exarion Universe
+74131780 3 -- Exiled Force
+12600382 3 -- Exodia Necross
+13893596 3 -- Exodius the Ultimate Forbidden Lord
+20586572 3 -- Exploder Dragon
+984114 3 -- Expressroid
+55737443 3 -- Exxod, Master of The Guard
+20315854 3 -- Fairy Dragon
+22419772 3 -- Fairy Guardian
+45425051 3 -- Fairy King Truesdale
+68401546 3 -- Fairy's Gift
+75582395 3 -- Faith Bird
+86170989 3 -- Falchion Beta
+89731911 3 -- Familiar Knight
+31887906 3 -- Familiar-Possessed - Aussa
+31887905 3 -- Familiar-Possessed - Aussa
+68881650 3 -- Familiar-Possessed - Eria
+68881649 3 -- Familiar-Possessed - Eria
+4376659 3 -- Familiar-Possessed - Hiita
+4376658 3 -- Familiar-Possessed - Hiita
+31764354 3 -- Familiar-Possessed - Wynn
+31764353 3 -- Familiar-Possessed - Wynn
+34193084 3 -- Fear from the Dark
+32271987 3 -- Featherizer
+3954901 3 -- Felgrand Dragon
+218704 3 -- Fenrir
+41392891 3 -- Feral Imp
+89529919 3 -- Field-Commander Rahz
+2863439 3 -- Fiend Reflection #2
+26566878 3 -- Fiend Scorpion
+82556058 3 -- Fiendish Engine Omega
+78275321 3 -- Fire Ant Ascator
+46534755 3 -- Fire Kraken
+64752646 3 -- Fire Princess
+27132350 3 -- Fire Sorcerer
+53927679 3 -- Fire Trooper
+87473172 3 -- Firebird
+53293545 3 -- Firegrass
+13846680 3 -- Firestorm Prominence
+71407486 3 -- Fireyarou
+93369354 3 -- Fishborg Blaster
+60862676 3 -- Flame Cerebrus
+42599677 3 -- Flame Champion
+12883044 3 -- Flame Dancer
+34460851 3 -- Flame Manipulator
+58098303 3 -- Flame Ogre
+41089128 3 -- Flame Ruler
+79444933 3 -- Flame Spirit Ignis
+2830619 3 -- Flame Viper
+40189917 3 -- Flamvell Commando
+68226653 3 -- Flamvell Dragnov
+23297235 3 -- Flamvell Firedog
+21615956 3 -- Flamvell Guard
+95621257 3 -- Flamvell Magician
+96890582 3 -- Flash Assailant
+83812099 3 -- Flint Lock
+81278754 3 -- Flip Flop Frog
+31987274 3 -- Flying Fish
+16898077 3 -- Flying Fortress SKY FIRE
+84834865 3 -- Flying Kamakiri #1
+3134241 3 -- Flying Kamakiri #2
+5628232 3 -- Flying Penguin
+97697678 3 -- Flying Saucer Muusik'i
+6614221 3 -- Fog King
+66288028 3 -- Fortress Warrior
+62337487 3 -- Fortress Whale
+55586621 3 -- Fortune Lady Dark
+82971335 3 -- Fortune Lady Earth
+71870152 3 -- Fortune Lady Fire
+34471458 3 -- Fortune Lady Light
+29088922 3 -- Fortune Lady Water
+82693917 3 -- Fortune Lady Wind
+42009836 3 -- Fossil Dyna Pachycephalo
+17706537 3 -- Fossil Tusker
+88753985 3 -- Fox Fire
+16556849 3 -- Freed the Brave Wanderer
+49681811 3 -- Freed the Matchless General
+85359414 3 -- Freezing Beast
+98818516 3 -- Frenzied Panda
+62154416 3 -- Frequency Magician
+12398280 3 -- Freya, Spirit of Victory
+38742075 3 -- Frontier Wiseman
+55589254 3 -- Frost and Flame Dragon
+6631034 3 -- Frostosaurus
+38538445 3 -- Fushi No Tori
+39711336 3 -- Fushioh Richie
+51632798 3 -- Fusilier Dragon, the Dual-Mode Beast
+98336111 3 -- Fusion Devourer
+90642597 3 -- Future Samurai
+4130270 3 -- G.B. Hunter
+37955049 3 -- Gaap the Divine Soldier
+47985614 3 -- Gadget Arms
+54497620 3 -- Gadget Driver
+28002611 3 -- Gadget Hauler
+86281779 3 -- Gadget Soldier
+49003308 3 -- Gagagigo
+14258627 3 -- Gaia Plate the Earth Giant
+51355346 3 -- Gaia Soul the Combustible Collective
+6368038 3 -- Gaia The Fierce Knight
+6368039 3 -- Gaia The Fierce Knight
+16229315 3 -- Gale Dogra
+77491079 3 -- Gale Lizard
+30915572 3 -- Gallis the Star Beast
+2196767 3 -- Gambler of Legend
+11549357 3 -- Gamma the Magnet Warrior
+64681432 3 -- Gandora the Dragon of Destruction
+30646525 3 -- Garlandolf, King of Destruction
+90844184 3 -- Garma Sword
+49888191 3 -- Garnecia Elefantis
+14977074 3 -- Garoozis
+59019082 3 -- Garoth, Lightsworn Warrior
+12800777 3 -- Garuda the Wind Spirit
+25833572 3 -- Gate Guardian
+19737320 3 -- Gatekeeper
+79337169 3 -- Gauntlet Warrior
+5818798 3 -- Gazelle the King of Mythical Beasts
+30190809 3 -- Gear Golem the Moving Fortress
+423705 3 -- Gearfried the Iron Knight
+57046845 3 -- Gearfried the Swordmaster
+11662742 3 -- Gellenduo
+69140098 3 -- Gemini Elf
+69140099 3 -- Gemini Elf
+67688478 3 -- Gemini Imps
+26254876 3 -- Gemini Lancer
+91798373 3 -- Gemini Scorpion
+68366996 3 -- Gemini Soldier
+19041767 3 -- Gemini Summoner
+69247929 3 -- Gene-Warped Warwolf
+31038159 3 -- Genesis Dragon
+98147766 3 -- Genetic Woman
+77936940 3 -- Gernia
+21887179 3 -- Getsu Fuhma
+59965151 3 -- Ghost Gardna
+13386503 3 -- Ghost Knight of Jackal
+78266168 3 -- Giant Axe Mummy
+41762634 3 -- Giant Flea
+95178994 3 -- Giant Germ
+58185394 3 -- Giant Kozaky
+73698349 3 -- Giant Orc
+97017120 3 -- Giant Rat
+58831685 3 -- Giant Red Seasnake
+13039848 3 -- Giant Soldier of Stone
+96981563 3 -- Giant Turtle Who Feeds on Flames
+43793530 3 -- Giga Gagagigo
+8471389 3 -- Giga-Tech Wolf
+47606319 3 -- Gigantes
+82116191 3 -- Gigantic Cephalotus
+53257892 3 -- Gigaplant
+79080761 3 -- Gigastone Omega
+53776525 3 -- Gigobyte
+38445524 3 -- Gil Garth
+45894482 3 -- Gilasaurus
+69933858 3 -- Gilford the Legend
+36354008 3 -- Gilford the Lightning
+36354007 3 -- Gilford the Lightning
+84620194 3 -- Girochin Kuwagata
+42592719 3 -- Gladiator Beast Alexander
+90582719 3 -- Gladiator Beast Andal
+25924653 3 -- Gladiator Beast Darius
+31247589 3 -- Gladiator Beast Dimacari
+57731460 3 -- Gladiator Beast Equeste
+4253484 3 -- Gladiator Beast Hoplomus
+78868776 3 -- Gladiator Beast Laquari
+5975022 3 -- Gladiator Beast Murmillo
+29590752 3 -- Gladiator Beast Octavius
+612115 3 -- Gladiator Beast Retiari
+2619149 3 -- Gladiator Beast Samnite
+77642288 3 -- Gladiator Beast Secutor
+79580323 3 -- Gladiator Beast Spartacus
+65984457 3 -- Gladiator Beast Torax
+78658564 3 -- Goblin Attack Force
+66707058 3 -- Goblin Black Ops
+12057781 3 -- Goblin Calligrapher
+18960169 3 -- Goblin Decoy Squad
+85306040 3 -- Goblin Elite Attack Force
+18590133 3 -- Goblin King
+425934 3 -- Goblin of Greed
+82324312 3 -- Goblin Recon Squad
+67959180 3 -- Goddess of Whim
+53493204 3 -- Goddess with the Third Eye
+10236520 3 -- Goe Goe the Gallant Ninja
+21155323 3 -- Goggle Golem
+39674352 3 -- Gogiga Gagagigo
+23116808 3 -- Goka, the Pyre of Malice
+15367030 3 -- Gokibore
+14472500 3 -- Gokipon
+78004197 3 -- Goldd, Wu-Lord of Dark World
+76203291 3 -- Golden Flying Fish
+27408609 3 -- Golden Homunculus
+87102774 3 -- Golden Ladybug
+52323207 3 -- Golem Sentry
+59797187 3 -- Gonogo
+80233946 3 -- Gora Turtle
+42868711 3 -- Gora Turtle of Illusion
+10992251 3 -- Gradius
+14291024 3 -- Gradius' Option
+21785144 3 -- Gragonith, Lightsworn Dragon
+13944422 3 -- Granadora
+13676474 3 -- Grand Tiki Elder
+83039729 3 -- Grandmaster of the Six Samurai
+60229110 3 -- Granmarg the Rock Monarch
+32907538 3 -- Grapple Blocker
+41249545 3 -- Grass Phantom
+95166228 3 -- Grasschopper
+40937767 3 -- Grave Ohja
+11448373 3 -- Grave Protector
+48343627 3 -- Grave Squirmer
+25262697 3 -- Gravekeeper's Assailant
+99877698 3 -- Gravekeeper's Cannonholder
+62473983 3 -- Gravekeeper's Chief
+17393207 3 -- Gravekeeper's Commandant
+50712728 3 -- Gravekeeper's Curse
+30213599 3 -- Gravekeeper's Descendant
+37101832 3 -- Gravekeeper's Guard
+3381441 3 -- Gravekeeper's Priestess
+63695531 3 -- Gravekeeper's Spear Soldier
+24317029 3 -- Gravekeeper's Spy
+99690140 3 -- Gravekeeper's Vassal
+3825890 3 -- Gravekeeper's Visionary
+26084285 3 -- Gravekeeper's Watcher
+9391354 3 -- Gravi-Crush Dragon
+29216198 3 -- Gravitic Orb
+56931015 3 -- Gravity Behemoth
+29618570 3 -- Gray Wing
+11813953 3 -- Great Angus
+88989706 3 -- Great Dezard
+2356994 3 -- Great Long Nose
+47942531 3 -- Great Maju Garzett
+14141448 3 -- Great Moth
+10809984 3 -- Great Phantom Thief
+63176202 3 -- Great Shogun Shien
+92736188 3 -- Great Spirit
+13429800 3 -- Great White
+50263751 3 -- Greed Quasar
+46668237 3 -- Green Baboon, Defender of the Forest
+41172955 3 -- Green Gadget
+22910685 3 -- Green Phantom King
+61831093 3 -- Greenkappa
+36584821 3 -- Gren Maju Da Eiza
+51232472 3 -- Gren, Tactician of Dark World
+95744531 3 -- Griggle
+75732622 3 -- Grinder Golem
+58314394 3 -- Ground Attacker Bugroth
+17243896 3 -- Ground Spider
+57346400 3 -- Guard Dog
+68007326 3 -- Guardian Angel Joan
+73544866 3 -- Guardian Baou
+10755153 3 -- Guardian Ceal
+34022290 3 -- Guardian Eatos
+74367458 3 -- Guardian Elma
+47150851 3 -- Guardian Grarl
+9633505 3 -- Guardian Kay'est
+71799173 3 -- Guardian of Order
+89272878 3 -- Guardian of the Labyrinth
+47879985 3 -- Guardian of the Throne Room
+40659562 3 -- Guardian Sphinx
+75209824 3 -- Guardian Statue
+46037213 3 -- Guardian Tryce
+38975369 3 -- Gundari
+9817927 3 -- Gyaku-Gire Panda
+31122090 3 -- Gyakutenno Megami
+31122091 3 -- Gyakutenno Megami
+18325492 3 -- Gyroid
+28357177 3 -- Hade-Hane
+32491822 3 -- Hamon, Lord of Striking Thunder
+98446407 3 -- Hand of Nephthys
+78792195 3 -- Hand of the Six Samurai
+97904474 3 -- Handcuffs Dragon
+7089711 3 -- Hane-Hane
+20450925 3 -- Hanewata
+84285623 3 -- Haniwa
+5640330 3 -- Hannibal Necromancer
+99030164 3 -- Happy Lover
+20060230 3 -- Hard Armor
+68473226 3 -- Hardened Armed Dragon
+34100324 3 -- Harpie Girl
+76812113 3 -- Harpie Lady
+91932350 3 -- Harpie Lady 1
+27927359 3 -- Harpie Lady 2
+54415063 3 -- Harpie Lady 3
+12206212 3 -- Harpie Lady Sisters
+75064463 3 -- Harpie Queen
+6924874 3 -- Harpie's Pet Baby Dragon
+52040216 3 -- Harpie's Pet Dragon
+85399281 3 -- Harvest Angel of Wisdom
+21015833 3 -- Hayabusa Knight
+5434080 3 -- Headless Knight
+31281980 3 -- Healing Wave Generator
+23265594 3 -- Heavy Mech Support Platform
+74968065 3 -- Hecatrice
+59042331 3 -- Hedge Guard
+54493213 3 -- Helios - The Primordial Sun
+80887952 3 -- Helios Duo Megistus
+17286057 3 -- Helios Trice Megistus
+47025270 3 -- Helping Robo for Combat
+76052811 3 -- Helpoemer
+66337215 3 -- Herald of Creation
+21074344 3 -- Herald of Green Light
+17266660 3 -- Herald of Orange Light
+94689635 3 -- Herald of Purple Light
+52584282 3 -- Hercules Beetle
+32679370 3 -- Hero Kid
+64501875 3 -- Hibikime
+82260502 3 -- Hieracosphinx
+54579801 3 -- High Tide Gyojin
+759393 3 -- Hiita the Fire Charmer
+75745607 3 -- Hino-Kagu-Tsuchi
+96851799 3 -- Hinotama Soul
+81863068 3 -- Hiro's Shadow Scout
+76184692 3 -- Hitotsu-Me Giant
+40410110 3 -- Homunculus the Alchemic Being
+82994509 3 -- Horseytail
+75830094 3 -- Horus the Black Flame Dragon LV4
+11224103 3 -- Horus the Black Flame Dragon LV6
+48229808 3 -- Horus the Black Flame Dragon LV8
+9264485 3 -- Horus' Servant
+67629977 3 -- Hoshiningen
+93107608 3 -- Howling Insect
+46821314 3 -- Humanoid Slime
+30243636 3 -- Hungry Burger
+96005454 3 -- Hunter Dragon
+51962254 3 -- Hunter Owl
+80141480 3 -- Hunter Spider
+37869028 3 -- Hydra Viper
+22587018 3 -- Hydrogeddon
+22873798 3 -- Hyena
+2118022 3 -- Hyosube
+62397231 3 -- Hyozanryu
+2671330 3 -- Hyper Hammerhead
+37169670 3 -- Hyper Psychic Blaster/Assault Mode
+40348946 3 -- Hyper Synchron
+21297224 3 -- Hysteric Fairy
+32750510 3 -- Ice Master
+14462257 3 -- Ice Queen
+35984222 3 -- Ido the Supreme Magical Force
+70595331 3 -- Il Blud
+28546905 3 -- Illusionist Faceless Mage
+32485518 3 -- Immortal Ruler
+52248570 3 -- Imprisoned Queen Archfiend
+77084837 3 -- Inaba White Rabbit
+84173492 3 -- Indomitable Fighter Lei Lei
+47754278 3 -- Infernal Dragon
+19847532 3 -- Infernal Flame Emperor
+23309606 3 -- Infernal Incinerator
+8581705 3 -- Infernalqueen Archfiend
+99177923 3 -- Infernity Archfiend
+7264861 3 -- Infernity Beast
+25171661 3 -- Infernity Dwarf
+51566770 3 -- Infernity Guardian
+56209279 3 -- Infernity Necromancer
+74823665 3 -- Inferno
+17185260 3 -- Inferno Hammer
+76520646 3 -- Infinity Dark
+4941482 3 -- Informer Spider
+79575620 3 -- Injection Fairy Lily
+39703254 3 -- Inmato
+97923414 3 -- Inpachi
+35052053 3 -- Insect Knight
+37957847 3 -- Insect Princess
+91512835 3 -- Insect Queen
+7019529 3 -- Insect Soldiers of the Sky
+14729426 3 -- Interplanetary Invader "A"
+56647086 3 -- Invader of Darkness
+3056267 3 -- Invader of the Throne
+26082229 3 -- Invasion of Flames
+52675689 3 -- Invitation to a Dark Sleep
+9628664 3 -- Iris, the Earth Mother
+73431236 3 -- Iron Blacksmith Kotetsu
+26157485 3 -- Iron Chain Blaster
+53152590 3 -- Iron Chain Coil
+53274132 3 -- Iron Chain Repairman
+80769747 3 -- Iron Chain Snake
+4042268 3 -- Island Turtle
+6544078 3 -- Izanagi
+43543777 3 -- Izanami
+90876561 3 -- Jack's Knight
+44364207 3 -- Jade Knight
+96235275 3 -- Jain, Lightsworn Paladin
+26932788 3 -- Javelin Beetle
+14851496 3 -- Jellyfish
+83725008 3 -- Jenis, Lightsworn Mender
+23635815 3 -- Jerry Beans Man
+8487449 3 -- Jester Confit
+72992744 3 -- Jester Lord
+43697559 3 -- Jetroid
+90020065 3 -- Jigen Bakudan
+77585513 3 -- Jinzo
+77585514 3 -- Jinzo
+32809211 3 -- Jinzo #7
+35803249 3 -- Jinzo - Lord
+9418534 3 -- Jinzo - Returner
+94773007 3 -- Jirai Gumo
+41855169 3 -- Jowgen the Spiritualist
+5257687 3 -- Jowls of Dark Demise
+30113682 3 -- Judge Man
+63977008 3 -- Junk Synchron
+60410769 3 -- Jutte Fighter
+52768103 3 -- KA-2 Des Scissors
+51934376 3 -- Kabazauls
+15401633 3 -- Kagemusha of the Blue Flame
+25847467 3 -- Kahkki, Guerilla of Dark World
+34627841 3 -- Kaibaman
+52824910 3 -- Kaiser Glider
+17444133 3 -- Kaiser Sea Horse
+95789089 3 -- Kangaroo Champ
+23289281 3 -- Karate Man
+52512994 3 -- Kasha
+62340868 3 -- Kazejin
+54878498 3 -- Kelbek
+80441106 3 -- Keldo
+88979991 3 -- Killer Needle
+84686841 3 -- King Fog
+501000002 3 -- King of Destruction - Xexex
+67757079 3 -- King of the Beasts
+36021814 3 -- King of the Skull Servants
+79109599 3 -- King of the Swamp
+69455834 3 -- King of Yamimakai
+20438745 3 -- King Pyron
+83986578 3 -- King Tiger Wanghu
+64788463 3 -- King's Knight
+45452224 3 -- Kinka-byo
+84814897 3 -- Kiryu
+4266839 3 -- Kiseitai
+46237548 3 -- Knight of the Red Lotus
+39037517 3 -- Koa'ki Meiru Beetle
+6320631 3 -- Koa'ki Meiru Boulder
+32314730 3 -- Koa'ki Meiru Crusader
+80925836 3 -- Koa'ki Meiru Doom
+12435193 3 -- Koa'ki Meiru Drago
+5817857 3 -- Koa'ki Meiru Ghoulungulate
+41201555 3 -- Koa'ki Meiru Gravirose
+45041488 3 -- Koa'ki Meiru Guardian
+31692182 3 -- Koa'ki Meiru Hydro Barrier
+54520292 3 -- Koa'ki Meiru Ice
+65026212 3 -- Koa'ki Meiru Maximus
+19642889 3 -- Koa'ki Meiru Powerhand
+10060427 3 -- Koa'ki Meiru Rooklord
+74576482 3 -- Koa'ki Meiru Sea Panther
+68809475 3 -- Koa'ki Meiru Speeder
+95204084 3 -- Koa'ki Meiru Tornado
+30936186 3 -- Koa'ki Meiru Urnight
+72258771 3 -- Koa'ki Meiru Valafar
+95090813 3 -- Koa'ki Meiru War Arms
+69456283 3 -- Koitsu
+1184620 3 -- Kojikocy
+19406822 3 -- Kotodama
+67724379 3 -- Koumori Dragon
+99171160 3 -- Kozaky
+59575539 3 -- Krebons
+82642348 3 -- Kryuel
+56283725 3 -- Kumootoko
+56514812 3 -- Kunoichi
+85705804 3 -- Kurama
+57666212 3 -- Kuraz the Light Monarch
+40640057 3 -- Kuriboh
+40640058 3 -- Kuriboh
+40640059 3 -- Kuriboh
+47432275 3 -- Kuribon
+60802233 3 -- Kuwagata α
+88240808 3 -- Kycoo the Ghost Destroyer
+97590747 3 -- La Jinn the Mystical Genie of the Lamp
+97590748 3 -- La Jinn the Mystical Genie of the Lamp
+67284908 3 -- Labyrinth Wall
+90147755 3 -- Lady Assailant of Flames
+82005435 3 -- Lady Ninja Yae
+17358176 3 -- Lady of Faith
+38480590 3 -- Lady Panther
+87756343 3 -- Larvae Moth
+94675535 3 -- Larvas
+87322377 3 -- Launcher Spider
+87322378 3 -- Launcher Spider
+20394040 3 -- Lava Battleguard
+41741922 3 -- Lava Dragon
+102380 3 -- Lava Golem
+67468948 3 -- Layard the Liberator
+87010442 3 -- Legacy Hunter
+99747800 3 -- Legendary Fiend
+60258960 3 -- Legendary Flame Lord
+25773409 3 -- Legendary Jujitsu Master
+12472242 3 -- Leghul
+62543393 3 -- Lekunga
+10538007 3 -- Leogun
+55444629 3 -- Lesser Dragon
+16475472 3 -- Lesser Fiend
+57421866 3 -- Level Eater
+97385276 3 -- Level Warrior
+37721209 3 -- Levia-Dragon - Daedalus
+55818463 3 -- Lich Lord, King of the Underworld
+76214441 3 -- Lifeforce Harmonizer
+47297616 3 -- Light and Darkness Dragon
+54766667 3 -- Light Effigy
+27671321 3 -- Lightning Conger
+45023678 3 -- Lightning Punisher
+93108297 3 -- Liquid Beast
+68658728 3 -- Little Chimera
+90790253 3 -- Little-Winguard
+20831168 3 -- Lizard Soldier
+35514096 3 -- Lord British Space Fighter
+17985575 3 -- Lord of D.
+99510761 3 -- Lord of the Lamp
+40320754 3 -- Lord Poison
+45871897 3 -- Lost Guardian
+68762510 3 -- Lucky Pied Piper
+57482479 3 -- Luminous Soldier
+11091375 3 -- Luster Dragon
+17658803 3 -- Luster Dragon #2
+84385264 3 -- Lycanthrope
+22624373 3 -- Lyla, Lightsworn Sorceress
+56342351 3 -- M-Warrior #1
+92731455 3 -- M-Warrior #2
+96384007 3 -- Machina Defender
+58054262 3 -- Machina Force
+5556499 3 -- Machina Fortress
+42940404 3 -- Machina Gearframe
+78349103 3 -- Machina Peacekeeper
+23782705 3 -- Machina Sniper
+60999392 3 -- Machina Soldier
+46700124 3 -- Machine King
+89222931 3 -- Machine King Prototype
+96938777 3 -- Machine Lord Ur
+94664694 3 -- Mad Archfiend
+79182538 3 -- Mad Dog of Darkness
+97240270 3 -- Mad Lobster
+31034919 3 -- Mad Reloader
+79870141 3 -- Mad Sword Beast
+82458280 3 -- Magic Hole Golem
+6061630 3 -- Magical Exemplar
+46474915 3 -- Magical Ghost
+8034697 3 -- Magical Marionette
+32362575 3 -- Magical Merchant
+7802006 3 -- Magical Plant Mandragola
+3918345 3 -- Magical Reflect Slime
+25531465 3 -- Magicat
+30208479 3 -- Magician of Black Chaos
+80304126 3 -- Magician's Valkyria
+36750412 3 -- Magna Drago
+72903645 3 -- Magna-Slash Dragon
+50074522 3 -- Magnetic Mosquito
+93013676 3 -- Maha Vailo
+40695128 3 -- Maharaghi
+84055227 3 -- Maiden of Macabre
+17214465 3 -- Maiden of the Aqua
+79629370 3 -- Maiden of the Moonlight
+21159309 3 -- Majestic Dragon
+95701283 3 -- Majestic Mech - Goryu
+69303178 3 -- Majestic Mech - Ohka
+32918479 3 -- Majestic Mech - Senku
+60102563 3 -- Maji-Gire Panda
+8794435 3 -- Maju Garzett
+9433350 3 -- Malefic Blue-Eyes White Dragon
+31571902 3 -- Malevolent Mech - Goku En
+14255590 3 -- Malice Ascendant
+72657739 3 -- Malice Doll of Demise
+40374923 3 -- Mammoth Graveyard
+71395725 3 -- Man Beast of Ares
+93553943 3 -- Man Eater
+54652250 3 -- Man-Eater Bug
+13723605 3 -- Man-Eating Treasure Chest
+43714890 3 -- Man-Thro' Tro'
+38369349 3 -- Manga Ryu-Ran
+33455338 3 -- Maniacal Servant
+95492061 3 -- Manju of the Ten Thousand Hands
+77121851 3 -- Manticore of Darkness
+2460565 3 -- Marauding Captain
+87514539 3 -- Marionette Mite
+71466592 3 -- Maryokutai
+44287299 3 -- Masaki the Legendary Swordsman
+28933734 3 -- Mask of Darkness
+48948935 3 -- Masked Beast Des Gardius
+87350908 3 -- Masked Chopper
+39191307 3 -- Masked Dragon
+10189126 3 -- Masked Sorcerer
+75499502 3 -- Master & Expert
+16191953 3 -- Master Gig
+24530661 3 -- Master Kyonshee
+49814180 3 -- Master Monk
+22609617 3 -- Mataza the Zapper
+94538053 3 -- Max Warrior
+30707994 3 -- Maximum Six
+6133894 3 -- Mazera DeVille
+10110717 3 -- Mecha Bunny
+94667532 3 -- Mecha-Dog Marron
+22512237 3 -- Mechanical Hound
+34442949 3 -- Mechanical Snail
+7359741 3 -- Mechanicalchaser
+76211194 3 -- Meda Bat
+58843503 3 -- Medium Piece Golem
+2694423 3 -- Medusa Worm
+46820049 3 -- Mefist the Infernal General
+21817254 3 -- Mega Thunderball
+71544954 3 -- Megarock Dragon
+7562372 3 -- Megasonic Eye
+47731128 3 -- Mei-Kou, Master of Barriers
+86569121 3 -- Melchid the Four-Face Beast
+49905576 3 -- Meltiel, Sage of the Sky
+48700891 3 -- Memory Crusher
+4252828 3 -- Mermaid Archer
+24435369 3 -- Mermaid Knight
+49808196 3 -- Metabo Globster
+37792478 3 -- Metabo-Shark
+65957473 3 -- Metal Armored Bug
+55998462 3 -- Metal Fish
+68339286 3 -- Metal Guardian
+7200041 3 -- Metal Shooter
+7369217 3 -- Metallizing Parasite - Lunatite
+50705071 3 -- Metalzoa
+64271667 3 -- Meteor Dragon
+75487237 3 -- Mid Shield Gardna
+62327910 3 -- Mighty Guard
+38277918 3 -- Mikazukinoyaiba
+47986555 3 -- Millennium Golem
+82482194 3 -- Millennium Scorpion
+32012841 3 -- Millennium Shield
+32012842 3 -- Millennium Shield
+7489323 3 -- Milus Radiant
+32539892 3 -- Minar
+66690411 3 -- Mind on Air
+85060248 3 -- Mind Protector
+76321376 3 -- Mine Golem
+24419823 3 -- Minefieldriller
+43708640 3 -- Minoan Centaur
+131182 3 -- Miracle Flipper
+63259351 3 -- Miracle Jurassic Egg
+15960641 3 -- Mirage Dragon
+49217579 3 -- Mirage Knight
+33178416 3 -- Misairuzame
+28601770 3 -- Mist Archfiend
+95443805 3 -- Mist Valley Shaman
+22837504 3 -- Mist Valley Soldier
+69448290 3 -- Mist Valley Thunderbird
+45159319 3 -- Moai Interceptor Cannons
+4929256 3 -- Mobius the Frost Monarch
+75285069 3 -- Moisture Creature
+94878265 3 -- Moja
+27288416 3 -- Mokey Mokey
+17192817 3 -- Molten Behemoth
+4732017 3 -- Molten Zombie
+3810071 3 -- Monk Fighter
+36121917 3 -- Monster Egg
+23303072 3 -- Montage Dragon
+45909477 3 -- Moon Envoy
+55784832 3 -- Morinphen
+71717923 3 -- Mormolith
+79106360 3 -- Morphing Jar #2
+48381268 3 -- Morphtronic Boarden
+92720564 3 -- Morphtronic Boomboxen
+28124263 3 -- Morphtronic Cameran
+93542102 3 -- Morphtronic Celfon
+91607976 3 -- Morphtronic Clocken
+66331855 3 -- Morphtronic Datatron
+29947751 3 -- Morphtronic Magnen
+45593005 3 -- Morphtronic Magnen Bar
+55119278 3 -- Morphtronic Radion
+57108202 3 -- Morphtronic Remoten
+10591919 3 -- Morphtronic Scopen
+75775867 3 -- Morphtronic Slingen
+84592800 3 -- Morphtronic Videon
+8483333 3 -- Mosaic Manticore
+57839750 3 -- Mother Grizzly
+17021204 3 -- Mother Spider
+31477025 3 -- Mr. Volcano
+70307656 3 -- Mucus Yolk
+82108372 3 -- Mudora
+46657337 3 -- Muka Muka
+14181608 3 -- Mushroom Man
+93900406 3 -- Mushroom Man #2
+11508758 3 -- Mutant Mindmaster
+1347977 3 -- Mysterious Guard
+54098121 3 -- Mysterious Puppeteer
+47060154 3 -- Mystic Clown
+68516705 3 -- Mystic Horseman
+98049915 3 -- Mystic Lamp
+47507260 3 -- Mystic Swordsman LV2
+74591968 3 -- Mystic Swordsman LV4
+60482781 3 -- Mystic Swordsman LV6
+83011278 3 -- Mystic Tomato
+83011277 3 -- Mystic Tomato
+15025844 3 -- Mystical Elf
+98745000 3 -- Mystical Knight of Jackal
+30451366 3 -- Mystical Sheep #1
+83464209 3 -- Mystical Sheep #2
+39552864 3 -- Mystical Shine Ball
+55424270 3 -- Mythical Beast Cerberus
+70948327 3 -- Nanobreaker
+61454890 3 -- Necrolancer the Time-lord
+98162242 3 -- Needle Burrower
+81843628 3 -- Needle Worm
+11021521 3 -- Neko Mane King
+1761063 3 -- Nekogal #1
+43352213 3 -- Nekogal #2
+90963488 3 -- Nemuriko
+49563947 3 -- Neo Aqua Madoor
+16587243 3 -- Neo Bug
+19594506 3 -- Neo Space Pathfinder
+50930991 3 -- Neo the Magic Swordsman
+12510878 3 -- Neo-Parshath, the Sky Paladin
+54959865 3 -- Neo-Spacian Air Hummingbird
+17955766 3 -- Neo-Spacian Aqua Dolphin
+43237273 3 -- Neo-Spacian Dark Panther
+89621922 3 -- Neo-Spacian Flare Scarab
+17732278 3 -- Neo-Spacian Glow Moss
+5126490 3 -- Neos Wiseman
+19505896 3 -- Nettles
+4335645 3 -- Newdoria
+49826746 3 -- Night Wing Sorceress
+36107810 3 -- Night's End Sorcerer
+59290628 3 -- Nightmare Horse
+81306586 3 -- Nightmare Penguin
+22567609 3 -- Nimble Momonga
+57844634 3 -- Nimble Musasabi
+11987744 3 -- Nin-Ken Dog
+4041838 3 -- Ninja Grandmaster Sasuke
+96182448 3 -- Nitro Synchron
+7805359 3 -- Niwatori
+65878864 3 -- Nobleman-Eater Bug
+45620686 3 -- Noisy Gnat
+48783998 3 -- Nova Summoner
+51616747 3 -- Nubian Guard
+12953226 3 -- Nuvia the Wicked
+10000000 3 -- Obelisk the Tormentor
+10000001 3 -- Obelisk the Tormentor
+10000002 3 -- Obelisk the Tormentor
+52077741 3 -- Obnoxious Celtic Guard
+90464188 3 -- Obsidian Dragon
+10485110 3 -- Ocean Dragon Lord - Neo-Daedalus
+45045866 3 -- Ocean's Keeper
+74637266 3 -- Octoberser
+86088138 3 -- Ocubeam
+45121025 3 -- Ogre of the Black Shadow
+82670878 3 -- Ogre of the Scarlet Sorrow
+31768112 3 -- Oilman
+79335209 3 -- Ojama Black
+64627453 3 -- Ojama Blue
+12482652 3 -- Ojama Green
+37132349 3 -- Ojama Red
+42941100 3 -- Ojama Yellow
+45141844 3 -- Old Vindictive Magician
+33064647 3 -- One-Eyed Shield Dragon
+66927994 3 -- Oni Tank T-34
+58861941 3 -- Ooguchi
+58538870 3 -- Oppressed People
+14531242 3 -- Opticlops
+42280216 3 -- Oracle of the Sun
+63120904 3 -- Orca Mega-Fortress of Darkness
+7634581 3 -- Orichalcos Shunoros
+82065276 3 -- Oscillo Hero
+71519605 3 -- Oshaleon
+39751094 3 -- Otohime
+39751093 3 -- Otohime
+11548522 3 -- Outstanding Dog Marron
+2311603 3 -- Overdrive
+1834753 3 -- Overdrive Teleporter
+58071123 3 -- Oxygeddon
+83239739 3 -- Oyster Meister
+68670547 3 -- Paladin of the Cursed Dragon
+73398797 3 -- Paladin of White Dragon
+21263083 3 -- Pale Beast
+39091951 3 -- Pandaborg
+75375465 3 -- Pandemonium Watchbear
+42035044 3 -- Panther Warrior
+42035045 3 -- Panther Warrior
+27911549 3 -- Parasite Paracide
+27911550 3 -- Parasite Paracide
+87978805 3 -- Parasitic Ticky
+62762898 3 -- Parrot Dragon
+19153634 3 -- Patrician of Darkness
+71930383 3 -- Patroid
+76775123 3 -- Patrol Robo
+20624263 3 -- Peacock
+36039163 3 -- Penguin Knight
+93920745 3 -- Penguin Soldier
+64751286 3 -- Penumbral Soldier Lady
+12143771 3 -- People Running About
+18891691 3 -- Perfect Machine King
+48579379 3 -- Perfectly Ultimate Great Moth
+4849037 3 -- Performance of Sword
+52624755 3 -- Peten the Dark Clown
+38142739 3 -- Petit Angel
+75356564 3 -- Petit Dragon
+58192742 3 -- Petit Moth
+71181155 3 -- Phantom Beast Cross-Wing
+70969517 3 -- Phantom Beast Rock-Lizard
+34961968 3 -- Phantom Beast Thunder-Pegasus
+7576264 3 -- Phantom Beast Wild-Horn
+56605802 3 -- Phantom Cricket
+49879995 3 -- Phantom Dragon
+43191636 3 -- Phantom Dragonray Bronto
+30312361 3 -- Phantom of Chaos
+12958919 3 -- Phantom Skyblaster
+52550973 3 -- Pharaoh's Servant
+89959682 3 -- Pharaonic Protector
+69488544 3 -- Phoenix Gearfried
+23558733 3 -- Phoenixian Cluster Amaryllis
+96553688 3 -- Phoenixian Seed
+26185991 3 -- Pinch Hopper
+50823978 3 -- Piranha Army
+88975532 3 -- Pitch-Black Warwolf
+47415292 3 -- Pitch-Dark Dragon
+35429292 3 -- Pixie Knight
+55696885 3 -- Plague Wolf
+56840658 3 -- Poison Draw Frog
+43716289 3 -- Poison Mummy
+52860176 3 -- Possessed Dark Soul
+89547299 3 -- Power Injector
+18842395 3 -- Power Invader
+55063681 3 -- Power Supplier
+50621530 3 -- Powered Tuner
+549481 3 -- Prevent Rat
+91559748 3 -- Prickle Fairy
+12298909 3 -- Prime Material Dragon
+1287123 3 -- Prime Material Falcon
+2316186 3 -- Princess Curran
+51371017 3 -- Princess of Tsurugi
+75917088 3 -- Princess Pikeru
+80234301 3 -- Prisman
+82213171 3 -- Prometheus, King of the Shadows
+11678191 3 -- Protective Soul Ailin
+24221739 3 -- Protector of the Sanctuary
+10071456 3 -- Protector of the Throne
+26439287 3 -- Proto-Cyber Dragon
+21454943 3 -- Psychic Commander
+77600660 3 -- Psychic Emperor
+52430902 3 -- Psychic Jumper
+7892180 3 -- Psychic Kappa
+58453942 3 -- Psychic Snail
+29155212 3 -- Pumpking the King of Ghosts
+3167573 3 -- Puppet King
+41442341 3 -- Puppet Master
+51119924 3 -- Puppet Plant
+27870033 3 -- Pursuit Chaser
+77044671 3 -- Pyramid Turtle
+73081602 3 -- Queen Bird
+4179849 3 -- Queen of Autumn Leaves
+71411377 3 -- Queen's Bodyguard
+5901497 3 -- Queen's Double
+25652259 3 -- Queen's Knight
+20932152 3 -- Quickdraw Synchron
+23571046 3 -- Quillbolt Hedgehog
+84177693 3 -- Radiant Jeral
+12624008 3 -- Radiant Spirit
+31440542 3 -- Rafflesia Seduction
+50957346 3 -- Raging Earth
+56524813 3 -- Raging Eria
+90810762 3 -- Raging Flame Sprite
+37829468 3 -- Rai-Jin
+63223467 3 -- Rai-Mei
+79407975 3 -- Rainbow Dark Dragon
+79856792 3 -- Rainbow Dragon
+21347810 3 -- Rainbow Flower
+73125233 3 -- Raiza the Storm Monarch
+41382147 3 -- Rallis the Star Bird
+3784434 3 -- Rampaging Rhynos
+6337436 3 -- Rapid-Fire Magician
+25236056 3 -- Rare Metal Dragon
+69890967 3 -- Raviel, Lord of Phantasms
+85309439 3 -- Ray & Temperature
+18372968 3 -- Razor Lizard
+33066139 3 -- Reaper of the Cards
+23421244 3 -- Reborn Zombie
+65570596 3 -- Red Archery Girl
+77336644 3 -- Red Dragon Archfiend/Assault Mode
+86445415 3 -- Red Gadget
+68722455 3 -- Red Ogre
+74677427 3 -- Red-Eyes Black Dragon
+74677422 3 -- Red-Eyes Black Dragon
+74677423 3 -- Red-Eyes Black Dragon
+74677424 3 -- Red-Eyes Black Dragon
+74677425 3 -- Red-Eyes Black Dragon
+74677426 3 -- Red-Eyes Black Dragon
+64335805 3 -- Red-Eyes Black Metal Dragon
+64335804 3 -- Red-Eyes Black Metal Dragon
+96561011 3 -- Red-Eyes Darkness Dragon
+88264988 3 -- Red-Eyes Darkness Metal Dragon
+67300516 3 -- Red-Eyes Wyvern
+5186893 3 -- Red-Eyes Zombie Dragon
+2851070 3 -- Reflect Bounder
+70821187 3 -- Regenerating Mummy
+31986288 3 -- Regenerating Rose
+20210570 3 -- Regulus
+99458769 3 -- Reign-Beaux, Overlord of Dark World
+80102359 3 -- Reinforced Human Psychic Borg
+64631466 3 -- Relinquished
+54248491 3 -- Relinquished Spider
+60606759 3 -- Renge, Gatekeeper of Dark World
+43002864 3 -- Reptilianne Gardna
+43426903 3 -- Reptilianne Gorgon
+89810518 3 -- Reptilianne Medusa
+79491903 3 -- Reptilianne Naga
+16909657 3 -- Reptilianne Scylla
+16008155 3 -- Reptilianne Servant
+16886617 3 -- Reptilianne Vaskii
+42303365 3 -- Reptilianne Viper
+24311595 3 -- Rescueroid
+62420419 3 -- Reshef the Dark Being
+3072077 3 -- Return Zombie
+31709826 3 -- Revival Jam
+39180960 3 -- Rigorous Reaver
+38815069 3 -- Rinyan, Lightsworn Rogue
+34334692 3 -- Ritual Raven
+71971554 3 -- Road Synchron
+92421852 3 -- Robolady
+44203504 3 -- Robotic Knight
+38916461 3 -- Roboyarou
+28143906 3 -- Roc from the Valley of Haze
+68846917 3 -- Rock Ogre Grotto #1
+53890795 3 -- Rocket Jumper
+30860696 3 -- Rocket Warrior
+51987571 3 -- Rockstone Warrior
+91939608 3 -- Rogue Doll
+39004808 3 -- Root Water
+44125452 3 -- Rose Fairy
+41160533 3 -- Rose Tentacles
+1557341 3 -- Rose, Warrior of Revenge
+46303688 3 -- Roulette Barrel
+54040221 3 -- Royal Firestorm Guards
+16509093 3 -- Royal Keeper
+68280530 3 -- Royal Knight
+70791313 3 -- Royal Magical Library
+37953640 3 -- Royal Swamp Eel
+26378150 3 -- Rude Kaiser
+46427957 3 -- Ruin, Queen of Oblivion
+511003007 3 -- Ryko, Lightsworn Hunter
+57281778 3 -- Ryu Kokki
+15303296 3 -- Ryu-Kishin
+42647539 3 -- Ryu-Kishin Clown
+24611934 3 -- Ryu-Kishin Powered
+2964201 3 -- Ryu-Ran
+49645921 3 -- Saber Beetle
+37265642 3 -- Sabersaurus
+30914564 3 -- Sacred Crane
+61441708 3 -- Sacred Phoenix of Nephthys
+26669055 3 -- Sage of Silence
+62054060 3 -- Sage of Stillness
+66602787 3 -- Saggi the Dark Clown
+72237166 3 -- Samsara Kaiser
+5592689 3 -- Samsara Lotus
+14344682 3 -- Samurai Sword Baron
+50593156 3 -- Sand Gambler
+73648243 3 -- Sand Moth
+73051941 3 -- Sand Stone
+25955164 3 -- Sanga of the Thunder
+16222645 3 -- Sasuke Samurai
+11760174 3 -- Sasuke Samurai #2
+77379481 3 -- Sasuke Samurai #3
+64538655 3 -- Sasuke Samurai #4
+50400231 3 -- Satellite Cannon
+41753322 3 -- Sauropod Brachion
+75198893 3 -- Scanner
+5498296 3 -- Scarr, Scout of Dark World
+68087897 3 -- Scary Moth
+67532912 3 -- Science Soldier
+4334811 3 -- Scrap Recycler
+87685879 3 -- Sea Koala
+42071342 3 -- Sea Serpent Warrior of Darkness
+2468169 3 -- Sealmaster Meisei
+80885324 3 -- Search Striker
+67646312 3 -- Searchlightman
+19086954 3 -- Second Goblin
+15507080 3 -- Sectarian of Secrets
+38041940 3 -- Seed of Flame
+114932 3 -- Seismic Crasher
+6740720 3 -- Seiyaryu
+76232340 3 -- Sengenjin
+23401840 3 -- Senju of the Thousand Hands
+23401839 3 -- Senju of the Thousand Hands
+85448931 3 -- Sentinel of the Seas
+66516792 3 -- Serpent Night Dragon
+71829750 3 -- Serpentine Princess
+2792265 3 -- Servant of Catabolism
+57827484 3 -- Shadow Delver
+30778711 3 -- Shadow Ghoul
+37620434 3 -- Shadow Tamer
+9603356 3 -- Shadowknight Archfiend
+27869883 3 -- Shadowpriestess of Ohm
+20939559 3 -- Shadowslayer
+4035199 3 -- Shapesnatch
+20358953 3 -- Shark Cruiser
+27416701 3 -- Shiba-Warrior Taro
+95360850 3 -- Shield Warrior
+28859794 3 -- Shield Wing
+15939448 3 -- Shield Worm
+99675356 3 -- Shien's Footsoldier
+86327225 3 -- Shinato, King of a Higher Plane
+87303357 3 -- Shining Abyss
+95956346 3 -- Shining Angel
+82085619 3 -- Shining Friendship
+94081496 3 -- Shiny Black "C"
+2420921 3 -- Shire, Lightsworn Spirit
+71950093 3 -- Shovel Crusher
+3603242 3 -- Shreddder
+65422840 3 -- Shutendoji
+86442081 3 -- Silent Abyss
+40867519 3 -- Silent Insect
+73665146 3 -- Silent Magician LV4
+72443568 3 -- Silent Magician LV8
+18235577 3 -- Silent Strider
+1995985 3 -- Silent Swordsman LV3
+74388798 3 -- Silent Swordsman LV5
+37267041 3 -- Silent Swordsman LV7
+32619583 3 -- Sillva, Warlord of Dark World
+73001017 3 -- Silpheed
+90357090 3 -- Silver Fang
+86489182 3 -- Simorgh, Bird of Ancestry
+14989021 3 -- Simorgh, Bird of Divinity
+61632317 3 -- Sinister Sprocket
+60694662 3 -- Skelengel
+73752131 3 -- Skilled Dark Magician
+46363422 3 -- Skilled White Magician
+27655513 3 -- Skreech
+61370518 3 -- Skull Archfiend of Lightning
+62782218 3 -- Skull Conductor
+86652646 3 -- Skull Dog Marron
+99899504 3 -- Skull Flame
+3627449 3 -- Skull Guardian
+15653824 3 -- Skull Knight #2
+5265750 3 -- Skull Mariner
+10202894 3 -- Skull Red Bird
+32274490 3 -- Skull Servant
+64306248 3 -- Skull-Mark Ladybug
+95288024 3 -- Sky Dragon
+11458071 3 -- Sky Scourge Enrise
+74841885 3 -- Sky Scourge Invicil
+48453776 3 -- Sky Scourge Norleras
+30532390 3 -- Sky Scout
+78636495 3 -- Slate Warrior
+40200834 3 -- Sleeping Lion
+68638985 3 -- Slime Toad
+3797883 3 -- Slot Machine
+22754505 3 -- Small Piece Golem
+91133740 3 -- Snowman Eater
+60246171 3 -- Soitsu
+45985838 3 -- Solar Flare Dragon
+28966434 3 -- Solitaire Magician
+57617178 3 -- Sonic Bird
+36472900 3 -- Sonic Chick
+84696266 3 -- Sonic Duck
+84550200 3 -- Sonic Jammer
+38942059 3 -- Sonic Maid
+40384720 3 -- Sonic Shooter
+88619463 3 -- Sorcerer of Dark Magic
+49218300 3 -- Sorcerer of the Doomed
+77527210 3 -- Soul of Purity and Light
+15734813 3 -- Soul Tiger
+63012333 3 -- Soul-Absorbing Bone Tower
+31242786 3 -- Souleater
+4920010 3 -- Souls of the Forgotten
+36119641 3 -- Space Mambo
+58551308 3 -- Spear Cretin
+31553716 3 -- Spear Dragon
+9365703 3 -- Speed Warrior
+84636823 3 -- Spell Canceller
+15175429 3 -- Spell Reactor RE
+93187568 3 -- Spell Striker
+82693042 3 -- Sphere of Chaos
+52121290 3 -- Spherous Lady
+51402177 3 -- Sphinx Teleia
+85326399 3 -- Spike Seadra
+87511987 3 -- Spikebot
+42463414 3 -- Spined Gillman
+32626733 3 -- Spiral Serpent
+48659020 3 -- Spirit Caller
+13522325 3 -- Spirit of Flames
+14037717 3 -- Spirit of the Books
+53530069 3 -- Spirit of the Breeze
+80770678 3 -- Spirit of the Harp
+25343280 3 -- Spirit of the Pharaoh
+4896788 3 -- Spirit of the Pot of Greed
+65685470 3 -- Spirit of the Six Samurai
+67957315 3 -- Spirit Ryu
+5645210 3 -- Splendid Venus
+80637190 3 -- Spyder Spider
+8201910 3 -- Star Boy
+61257789 3 -- Stardust Dragon/Assault Mode
+68543408 3 -- Stardust Xiaolong
+3510565 3 -- Stealth Bird
+98049038 3 -- Stealthroid
+44729197 3 -- Steamroid
+29172562 3 -- Steel Ogre Grotto #1
+90908427 3 -- Steel Ogre Grotto #2
+13599884 3 -- Steel Scorpion
+68171737 3 -- Stone Dragon
+15023985 3 -- Stone Ogre Grotto
+31812496 3 -- Stone Statue of the Aztecs
+15935204 3 -- Storm Caller
+39188539 3 -- Storm Shooter
+29013526 3 -- Storming Wynn
+86209650 3 -- Stray Asmodian
+41006930 3 -- Strike Ninja
+23770284 3 -- Strong Wind Dragon
+71068263 3 -- Stuffed Animal
+50732780 3 -- Stygian Security
+63948258 3 -- Submarine Frog
+99861526 3 -- Submarineroid
+20663556 3 -- Substitoad
+55291359 3 -- Succubus Knight
+98434877 3 -- Suijin
+89493368 3 -- Summon Reactor SK
+14644902 3 -- Summoner of Illusions
+10321588 3 -- Sunlight Unicorn
+73837870 3 -- Sunny Pixie
+78552773 3 -- Supay
+85520851 3 -- Super Conductor Tyranno
+33951077 3 -- Super War-Lion
+6849042 3 -- Super-Ancient Dinobeast
+20529766 3 -- Super-Electromagnetic Voltech Dragon
+5220687 3 -- Super-Nimble Mega Hamster
+88307361 3 -- Superancient Deepsea King Coelacanth
+63804806 3 -- Supersonic Skull Flame
+44072894 3 -- Supply
+40473581 3 -- Susa Soldier
+40453765 3 -- Swamp Battleguard
+9126351 3 -- Swap Frog
+41872150 3 -- Swarm of Locusts
+15383415 3 -- Swarm of Scarabs
+81896370 3 -- Swift Birdman Joe
+16589042 3 -- Swift Gaia the Fierce Knight
+51345461 3 -- Sword Hunter
+81336148 3 -- Sword Master
+3573512 3 -- Swordsman of Landstar
+50005633 3 -- Swordstalker
+10456559 3 -- T.A.D.P.O.L.E.
+89698120 3 -- Tactical Espionage Expert
+28725004 3 -- Tainted Wisdom
+44073668 3 -- Takriminos
+3170832 3 -- Takuhee
+84847656 3 -- Telekinetic Shocker
+732302 3 -- Temple of Skulls
+41589166 3 -- Tenkabito Shien
+63308047 3 -- Terra the Terrible
+35975813 3 -- Terrorking Archfiend
+78060096 3 -- Terrorking Salmon
+3030892 3 -- Test Ape
+92373006 3 -- Test Tiger
+87148330 3 -- Tethys, Goddess of Light
+16469012 3 -- Teva
+32864 3 -- The 13th Grave
+64734921 3 -- The Agent of Creation - Venus
+91123920 3 -- The Agent of Force - Mars
+91345518 3 -- The Agent of Judgment - Saturn
+38730226 3 -- The Agent of Wisdom - Mercury
+32269855 3 -- The All-Seeing White Tiger
+34004470 3 -- The Big Saturn
+71107816 3 -- The Bistro Butcher
+51196174 3 -- The Calculator
+61505339 3 -- The Creator
+97093037 3 -- The Creator Incarnate
+52101615 3 -- The Dark - Hex-Sealed Fusion
+92719314 3 -- The Dark Creator
+93346024 3 -- The Dragon Dwelling in the Cave
+4404099 3 -- The Dragon Dwelling in the Deep
+66989694 3 -- The Earl of Demise
+88696724 3 -- The Earth - Hex-Sealed Fusion
+65403020 3 -- The End of Anubis
+66362965 3 -- The Fiend Megacyber
+84080939 3 -- The Forgiving Maiden
+84080938 3 -- The Forgiving Maiden
+18710707 3 -- The Furious Sea King
+68049471 3 -- The Gross Ghost of Fled Dreams
+1525329 3 -- The Hunter with 7 Weapons
+83764996 3 -- The Illusory Gentleman
+52035300 3 -- The Immortal Bushi
+84926738 3 -- The Immortal of Thunder
+28003512 3 -- The Judgement Hand
+90407382 3 -- The Kick Man
+40991587 3 -- The Lady in Wight
+3643300 3 -- The Legendary Fisherman
+15717011 3 -- The Light - Hex-Sealed Fusion
+25109950 3 -- The Little Swordsman of Aile
+49064413 3 -- The Masked Beast
+32541773 3 -- The Portrait's Secret
+76305638 3 -- The Rock Spirit
+27782503 3 -- The Six Samurai - Irou
+90397998 3 -- The Six Samurai - Kamon
+31904181 3 -- The Six Samurai - Nisashi
+64398890 3 -- The Six Samurai - Yaichi
+69025477 3 -- The Six Samurai - Yariza
+95519486 3 -- The Six Samurai - Zanji
+10262698 3 -- The Statue of Easter Island
+87557188 3 -- The Stern Mystic
+78243409 3 -- The Thing in the Crater
+14778250 3 -- The Tricky
+38479725 3 -- The Trojan Horse
+65475294 3 -- The Unfriendly Amazon
+27618634 3 -- The Unhappy Girl
+51275027 3 -- The Unhappy Maiden
+79814787 3 -- The White Stone of Legend
+21208154 3 -- The Wicked Avatar
+62180201 3 -- The Wicked Dreadroot
+57793869 3 -- The Wicked Eraser
+6285791 3 -- The Wicked Worm Beast
+51838385 3 -- Theban Nightmare
+87997872 3 -- Theinen the Great Sphinx
+26205777 3 -- Thestalos the Firestorm Monarch
+33977496 3 -- Thousand Needles
+27125110 3 -- Thousand-Eyes Idol
+81434470 3 -- Thousand-Eyes Jellyfish
+78423643 3 -- Three-Headed Geedo
+33734439 3 -- Three-Legged Zombies
+76075810 3 -- Throwstone Unit
+31786629 3 -- Thunder Dragon
+15510988 3 -- Thunder Kid
+71564252 3 -- Thunder King Rai-Oh
+70797118 3 -- Thunder Nyan Nyan
+49791927 3 -- Tiger Axe
+49791928 3 -- Tiger Axe
+10097168 3 -- Tiger Dragon
+71625222 3 -- Time Wizard
+44913552 3 -- Timeater
+91250514 3 -- Tongue Twister
+69572024 3 -- Tongyo
+59383041 3 -- Toon Alligator
+79875176 3 -- Toon Cannon Soldier
+90960358 3 -- Toon Dark Magician Girl
+42386471 3 -- Toon Gemini Elf
+15270885 3 -- Toon Goblin Attack Force
+16392422 3 -- Toon Masked Sorcerer
+65458948 3 -- Toon Mermaid
+91842653 3 -- Toon Summoned Skull
+83370323 3 -- Torapart
+71283180 3 -- Tornado Bird
+90337190 3 -- Torpedo Fish
+75372290 3 -- Total Defense Shogun
+564541 3 -- Totem Dragon
+58132856 3 -- Toy Magician
+42348802 3 -- Trakodon
+13821299 3 -- Trap Eater
+46461247 3 -- Trap Master
+52286175 3 -- Trap Reactor Y FI
+71759912 3 -- Tree Otter
+78780140 3 -- Trent
+39111158 3 -- Tri-Horned Dragon
+77827521 3 -- Trial of Nightmare
+20797524 3 -- Tricular
+45042329 3 -- Tripwire Beast
+55013285 3 -- Troop Dragon
+61538782 3 -- Truckroid
+27769400 3 -- Tualatin
+74093656 3 -- Tune Warrior
+47459126 3 -- Tuned Magician
+92676637 3 -- Tuningware
+60187739 3 -- Turbo Booster
+6142213 3 -- Turbo Rocket
+67270095 3 -- Turbo Synchron
+88559132 3 -- Turret Warrior
+72929454 3 -- Turtle Bird
+37313348 3 -- Turtle Tiger
+59053232 3 -- Turu-Purun
+2986553 3 -- Twilight Rose Knight
+29692206 3 -- Twin Long Rods #2
+70050374 3 -- Twin-Barrel Dragon
+43586926 3 -- Twin-Headed Behemoth
+78984772 3 -- Twin-Headed Fire Dragon
+88132637 3 -- Twin-Headed Wolf
+24025620 3 -- Twin-Shield Defender
+40225398 3 -- Twin-Sword Marauder
+82035781 3 -- Twinheaded Beast
+83228073 3 -- Two Thousand Needles
+94119974 3 -- Two-Headed King Rex
+57305373 3 -- Two-Mouth Darkruler
+72842870 3 -- Tyhone
+56789759 3 -- Tyhone #2
+68811206 3 -- Tyler the Great Warrior
+83235263 3 -- Tyranno Infinity
+94568601 3 -- Tyrant Dragon
+11819616 3 -- Tytannial, Princess of Camellias
+60806437 3 -- UFO Turtle
+7602840 3 -- UFOroid
+67934141 3 -- Ultimate Baseball Kid
+49441499 3 -- Ultimate Insect LV1
+34088136 3 -- Ultimate Insect LV3
+34830502 3 -- Ultimate Insect LV5
+19877898 3 -- Ultimate Insect LV7
+32240937 3 -- Ultimate Obedient Fiend
+15894048 3 -- Ultimate Tyranno
+86229493 3 -- Umbral Soul
+57308711 3 -- Unicycular
+56052205 3 -- Unifrog
+11743119 3 -- Union Rider
+85936485 3 -- United Resistance
+97360116 3 -- Unknown Warrior of Fiend
+92084010 3 -- Unshaven Angler
+1784619 3 -- Uraby
+6007213 3 -- Uria, Lord of Searing Flames
+48649353 3 -- Ushi Oni
+51638941 3 -- V-Tiger Jet
+75347539 3 -- Valkyrion the Magna Warrior
+56387350 3 -- Vampire Baby
+22056710 3 -- Vampire Genesis
+26495087 3 -- Vampire Lady
+53839837 3 -- Vampire Lord
+34294855 3 -- Vampire's Curse
+46571052 3 -- Vampiric Orchis
+24857466 3 -- Van'Dalgyon the Dark Dragon Lord
+77135531 3 -- Vanguard of the Dragon
+47084486 3 -- Vanity's Fiend
+72634965 3 -- Vanity's Ruler
+26046205 3 -- Vengeful Shinobi
+8062132 3 -- Vennominaga the Deity of Poisonous Snakes
+72677437 3 -- Vennominon the King of Poisonous Snakes
+9284723 3 -- Venom Boa
+22499463 3 -- Venom Cobra
+36278828 3 -- Venom Serpent
+73899015 3 -- Venom Snake
+50259460 3 -- Versago the Destroyer
+75162696 3 -- Victoria
+93130021 3 -- Victory Viper XX03
+73219648 3 -- Vilepawn Archfiend
+94042337 3 -- Violent Rain
+62379337 3 -- Violet Witch
+56043447 3 -- Viser Des
+56043446 3 -- Viser Des
+81020140 3 -- Volcanic Blaster
+66436257 3 -- Volcanic Counter
+32543380 3 -- Volcanic Doomfire
+54514594 3 -- Volcanic Hammerer
+63014935 3 -- Volcanic Queen
+33112041 3 -- Volcanic Rat
+76459806 3 -- Volcanic Rocket
+69750546 3 -- Volcanic Scattershot
+33365932 3 -- Volcanic Shell
+17415895 3 -- Volcanic Slicer
+20951752 3 -- Voltanis the Adjudicator
+93151201 3 -- Voltic Kong
+14898067 3 -- Vorse Raider
+14898066 3 -- Vorse Raider
+7736719 3 -- Vortex Trooper
+96300057 3 -- W-Wing Catapult
+13945283 3 -- Wall of Illusion
+30069398 3 -- Wall of Ivy
+63162310 3 -- Wall Shadow
+42994702 3 -- Wandering Mummy
+16751086 3 -- Warm Worm
+75953262 3 -- Warrior Dai Grepher
+5438492 3 -- Warrior Lady of the Wasteland
+43797906 3 -- Warrior of Atlantis
+66073051 3 -- Warrior of Zera
+87774234 3 -- Watapon
+85066822 3 -- Water Dragon
+93343894 3 -- Water Magician
+2483611 3 -- Water Omotics
+487395 3 -- Water Spirit
+27324313 3 -- Wattkid
+72053645 3 -- Weather Report
+5763020 3 -- Weeping Idol
+91996584 3 -- Whiptail Crow
+15090429 3 -- Whirlwind Prodigy
+93730409 3 -- Whirlwind Weasel
+15150365 3 -- White Magical Hat
+81383947 3 -- White Magician Pikeru
+79473793 3 -- White Night Dragon
+1571945 3 -- White Ninja
+98024118 3 -- White Potan
+73891874 3 -- White-Horned Dragon
+99865167 3 -- Wind Effigy
+87796900 3 -- Winged Dragon, Guardian of the Fortress #1
+57405307 3 -- Winged Dragon, Guardian of the Fortress #2
+57116033 3 -- Winged Kuriboh
+57116034 3 -- Winged Kuriboh
+98585345 3 -- Winged Kuriboh LV10
+33776734 3 -- Winged Kuriboh LV9
+89258225 3 -- Winged Minion
+18430390 3 -- Winged Rhynos
+87523462 3 -- Winged Sage Falcos
+31447217 3 -- Wingweaver
+75946257 3 -- Witch Doctor of Chaos
+30525991 3 -- Witch Doctor of Sparta
+17720747 3 -- Witch of the Black Rose
+80741828 3 -- Witch's Apprentice
+36304921 3 -- Witty Phantom
+42883273 3 -- Wodan the Resident of the Forest
+56369281 3 -- Wolf Axwielder
+35322812 3 -- Woodborg Inpachi
+9848939 3 -- Woodland Archer
+6979239 3 -- Woodland Sprite
+88650530 3 -- Worm Apocalypse
+15658249 3 -- Worm Barses
+51043243 3 -- Worm Cartaros
+88438982 3 -- Worm Dimikles
+73216412 3 -- Worm Drake
+14936691 3 -- Worm Erokin
+69750536 3 -- Wow Warrior
+17238333 3 -- Wretched Ghost of the Attic
+6480253 3 -- Wroughtweiler
+58996430 3 -- Wulf, Lightsworn Beast
+37744402 3 -- Wynn the Wind Charmer
+62651957 3 -- X-Head Cannon
+90508760 3 -- X-Saber Airbellum
+23115241 3 -- X-Saber Anu Piranha
+53100061 3 -- X-Saber Axel
+50604950 3 -- X-Saber Galahad
+26993374 3 -- X-Saber Uruz
+42737833 3 -- XX-Saber Emmersblade
+51808422 3 -- XX-Saber Faultroll
+78422252 3 -- XX-Saber Fulhelmknight
+42024143 3 -- XX-Saber Gardestrike
+77330185 3 -- XX-Saber Garsem
+87292536 3 -- XX-Saber Ragigura
+65622692 3 -- Y-Dragon Head
+29380133 3 -- Yado Karu
+70345785 3 -- Yamadron
+76862289 3 -- Yamata Dragon
+82841979 3 -- Yamato-no-Kami
+71280811 3 -- Yaranzo
+65303664 3 -- Yellow Baboon, Archer of the Forest
+13839120 3 -- Yellow Gadget
+51534754 3 -- Yomi Ship
+78371393 3 -- Yubel
+4779091 3 -- Yubel - Terror Incarnate
+31764700 3 -- Yubel - The Ultimate Nightmare
+64500000 3 -- Z-Metal Tank
+51945556 3 -- Zaborg the Thunder Monarch
+69123138 3 -- Zera the Mant
+12171659 3 -- Zeradias, Herald of Heaven
+93816465 3 -- Zero Gardna
+64382839 3 -- Zeta Reticulant
+24311372 3 -- Zoa
+16268841 3 -- Zolga
+43642620 3 -- Zombie Mammoth
+17259470 3 -- Zombie Master
+47693640 3 -- Zombie Tiger
+88472456 3 -- Zombyra the Dark
+86100785 3 -- Zone Eater
+7459013 3 -- Zure, Knight of Dark World
+##Extra deck monsters
+26593852 3 -- Ally of Justice Catastor
+98927491 3 -- Ambulance Rescueroid
+40173854 3 -- Amphibious Bugroth
+25862681 3 -- Ancient Fairy Dragon
+25958491 3 -- Ancient Sacred Wyvern
+86164529 3 -- Aqua Dragon
+6150044 3 -- Arcana Knight Joker
+6150045 3 -- Arcana Knight Joker
+31924889 3 -- Arcanite Magician
+59969392 3 -- Archfiend Zombie-Skull
+43378048 3 -- Armityle the Chaos Phantasm
+29071332 3 -- Armory Arm
+69514125 3 -- Avenging Knight Parshath
+25655502 3 -- Bickuribox
+96029574 3 -- Black Brutdrago
+11901678 3 -- Black Skull Dragon
+33236860 3 -- Blackwing - Silverwind the Ascendant
+76913983 3 -- Blackwing Armed Wing
+69031175 3 -- Blackwing Armor Master
+23995346 3 -- Blue-Eyes Ultimate Dragon
+23995347 3 -- Blue-Eyes Ultimate Dragon
+23995348 3 -- Blue-Eyes Ultimate Dragon
+37421579 3 -- Charubin the Fire Knight
+4796100 3 -- Chimera the Flying Mythical Beast
+64599569 3 -- Chimeratech Overdragon
+79229522 3 -- Chimeratech Fortress Dragon
+23693634 3 -- Colossal Fighter
+68319538 3 -- Cosmic Fortress Gol'gar
+10248389 3 -- Cyber Blader
+1546123 3 -- Cyber End Dragon
+1546124 3 -- Cyber End Dragon
+37057012 3 -- Cyber Ogre 2
+89112729 3 -- Cyber Saurus
+74157028 3 -- Cyber Twin Dragon
+40418351 3 -- Cyberdark Dragon
+9910360 3 -- D.3.S. Frog
+80071763 3 -- Dark Balter the Terrible
+86805855 3 -- Dark Blade the Dragon Knight
+88643579 3 -- Dark End Dragon
+13722870 3 -- Dark Flare Knight
+98502113 3 -- Dark Paladin
+98502114 3 -- Dark Paladin
+98502115 3 -- Dark Paladin
+17881964 3 -- Darkfire Dragon
+28593363 3 -- Deepsea Shark
+76263644 3 -- Destiny End Dragoon
+6021033 3 -- Doomkaiser Dragon
+62873545 3 -- Dragon Master Knight
+70681994 3 -- Dragoness the Wicked Knight
+3429238 3 -- Drill Warrior
+40854197 3 -- Elemental HERO Absolute Zero
+11502550 3 -- Elemental HERO Air Neos
+55171412 3 -- Elemental HERO Aqua Neos
+17032740 3 -- Elemental HERO Chaos Neos
+28677304 3 -- Elemental HERO Dark Neos
+41517968 3 -- Elemental HERO Darkbright
+31111109 3 -- Elemental HERO Divine Neos
+29343734 3 -- Elemental HERO Electrum
+35809262 3 -- Elemental HERO Flame Wingman
+81566151 3 -- Elemental HERO Flare Neos
+16304628 3 -- Elemental HERO Gaia
+85507811 3 -- Elemental HERO Glow Neos
+48996569 3 -- Elemental HERO Grand Neos
+68745629 3 -- Elemental HERO Inferno
+78512663 3 -- Elemental HERO Magma Neos
+5128859 3 -- Elemental HERO Marine Neos
+14225239 3 -- Elemental HERO Mariner
+52031567 3 -- Elemental HERO Mudballman
+81003500 3 -- Elemental HERO Necroid Shaman
+41436536 3 -- Elemental HERO Phoenix Enforcer
+60493189 3 -- Elemental HERO Plasma Vice
+47737087 3 -- Elemental HERO Rampart Blaster
+25366484 3 -- Elemental HERO Shining Flare Wingman
+88820235 3 -- Elemental HERO Shining Phoenix Enforcer
+81197327 3 -- Elemental HERO Steam Healer
+49352945 3 -- Elemental HERO Storm Neos
+83121692 3 -- Elemental HERO Tempest
+74711057 3 -- Elemental HERO Terra Firma
+61204971 3 -- Elemental HERO Thunder Giant
+55615891 3 -- Elemental HERO Wild Wingman
+10526791 3 -- Elemental HERO Wildedge
+15237615 3 -- Empress Judge
+58332301 3 -- Evil HERO Dark Gaia
+50282757 3 -- Evil HERO Infernal Sniper
+22160245 3 -- Evil HERO Inferno Wing
+21947653 3 -- Evil HERO Lightning Golem
+86676862 3 -- Evil HERO Malicious Fiend
+13293158 3 -- Evil HERO Wild Cyclone
+40529384 3 -- Exploder Dragonwing
+33413279 3 -- Explosive Magician
+66235877 3 -- Fiend Skull Dragon
+99267150 3 -- Five-Headed Dragon
+99267151 3 -- Five-Headed Dragon
+58528964 3 -- Flame Ghost
+45231177 3 -- Flame Swordsman
+45231178 3 -- Flame Swordsman
+53714009 3 -- Flamvell Uruquizas
+95952802 3 -- Flower Wolf
+1641882 3 -- Fusionist
+97204936 3 -- Gaia Knight, the Force of Earth
+66889139 3 -- Gaia the Dragon Champion
+87751584 3 -- Gatling Dragon
+51828629 3 -- Giltia the D. Knight
+90957527 3 -- Gladiator Beast Gaiodiaz
+48156348 3 -- Gladiator Beast Gyzarus
+27346636 3 -- Gladiator Beast Heraklinos
+5600127 3 -- Humanoid Worm Drake
+95526884 3 -- Hyper Psychic Blaster
+19974580 3 -- Iron Chain Dragon
+42810973 3 -- Junk Archer
+60800381 3 -- Junk Warrior
+94566432 3 -- Kaiser Dragon
+9653271 3 -- Kaminari Attack
+54541900 3 -- Karbonala Warrior
+13756293 3 -- King Dragun
+95144193 3 -- Kwagar Hercules
+99551425 3 -- Labyrinth Tank
+25132288 3 -- Light End Dragon
+43385557 3 -- Magical Android
+67030233 3 -- Majestic Red Dragon
+7841112 3 -- Majestic Star Dragon
+27134689 3 -- Master of Oz
+9293977 3 -- Metal Dragon
+27315304 3 -- Mist Wurm
+13803864 3 -- Mokey Mokey King
+66818682 3 -- Moon Dragon Quilla
+71628381 3 -- Multiple Piece Golem
+56907389 3 -- Musician King
+78734254 3 -- Neo-Spacian Marine Dolphin
+13857930 3 -- Neo-Spacian Twinkle Moss
+18013090 3 -- Nitro Warrior
+90140980 3 -- Ojama King
+40391316 3 -- Ojama Knight
+2403771 3 -- Power Tool Dragon
+33691040 3 -- Pragtical
+45379225 3 -- Psychic Lifetrancer
+74703140 3 -- Punished Eagle
+45500495 3 -- Queen of Thorns
+94905343 3 -- Rabid Horseman
+86346643 3 -- Rainbow Neos
+85684223 3 -- Reaper on the Nightmare
+70902743 3 -- Red Dragon Archfiend
+60634565 3 -- Reptilianne Hydra
+5309481 3 -- Revived King Ha Des
+2322421 3 -- Road Warrior
+19066538 3 -- Roaring Ocean Snake
+49868263 3 -- Ryu Senshi
+53539634 3 -- Sanwitch
+76891401 3 -- Sea Dragon Lord Gishilnodon
+2504891 3 -- Skull Knight
+21175632 3 -- St. Joan
+44508095 3 -- Stardust Dragon
+44508094 3 -- Stardust Dragon
+5368615 3 -- Steam Gyroid
+86137485 3 -- Stygian Sergeants
+39823987 3 -- Sun Dragon Inti
+75923050 3 -- Super Robolady
+1412158 3 -- Super Roboyarou
+3897065 3 -- Super Vehicroid - Stealth Union
+36256625 3 -- Super Vehicroid Jumbo Drill
+64463828 3 -- Superalloy Beast Raptinus
+63101919 3 -- Tempest Magician
+86099788 3 -- The Last Warrior from Another Planet
+70780151 3 -- Thought Ruler Archfiend
+41462083 3 -- Thousand Dragon
+41462084 3 -- Thousand Dragon
+39402797 3 -- Trident Dragion
+13574687 3 -- Turbo Cannon
+46195773 3 -- Turbo Warrior
+54752875 3 -- Twin-Headed Thunder Dragon
+32752319 3 -- UFOroid Fighter
+12652643 3 -- Ultimate Ancient Gear Golem
+63465535 3 -- Underground Arachnid
+58859575 3 -- VW-Tiger Catapult
+84243274 3 -- VWXYZ-Dragon Catapult Cannon
+56413937 3 -- Warrior of Tradition
+80108118 3 -- X-Saber Urbellum
+52352005 3 -- XX-Saber Gottoms
+2203790 3 -- XX-Saber Hyunlei
+2111707 3 -- XY-Dragon Cannon
+91998119 3 -- XYZ-Dragon Cannon
+91998120 3 -- XYZ-Dragon Cannon
+91998121 3 -- XYZ-Dragon Cannon
+99724761 3 -- XZ-Tank Cannon
+25119460 3 -- YZ-Tank Dragon
+22858242 3 -- Zeman the Ape King
+##Spells
+34541863 3 -- "A" Cell Breeding Device
+64163367 3 -- "A" Cell Incubator
+73262676 3 -- "A" Cell Scatter Burst
+67048711 3 -- 7
+86198326 3 -- 7 Completed
+6850209 3 -- A Deal with Dark Ruler
+49140998 3 -- A Feather of the Phoenix
+295517 3 -- A Legendary Ocean
+28596933 3 -- A Wingbeat of Giant Dragon
+89801755 3 -- Abyssal Designator
+21323861 3 -- Acid Rain
+35956022 3 -- Acidic Downpour
+51630558 3 -- Advance Draw
+38589847 3 -- Advance Force
+25345186 3 -- After the Struggle
+64952266 3 -- Against the Wind
+81325903 3 -- Amazoness Spellcaster
+303660 3 -- Amplifier
+5183693 3 -- Amulet of Ambition
+34487429 3 -- Ancient City - Rainbow Ruins
+87624166 3 -- Ancient Forest
+92001300 3 -- Ancient Gear Castle
+67829249 3 -- Ancient Gear Drill
+4446672 3 -- Ancient Gear Explosive
+30435145 3 -- Ancient Gear Factory
+40830387 3 -- Ancient Gear Fist
+37457534 3 -- Ancient Gear Tank
+59811955 3 -- Ancient Gear Workshop
+11830996 3 -- Ancient Leaf
+10667321 3 -- Ancient Rules
+17092736 3 -- Ancient Telescope
+34236961 3 -- Ante
+17896384 3 -- Arcane Barrier
+22796548 3 -- Archfiend's Oath
+90374791 3 -- Armed Changer
+69296555 3 -- Array of Revealing Light
+88301833 3 -- Ascending Soul
+88190790 3 -- Assault Armor
+93469007 3 -- Assault Overload
+56252810 3 -- Assault Revival
+29863101 3 -- Assault Teleport
+68786330 3 -- Attack Pheromones
+71453557 3 -- Autonomous Action Unit
+40619825 3 -- Axe of Despair
+47453433 3 -- Back to Square One
+7165085 3 -- Bait Doll
+242146 3 -- Ballista of Rampart Smashing
+10012614 3 -- Banner of Courage
+61181383 3 -- Battery Charger
+5052212 3 -- Battle Tuned
+46009906 3 -- Beast Fangs
+15471265 3 -- Berserker Crush
+61127349 3 -- Big Bang Shot
+84808313 3 -- Big Evolution Pill
+51562916 3 -- Big Wave Small Wave
+71645242 3 -- Black Garden
+41426869 3 -- Black Illusion Ritual
+55761792 3 -- Black Luster Ritual
+76792184 3 -- Black Magic Ritual
+65169794 3 -- Black Pendant
+69537999 3 -- Blaze Accelerator
+30653113 3 -- Blessings of the Nile
+25880422 3 -- Block Attack
+20871001 3 -- Blue Medicine
+45898858 3 -- Bonding - H2O
+35480699 3 -- Book of Eclipse
+2204140 3 -- Book of Life
+14087893 3 -- Book of Moon
+91595718 3 -- Book of Secret Arts
+38699854 3 -- Book of Taiyou
+66947414 3 -- Boss Rush
+85668449 3 -- Brain Research Lab
+30548775 3 -- Branch!
+63851864 3 -- Break! Draw!
+20101223 3 -- Breath of Light
+41587307 3 -- Broken Bamboo Sword
+53586134 3 -- Bubble Blaster
+80075749 3 -- Bubble Illusion
+61968753 3 -- Bubble Shuffle
+44947065 3 -- Burden of the Mighty
+24294108 3 -- Burning Land
+18937875 3 -- Burning Spear
+27191436 3 -- Burst Return
+17655904 3 -- Burst Stream of Destruction
+84740193 3 -- Buster Rancher
+4861205 3 -- Call of the Mummy
+51773900 3 -- Calming Magic
+28120197 3 -- Canyon
+42664989 3 -- Card of Sanctity
+72767833 3 -- Card Rotator
+12183332 3 -- Card Shuffle
+48712195 3 -- Card Trader
+39701395 3 -- Cards of Consonance
+28890974 3 -- Celestial Transformation
+1801154 3 -- Centrifugal Field
+28106077 3 -- Cestus of Dagla
+79323590 3 -- Chain Energy
+9952083 3 -- Chain Summoning
+61044390 3 -- Chaos End
+97439308 3 -- Chaos Greed
+69313735 3 -- Checkmate
+81380218 3 -- Chorus of Sanctuary
+21888494 3 -- Chosen One
+46910446 3 -- Chthonian Alliance
+33900648 3 -- Clear World
+75041269 3 -- Clock Tower Prison
+90135989 3 -- Cloudian Squall
+80368942 3 -- Cocoon Party
+43644025 3 -- Cocoon Rebirth
+99342953 3 -- Code A Ancient Ruins
+52518793 3 -- Colosseum - Cage of the Gladiator Beasts
+8964854 3 -- Combination Attack
+43417563 3 -- Commencement Dance
+14772491 3 -- Common Soul
+16616620 3 -- Contact
+69270537 3 -- Contact Out
+68057622 3 -- Continuous Destruction Punch
+33244944 3 -- Contract with Exodia
+69035382 3 -- Contract with the Abyss
+96420087 3 -- Contract with the Dark Master
+82639107 3 -- Convert Contact
+62966332 3 -- Convulsion of Nature
+59385322 3 -- Core Blaster
+13997673 3 -- Core Compression
+30770156 3 -- Core Transport Unit
+2561846 3 -- Corruption Cell "A"
+23265313 3 -- Cost Down
+38834303 3 -- Counter Cleaner
+15305240 3 -- Creature Seizure
+31036355 3 -- Creature Swap
+72881007 3 -- Crystal Abundance
+95326659 3 -- Crystal Beacon
+35486099 3 -- Crystal Blessing
+8275702 3 -- Crystal Promise
+10004783 3 -- Crystal Release
+47408488 3 -- Crystal Tree
+27178262 3 -- Cunning of the Six Samurai
+37812118 3 -- Cup of Ace
+12470447 3 -- Curse of Fiend
+94377247 3 -- Curse of the Masked Beast
+80033124 3 -- Cyberdark Impact!
+47295267 3 -- Cybernetic Zone
+5494820 3 -- Cyclon Laser
+22147147 3 -- Cyclone Blade
+29612557 3 -- Cyclone Boomerang
+74329404 3 -- D - Formation
+89899996 3 -- D - Spirit
+60912752 3 -- D.D. Borderline
+33423043 3 -- D.D. Designator
+9622164 3 -- D.D.R. - Different Dimension Reincarnation
+76895648 3 -- Dangerous Machine Type-6
+12071500 3 -- Dark Calling
+53527835 3 -- Dark City
+70231910 3 -- Dark Core
+78053598 3 -- Dark Designator
+4614116 3 -- Dark Energy
+674561 3 -- Dark Eruption
+90928333 3 -- Dark Factory of Mass Production
+94820406 3 -- Dark Fusion
+2314238 3 -- Dark Magic Attack
+99789342 3 -- Dark Magic Curtain
+85562745 3 -- Dark Room of Nightmare
+47233801 3 -- Dark Snake Syndrome
+74117290 3 -- Dark World Dealings
+61623148 3 -- Dark World Grimoire
+93554166 3 -- Dark World Lightning
+45895206 3 -- Dark-Piercing Light
+511003028 3 -- Darkness Approaches
+95286165 3 -- De-Fusion
+19159413 3 -- De-Spell
+32441317 3 -- De-Synchro
+1149109 3 -- Deck Lockdown
+69542930 3 -- Dedication through Light and Darkness
+36995273 3 -- Degenerate Circuit
+39719977 3 -- Delta Attacker
+48934760 3 -- Demise of the Land
+72575145 3 -- Demotion
+44883830 3 -- Des Croaking
+89086566 3 -- Detonate
+19980975 3 -- Diamond-Dust Cyclone
+84257640 3 -- Dian Keto the Cure Master
+84257639 3 -- Dian Keto the Cure Master
+11961740 3 -- Different Dimension Capsule
+56460688 3 -- Different Dimension Gate
+87880531 3 -- Diffusion Wave-Motion
+95194279 3 -- Dimension Distortion
+1896112 3 -- Dimension Explosion
+81674782 3 -- Dimensional Fissure
+22959079 3 -- Dimensionhole
+31423101 3 -- Divine Sword - Phoenix Blade
+32663969 3 -- Domino Effect
+23965037 3 -- Doriado's Blessing
+34187685 3 -- Double Attack
+3682106 3 -- Double Snare
+24096228 3 -- Double Spell
+43422537 3 -- Double Summon
+63730624 3 -- Double Tool C&D
+16435215 3 -- Dragged Down into the Grave
+1435851 3 -- Dragon Treasure
+55991637 3 -- Dragon's Gunfire
+71490127 3 -- Dragon's Mirror
+32437102 3 -- Dragonic Attack
+31476755 3 -- Dust Barrier
+213326 3 -- E - Emergency Call
+59820352 3 -- Earth Chant
+64187086 3 -- Earthbound Immortal Revival
+96907086 3 -- Earthbound Whirlwind
+82828051 3 -- Earthquake
+97342942 3 -- Ectoplasmer
+69954399 3 -- Ekibyo Drakmord
+37820550 3 -- Electro-Whip
+90219263 3 -- Elegant Egotist
+39897277 3 -- Elf's Light
+6390406 3 -- Emblem of Dragon Destroyer
+9845733 3 -- Emblem of the Awakening
+24019261 3 -- Emergency Assistance
+53046408 3 -- Emergency Provisions
+30531525 3 -- Enchanting Fitting Room
+8198712 3 -- End of the World
+98045062 3 -- Enemy Controller
+95051344 3 -- Eternal Rest
+31467372 3 -- Everliving Underworld Cannon
+52875873 3 -- Evolution Burst
+5556668 3 -- Exchange
+26725158 3 -- Exile of the Wicked
+7030340 3 -- Factory of 100 Machines
+97687912 3 -- Fairy Meteor Crush
+20188127 3 -- Fairy of the Spring
+78387742 3 -- Fake Hero
+32919136 3 -- Falling Down
+68396778 3 -- Faustian Bargain
+19394153 3 -- Feather Shot
+37406863 3 -- Fengsheng Mirror
+7153114 3 -- Field Barrier
+24874630 3 -- Fiend's Sanctuary
+55428811 3 -- Fifth Hope
+6178850 3 -- Fighting Spirit
+95308449 3 -- Final Countdown
+18591904 3 -- Final Destiny
+73134082 3 -- Final Flame
+73134081 3 -- Final Flame
+60369732 3 -- Final Ritual of the Ancients
+46173679 3 -- Fires of Doomsday
+66788016 3 -- Fissure
+39956951 3 -- Flash of the Forbidden Spell
+75560629 3 -- Flint
+16437822 3 -- Flint Missile
+63741331 3 -- Fog Control
+98252586 3 -- Follow Wind
+25789292 3 -- Forbidden Chalice
+87430998 3 -- Forest
+77454922 3 -- Fortress Whale's Oath
+68663748 3 -- Fortune's Future
+47325505 3 -- Fossil Dig
+69584564 3 -- Fragrance Storm
+46181000 3 -- Frontline Base
+9373534 3 -- Fuhma Shuriken
+48206762 3 -- Fulfillment of the Contract
+33550694 3 -- Fusion Gate
+18511384 3 -- Fusion Recovery
+26902560 3 -- Fusion Sage
+37684215 3 -- Fusion Sword Murasame Blade
+27967615 3 -- Fusion Weapon
+87902575 3 -- Future Visions
+56594520 3 -- Gaia Power
+78577570 3 -- Garma Sword Oath
+27970830 3 -- Gateway of the Six
+93431518 3 -- Gateway to Dark World
+7512044 3 -- Gather Your Mind
+37694547 3 -- Geartown
+33846209 3 -- Gemini Spark
+24668830 3 -- Germ Infection
+98792570 3 -- Gift of the Martyr
+8730435 3 -- Gladiator Beast's Battle Archfiend Shield
+25407406 3 -- Gladiator Beast's Battle Gladius
+99013397 3 -- Gladiator Beast's Battle Halberd
+52496105 3 -- Gladiator Beast's Battle Manica
+98891840 3 -- Gladiator Beast's Respite
+35224440 3 -- Gladiator Proving Ground
+24285858 3 -- Gladiator's Return
+45311864 3 -- Goblin Thief
+11868825 3 -- Goblin's Secret Remedy
+74029853 3 -- Golden Bamboo Sword
+74137509 3 -- Graceful Dice
+38430673 3 -- Grand Convergence
+82542267 3 -- Gravedigger Ghoul
+16762927 3 -- Gravekeeper's Servant
+99523325 3 -- Gravekeeper's Stele
+32022366 3 -- Gravity Axe - Grarl
+3972721 3 -- Greed Grado
+90502999 3 -- Ground Collapse
+34370473 3 -- Gryphon's Feather Duster
+48653261 3 -- Guard Penalty
+55321970 3 -- Gust Fan
+74825788 3 -- H - Heated Heart
+80811661 3 -- Hamburger Recipe
+26412047 3 -- Hammer Shot
+74519184 3 -- Hand Destruction
+75782277 3 -- Harpies' Hunting Ground
+64801562 3 -- Heart of Clear Water
+35762283 3 -- Heart of the Underdog
+57441100 3 -- Herculean Power
+191749 3 -- Hero Flash!!
+67951831 3 -- Hero Heart
+75141056 3 -- Hero Mask
+76442616 3 -- HERO's Bond
+52105192 3 -- Hidden Armory
+10248192 3 -- Hieroglyph Lithograph
+46130346 3 -- Hinotama
+38552107 3 -- Horn of Light
+64047146 3 -- Horn of the Unicorn
+12174035 3 -- Hydro Pressure Cannon
+96631852 3 -- Impenetrable Formation
+33031674 3 -- Incandescent Ordeal
+55136228 3 -- Indomitable Gladiator Beast
+52684508 3 -- Inferno Fire Blast
+12247206 3 -- Inferno Reckless Summon
+14391920 3 -- Inferno Tempest
+94163677 3 -- Infinite Cards
+23615409 3 -- Insect Barrier
+96965364 3 -- Insect Imitation
+22991179 3 -- Insect Neglect
+16227556 3 -- Inspection
+1845204 3 -- Instant Fusion
+11913700 3 -- Instant Neo Space
+98374133 3 -- Invigoration
+20457551 3 -- Iron Core Armor
+63018036 3 -- Iron Core Immediate Disposal
+36623431 3 -- Iron Core of Koa'ki Meiru
+53039326 3 -- Iron Core Specimen Lab
+95214051 3 -- Jade Insect Whistle
+21770260 3 -- Jam Breeding Machine
+33784505 3 -- Jar Robber
+41182875 3 -- Javelin Beetle Pact
+79068663 3 -- Junk Barrage
+37745919 3 -- Junk Box
+10080320 3 -- Jurassic World
+35059553 3 -- Kaiser Colosseum
+97570038 3 -- Kaminote Blow
+60519422 3 -- Kishido Spirit
+87210505 3 -- Knight's Title
+77007920 3 -- Laser Cannon Armor
+90330453 3 -- Last Day of Witch
+90330454 3 -- Last Day of Witch
+96458440 3 -- Legendary Black Belt
+12324546 3 -- Legendary Ebon Steed
+61854111 3 -- Legendary Sword
+90500169 3 -- Level Down!?
+61850482 3 -- Level Modulation
+74741494 3 -- Level Tuning
+25290459 3 -- Level Up!
+73206827 3 -- Light Barrier
+11471117 3 -- Light Laser
+2362787 3 -- Light of Redemption
+37231841 3 -- Lighten the Load
+55226821 3 -- Lightning Blade
+69162969 3 -- Lightning Vortex
+30502181 3 -- Lightsworn Sabre
+78845026 3 -- Lightwave Tuning
+64238008 3 -- Linear Accelerator Cannon
+82760689 3 -- Lucky Cloud
+34664411 3 -- Lucky Iron Axe
+81777047 3 -- Luminous Spark
+31828916 3 -- Machina Armored Unit
+25518020 3 -- Machine Assembly Line
+25769732 3 -- Machine Conversion Factory
+63995093 3 -- Machine Duplication
+83746708 3 -- Mage Power
+67227834 3 -- Magic Formula
+1073952 3 -- Magic Planter
+61844784 3 -- Magic Reflector
+91819979 3 -- Magical Blast
+39910367 3 -- Magical Citadel of Endymion
+28553439 3 -- Magical Dimension
+64389297 3 -- Magical Labyrinth
+85852291 3 -- Magical Mallet
+36045450 3 -- Magicians Unite
+94940436 3 -- Magnet Circle LV2
+27827272 3 -- Makiu, the Magical Mist
+99597615 3 -- Malevolent Nuzzler
+13626450 3 -- Malice Dispersion
+45247637 3 -- Mark of the Rose
+66865880 3 -- Marshmallon Glasses
+82432018 3 -- Mask of Brutality
+20765952 3 -- Mask of Dispel
+56948373 3 -- Mask of the Accursed
+34906152 3 -- Mass Driver
+80921533 3 -- Mausoleum of the Emperor
+32062913 3 -- Mega Ton Magical Cannon
+48642904 3 -- Mesmeric Control
+44656491 3 -- Messenger of Peace
+33114323 3 -- Metalsilver Armor
+33767325 3 -- Meteor of Destruction
+38680149 3 -- Mind Trust
+52817046 3 -- Mind Wipe
+6343408 3 -- Miracle Dig
+44887817 3 -- Miracle Fertilizer
+45906428 3 -- Miracle Fusion
+37011715 3 -- Miraculous Rebirth
+48017809 3 -- Mirage Tube
+1200843 3 -- Mirror of Yata
+1036974 3 -- Misfortune
+47529357 3 -- Mist Body
+1965724 3 -- Mokey Mokey Smackdown
+19384334 3 -- Molten Destruction
+95784434 3 -- Molting Escape
+93108433 3 -- Monster Recovery
+74848038 3 -- Monster Reincarnation
+93671934 3 -- Morale Boost
+22123627 3 -- Moray of Greed
+44424095 3 -- Morphtronic Accelerator
+70423794 3 -- Morphtronic Cord
+7817703 3 -- Morphtronic Engine
+56074358 3 -- Morphtronic Map
+90239723 3 -- Morphtronic Repair Unit
+20686759 3 -- Morphtronic Rusty Engine
+50913601 3 -- Mountain
+22493811 3 -- Multiplication of Ants
+40703222 3 -- Multiply
+68191243 3 -- Mustering of the Dark Scorpions
+69279219 3 -- My Body as a Shield
+53291093 3 -- Mysterious Triangle
+25774450 3 -- Mystic Box
+18161786 3 -- Mystic Plasma Zone
+48356796 3 -- Mystical Cards of Light
+36607978 3 -- Mystical Moon
+63516460 3 -- Mystical Wind Typhoon
+80161395 3 -- Mystik Wok
+62896588 3 -- Natural Tune
+48576971 3 -- Necklace of Command
+511002998 3 -- Necrovalley
+42015635 3 -- Neo Space
+47274077 3 -- Neos Force
+81913510 3 -- NEX
+58775978 3 -- Nightmare's Steelcage
+23842445 3 -- Nitro Unit
+71044499 3 -- Nobleman of Crossout
+17449108 3 -- Nobleman of Extermination
+20065549 3 -- Non-Spellcasting Area
+43694075 3 -- Novox's Prayer
+63703130 3 -- O - Oversoul
+19230408 3 -- Offerings to the Doomed
+19230407 3 -- Offerings to the Doomed
+90011152 3 -- Ojama Country
+8251996 3 -- Ojama Delta Hurricane!!
+24643836 3 -- Ojamagic
+98259197 3 -- Ojamuscle
+4857085 3 -- Omega Goggles
+19523799 3 -- Ookazi
+44762290 3 -- Opti-Camouflage Armor
+74115234 3 -- Orb of Yasaka
+78986941 3 -- Order to Charge
+60946968 3 -- Otherworld - The "A" Zone
+72204747 3 -- Over Destiny
+9720537 3 -- Owner's Seal
+94585852 3 -- Pandemonium
+79707116 3 -- Paralyzing Chain
+50152549 3 -- Paralyzing Potion
+42709949 3 -- Phalanx Pike
+93224848 3 -- Phantasmal Martyrs
+66607691 3 -- Photon Generator Unit
+33302407 3 -- Poison Chain
+76539047 3 -- Poison Fangs
+8842266 3 -- Poison of the Old Man
+24094653 3 -- Polymerization
+27847700 3 -- Polymerization
+67169062 3 -- Pot of Avarice
+51790181 3 -- Pot of Benevolence
+70278545 3 -- Pot of Generosity
+37630732 3 -- Power Bond
+54289683 3 -- Power Capsule
+19844995 3 -- Power Filter
+77027445 3 -- Power of Kaishin
+90246973 3 -- Power Pickaxe
+68304813 3 -- Precious Cards from Beyond
+96729612 3 -- Preparation of Rites
+94303232 3 -- Prevention Star
+86016245 3 -- Pride of the Weak
+23701465 3 -- Primal Seed
+43711255 3 -- Prohibition
+77584012 3 -- Pseudo Space
+31328739 3 -- Psi-Impulse
+4230620 3 -- Psi-Station
+25401880 3 -- Psychic Path
+92346415 3 -- Psychic Sword
+32180819 3 -- Psychokinesis
+76754619 3 -- Pyramid Energy
+38723936 3 -- Question
+49479374 3 -- Quick Charger
+37318031 3 -- R - Righteous Justice
+95507060 3 -- Raging Mad Plants
+56260110 3 -- Raimei
+66719324 3 -- Rain of Mercy
+12735388 3 -- Rainbow Veil
+51267887 3 -- Raise Body Heat
+94681654 3 -- Raptor Wing Strike
+60876124 3 -- Rare Value
+7625614 3 -- Raregold Armor
+74694807 3 -- Re-Fusion
+36099620 3 -- Realm of Light
+81191584 3 -- Recurring Nightmare
+96316857 3 -- Recycle
+99995595 3 -- Recycling Batteries
+38199696 3 -- Red Medicine
+74845897 3 -- Rekindling
+75417459 3 -- Release Restraint
+98847704 3 -- Release Restraint Wave
+22589918 3 -- Reload
+51482758 3 -- Remove Trap
+90576781 3 -- Reptilianne Poison
+91580102 3 -- Reptilianne Rage
+21179143 3 -- Reptilianne Spawn
+19827717 3 -- Return of the Doomed
+5990062 3 -- Reversal Quiz
+18302224 3 -- Reverse of Neos
+31066283 3 -- Revival of Dokurorider
+49469105 3 -- Revoke Fusion
+37534148 3 -- Ribbon of Rebirth
+58641905 3 -- Ring of Defense
+20436034 3 -- Ring of Magnetism
+34016756 3 -- Riryoku
+45778932 3 -- Rising Air Current
+25796442 3 -- Ritual Cage
+65450690 3 -- Ritual Foregone
+52913738 3 -- Ritual of Destruction
+60234913 3 -- Ritual of Grace
+54351224 3 -- Ritual Weapon
+27863269 3 -- Rocket Pilder
+95515060 3 -- Rod of Silence - Kay'est
+94793422 3 -- Rod of the Mind's Eye
+25090294 3 -- Rose Bud
+72405967 3 -- Royal Tribute
+70046172 3 -- Rush Recklessly
+73148972 3 -- Ruthless Denial
+11052544 3 -- Saber Slash
+13604200 3 -- Sage's Stone
+32268901 3 -- Salamandra
+96947648 3 -- Salvage
+44182827 3 -- Samsara
+32391631 3 -- Savage Colosseum
+10352095 3 -- Scroll of Bewitchment
+97809599 3 -- Seal of the Ancients
+22537443 3 -- Sebek's Blessing
+36562627 3 -- Second Coin Toss
+77876207 3 -- Secret Pass to the Treasures
+68462976 3 -- Secret Village of the Spellcasters
+81524977 3 -- Seed Cannon
+18752938 3 -- Seed of Deception
+63394872 3 -- Senet Switch
+60391791 3 -- Senri Eye
+49398568 3 -- Serial Spell
+56830749 3 -- Share the Pain
+52097679 3 -- Shield & Sword
+30683373 3 -- Shield Crush
+11102908 3 -- Shien's Castle of Mist
+7672244 3 -- Shien's Spy
+59237154 3 -- Shifting Shadows
+60365591 3 -- Shinato's Ark
+82878489 3 -- Shine Palace
+95638658 3 -- Shooting Star Bow - Ceal
+75967082 3 -- Short Circuit
+55713623 3 -- Shrink
+42534368 3 -- Silent Doom
+1557499 3 -- Silver Bow and Arrow
+25231813 3 -- Silver Wing
+72345736 3 -- Six Samurai United
+54913680 3 -- Six Scrolls of the Samurai
+63035430 3 -- Skyscraper
+47596607 3 -- Skyscraper 2 - Hero City
+97169186 3 -- Smashing Ground
+63789924 3 -- Smoke Grenade of the Thief
+17189677 3 -- Snake Rain
+86318356 3 -- Sogen
+691925 3 -- Solar Recharge
+86780027 3 -- Solidarity
+68073522 3 -- Soul Absorption
+51670553 3 -- Soul Devouring Bamboo Sword
+68005187 3 -- Soul Exchange
+95026693 3 -- Soul of Fire
+47852924 3 -- Soul of the Pure
+47852925 3 -- Soul of the Pure
+5758500 3 -- Soul Release
+78864369 3 -- Soul Reversal
+81510157 3 -- Soul Taker
+1539051 3 -- Space Gift
+97362768 3 -- Spark Blaster
+76103675 3 -- Sparks
+42598242 3 -- Special Hurricane
+51481927 3 -- Spell Absorption
+41160595 3 -- Spell Calling
+74402414 3 -- Spell Chronicle
+4259068 3 -- Spell Economics
+313513 3 -- Spell Gear
+76714458 3 -- Spell of Pain
+75014062 3 -- Spell Power Grasp
+29228529 3 -- Spell Reproduction
+93260132 3 -- Spell Shattering Arrow
+96677818 3 -- Spellbook Organization
+69408987 3 -- Spider Web
+26640671 3 -- Spiders' Lair
+49328340 3 -- Spiral Spear Strike
+50418970 3 -- Spirit Burner
+69832741 3 -- Spirit Elimination
+94772232 3 -- Spirit Message "A"
+31893528 3 -- Spirit Message "I"
+30170981 3 -- Spirit Message "L"
+67287533 3 -- Spirit Message "N"
+99173029 3 -- Spiritual Energy Settle Machine
+69112325 3 -- Spiritual Forest
+15866454 3 -- Spiritualism
+94425169 3 -- Spring of Rebirth
+81385346 3 -- Stamping Destruction
+67196946 3 -- Star Blast
+2370081 3 -- Steel Shell
+83225447 3 -- Stim-Pack
+63102017 3 -- Stop Defense
+60764581 3 -- Stray Lambs
+34646691 3 -- Stumbling
+55375684 3 -- Summon Cloud
+79816536 3 -- Summoner's Art
+26120084 3 -- Super Double Summon
+48130397 3 -- Super Polymerization
+27770341 3 -- Super Rejuvenation
+28529976 3 -- Super Solar Nutrient
+95750695 3 -- Supervise
+98380593 3 -- Supremacy Berry
+94145683 3 -- Swallow's Nest
+96765646 3 -- Swing of Memories
+37120512 3 -- Sword of Dark Destruction
+17589298 3 -- Sword of Dark Rites
+98495314 3 -- Sword of Deep-Seated
+61405855 3 -- Sword of Dragon's Soul
+48716139 3 -- Sword of Kusanagi
+48447192 3 -- Sword of Sparkles
+5371656 3 -- Sword of the Soul-Eater
+12923641 3 -- Swords of Concealing Light
+45305419 3 -- Symbol of Heritage
+78794994 3 -- Symbols of Duty
+35537860 3 -- Synchro Blast Wave
+98143165 3 -- Synchro Boost
+36737092 3 -- Synchro Change
+88289295 3 -- Synchro Control
+61032879 3 -- Synchronized Realm
+72446038 3 -- Synthesis Spell
+18895832 3 -- System Down
+83682725 3 -- Tail Swipe
+43641473 3 -- Tailor of the Fickle
+19312169 3 -- Talisman of Trap Sealing
+68392533 3 -- Telekinetic Charging Cell
+28741524 3 -- Telekinetic Power Well
+6795211 3 -- Teleport
+91468551 3 -- Temple of the Sun
+73628505 3 -- Terraforming
+403847 3 -- The A. Forces
+73680966 3 -- The Beginning of the End
+1689516 3 -- The Big March of Animals
+41142615 3 -- The Cheerful Coffin
+30606547 3 -- The Dark Door
+43973174 3 -- The Flute of Summoning Dragon
+20065322 3 -- The Flute of Summoning Kuriboh
+88089103 3 -- The Graveyard in the Fourth Dimension
+81820689 3 -- The Inexperienced Spy
+66926224 3 -- The Law of the Normal
+22610082 3 -- The Mask of Remnants
+40703393 3 -- The Puppet Magic of Dark Ruler
+16430187 3 -- The Reliable Guardian
+56433456 3 -- The Sanctuary in the Sky
+4081094 3 -- The Second Sarcophagus
+99351431 3 -- The Secret of the Bandit
+43434803 3 -- The Shallow Grave
+78697395 3 -- The Third Sarcophagus
+95281259 3 -- The Warrior Returning Alive
+5973663 3 -- The World Tree
+65079854 3 -- Thorn of Malice
+5703682 3 -- Thousand Energy
+63391643 3 -- Thousand Knives
+69196160 3 -- Thunder Crash
+94068856 3 -- Time Passage
+40350910 3 -- Timidity
+57182235 3 -- Token Thanksgiving
+82003859 3 -- Toll
+89997728 3 -- Toon Table of Contents
+15259703 3 -- Toon World
+15259704 3 -- Toon World
+61068510 3 -- Tornado
+38120068 3 -- Trade-In
+25573054 3 -- Transcendent Wings
+46918794 3 -- Tremendous Fire
+21420702 3 -- Tri-Blaze Accelerator
+72709014 3 -- Trial of the Princesses
+12181376 3 -- Triangle Ecstasy Spark
+32298781 3 -- Triangle Power
+2903036 3 -- Tribute Doll
+79759861 3 -- Tribute to the Doomed
+75622824 3 -- Tricky Spell 4
+76806714 3 -- Turtle Oath
+21900719 3 -- Twin Swords of Flashing Light - Tryce
+45939841 3 -- Twister
+25578802 3 -- Two-Man Cell Battle
+22431243 3 -- Ultra Evolution Pill
+22702055 3 -- Umi
+82999629 3 -- Umiiruka
+60399954 3 -- Union Attack
+14731897 3 -- Unity
+73567374 3 -- Unleash Your Power!
+62991886 3 -- Unstable Evolution
+70368879 3 -- Upstart Goblin
+99002135 3 -- Urgent Synthesis
+1353770 3 -- Valhalla, Hall of the Fallen
+65196094 3 -- Variety Comes Out
+23299957 3 -- Vehicroid Connection Zone
+90434926 3 -- Veil of Darkness
+95220856 3 -- Vengeful Bog Spirit
+21702241 3 -- Vengeful Servant
+60728397 3 -- Venom Shot
+54306223 3 -- Venom Swamp
+80402389 3 -- Verdant Sanctuary
+75524092 3 -- Vicious Claw
+39774685 3 -- Vile Germs
+15052462 3 -- Violet Crystal
+64973456 3 -- Viper's Rebirth
+54539105 3 -- War-Lion Ritual
+90873992 3 -- Warrior Elimination
+23424603 3 -- Wasteland
+49669730 3 -- Water Hazard
+38992735 3 -- Wave-Motion Cannon
+10035717 3 -- Weapon Change
+2084239 3 -- Wetlands
+9786492 3 -- White Dragon Ritual
+68427465 3 -- Wicked-Breaking Flamberge - Baou
+68815401 3 -- Wild Fire
+61166988 3 -- Wild Nature's Release
+38568567 3 -- Wonder Clover
+43140791 3 -- Worm Bait
+52098461 3 -- Wrath of Neos
+59197169 3 -- Yami
+4542651 3 -- Yellow Luster Shield
+81332143 3 -- Yu-Jo Friendship
+81756897 3 -- Zera Ritual
+4064256 3 -- Zombie World
+##Traps
+68170903 3 -- A Feint Plan
+21597117 3 -- A Hero Emerges
+32207100 3 -- A Major Upset
+5728014 3 -- A Rival Appears!
+27744077 3 -- Absolute End
+98444741 3 -- Accumulated Fortune
+41356845 3 -- Acid Trap Hole
+41356846 3 -- Acid Trap Hole
+62325062 3 -- Adhesion Trap Hole
+47060347 3 -- Aegis of Gaia
+7935043 3 -- Aegis of the Ocean Dragon Lord
+65384019 3 -- Alchemy Cycle
+17490535 3 -- Alien Brain
+30834988 3 -- All-Out Attacks
+21070956 3 -- Altar for Tribute
+67987611 3 -- Amazoness Archers
+77972406 3 -- Ambush Fangs
+19763315 3 -- An Unfortunate Report
+42364257 3 -- Anti Raigeki
+72150572 3 -- Anti-Fusion Device
+53112492 3 -- Anti-Spell
+58921041 3 -- Anti-Spell Fragrance
+43262273 3 -- Appointer of the Red Lotus
+48539234 3 -- Appropriate
+95132338 3 -- Aqua Chorus
+99189322 3 -- Arcana Call
+56246017 3 -- Archfiend's Roar
+79649195 3 -- Armor Break
+36868108 3 -- Armored Glass
+55348096 3 -- Arsenal Robber
+76407432 3 -- Assault Counter
+80280737 3 -- Assault Mode Activate
+62633180 3 -- Assault on GHQ
+40012727 3 -- Assault Slash
+37053871 3 -- Astral Barrier
+6112401 3 -- At One With the Sword
+63689843 3 -- Attack and Receive
+84389640 3 -- Attack of the Cornered Rat
+91989718 3 -- Attack Reflector Unit
+58990631 3 -- Automatic Laser
+82705573 3 -- Backfire
+32603633 3 -- Backs to the Wall
+36280194 3 -- Backup Soldier
+40633297 3 -- Bad Reaction to Simochi
+28062325 3 -- Bamboo Scrap
+41925941 3 -- Bark of Dark Ruler
+78783370 3 -- Barrel Behind the Door
+31245780 3 -- Battle Mania
+60530944 3 -- Battle of the Elements
+71652522 3 -- Battle Teleportation
+94463200 3 -- Battle-Scarred
+35149085 3 -- Beast Soul Swap
+16255442 3 -- Beckoning Light
+20374520 3 -- Begone, Knave!
+94662235 3 -- Bending Destiny
+56535497 3 -- Berserking
+95472621 3 -- Big Burn
+35539880 3 -- Birthright
+50323155 3 -- Black Horn of Heaven
+89041555 3 -- Blast Held by a Tribute
+98239899 3 -- Blast with Chain
+99788587 3 -- Blasting Fuse
+21466326 3 -- Blasting the Ruins
+32015116 3 -- Blind Destruction
+47778083 3 -- Bone Temple Block
+76532077 3 -- Bottomless Shifting Sand
+59258334 3 -- Brainwashing Beam
+96218085 3 -- Breakthrough!
+60930169 3 -- Broken Blocker
+30155789 3 -- Brutal Potion
+61622107 3 -- Bubble Crash
+80163754 3 -- Burst Breath
+35011819 3 -- By Order of the Emperor
+36935434 3 -- Byroad Sacrifice
+78637313 3 -- Call of Darkness
+65743242 3 -- Call of the Earthbound
+16970158 3 -- Call of the Grave
+45133463 3 -- Call of the Reaper
+44209392 3 -- Castle Walls
+84491298 3 -- Cell Explosion Virus
+51394546 3 -- Cemetary Bomb
+48276469 3 -- Chain Burst
+1248895 3 -- Chain Destruction
+51449743 3 -- Chain Detonation
+57139487 3 -- Chain Disappearance
+25050038 3 -- Chain Healing
+39980304 3 -- Chain Material
+74095602 3 -- Change of Hero - Reflector Ray
+24673894 3 -- Changing Destiny
+4923662 3 -- Chaos Burst
+18271561 3 -- Chthonian Blast
+72287557 3 -- Chthonian Polymer
+22479888 3 -- Clay Charge
+8323633 3 -- Cloak and Dagger
+86871614 3 -- Cloning
+56641453 3 -- Cocoon Veil
+65830223 3 -- Coffin Seller
+7565547 3 -- Collected Power
+40465719 3 -- Common Charity
+94192409 3 -- Compulsory Evacuation Device
+67630339 3 -- Confusion Chaff
+31000575 3 -- Conscription
+18517177 3 -- Core Blast
+8057630 3 -- Core Reinforcement
+42309337 3 -- Counter Counter
+11136371 3 -- Counter Gem
+74458486 3 -- Covering Fire
+24566654 3 -- Crimson Fire
+24082387 3 -- Crop Circles
+37083210 3 -- Cross Counter
+39712330 3 -- Cry Havoc!
+47121070 3 -- Crystal Pair
+96331676 3 -- Crystal Raigeki
+41398771 3 -- Curse of Aging
+66742250 3 -- Curse of Anubis
+84970821 3 -- Curse of Darkness
+2926176 3 -- Curse of Royal
+58851034 3 -- Cursed Seal of the Forbidden Spell
+90440725 3 -- Cyber Shadow Gardna
+63477921 3 -- Cyber Summon Blaster
+92773018 3 -- Cybernetic Hidden Technology
+43405287 3 -- D - Chain
+8698851 3 -- D - Counter
+9201964 3 -- D - Fortune
+62868900 3 -- D - Shield
+99075257 3 -- D - Time
+2833249 3 -- D. Tribe
+8628798 3 -- D.D. Dynamite
+5606466 3 -- D.D. Trap Hole
+44584775 3 -- Damage = Reptile
+28378427 3 -- Damage Condenser
+46031686 3 -- Damage Polarizer
+35268887 3 -- Damage Translation
+77538567 3 -- Dark Bribe
+1804528 3 -- Dark Coffin
+3701074 3 -- Dark Cure
+65824822 3 -- Dark Deal
+5562461 3 -- Dark Illusion
+20522190 3 -- Dark Mirror Force
+20858318 3 -- Dark Scorpion Combination
+38167722 3 -- Dark Spirit Art - Greed
+93599951 3 -- Dark Spirit of the Silent
+69122763 3 -- Deal of Phantom
+35027493 3 -- Deck Devastation Virus
+24268052 3 -- Defense Draw
+28877100 3 -- Defensive Tactics
+59839761 3 -- Delta Crow - Anti Reverse
+8279188 3 -- Depth Amulet
+39131963 3 -- Des Counterblow
+42079445 3 -- Descending Lost Star
+93747864 3 -- Desert Sunlight
+94212438 3 -- Destiny Board
+15294090 3 -- Destiny Mirage
+35464895 3 -- Destiny Signal
+18739764 3 -- Destruct Potion
+98956134 3 -- Destruction Jammer
+62980542 3 -- Destruction of Destiny
+5616412 3 -- Destruction Punch
+21219755 3 -- Destruction Ring
+77859858 3 -- Destructive Draw
+20985997 3 -- Detonator Circle "A"
+83241722 3 -- Dice Re-Roll
+59905358 3 -- Dice Try!
+67095270 3 -- Dimension Wall
+98666339 3 -- Dimensional Inversion
+70342110 3 -- Dimensional Prison
+24623598 3 -- Disappear
+26834022 3 -- Disarm
+20727787 3 -- Disarmament
+46480475 3 -- Discord
+77561728 3 -- Disturbance Strategy
+49010598 3 -- Divine Wrath
+27340877 3 -- DNA Checkup
+74701381 3 -- DNA Surgery
+56769674 3 -- DNA Transplant
+66395299 3 -- Doppelganger
+67464807 3 -- Dora of Fate
+67223587 3 -- Double Tag Team
+21007444 3 -- Double-Edged Sword Technique
+50045299 3 -- Dragon Capture Jar
+54178050 3 -- Dragon's Rage
+43250041 3 -- Draining Shield
+80193355 3 -- Dramatic Rescue
+80193356 3 -- Dramatic Rescue
+4440873 3 -- Drastic Drop Off
+473469 3 -- Driving Snow
+55773067 3 -- Drop Off
+60082869 3 -- Dust Tornado
+29934351 3 -- Earthbound Wave
+60866277 3 -- Earthshaker
+42578427 3 -- Eatgaboon
+88341502 3 -- Ebon Arrow
+84361420 3 -- Edge Hammer
+94253609 3 -- Elemental Absorber
+61411502 3 -- Elemental Burst
+36586443 3 -- Elemental Recharge
+73872164 3 -- Eliminating the League
+28649820 3 -- Embodiment of Apophis
+96355986 3 -- Enchanted Javelin
+56916805 3 -- Energy Drain
+57006589 3 -- Energy-Absorbing Monolith
+26022485 3 -- Enervating Mist
+57274196 3 -- Enlightenment
+62878208 3 -- Equip Shot
+54974237 3 -- Eradicator Epidemic Virus
+31550470 3 -- Escape from the Dark Dimension
+35787450 3 -- Eternal Dread
+15684835 3 -- Evil Blast
+95451366 3 -- Exhausting Spell
+21598948 3 -- Fairy Box
+73507661 3 -- Fairy Wind
+17653779 3 -- Fairy's Hand Mirror
+41234315 3 -- Fake Explosion
+22628574 3 -- Fake Feather
+3027001 3 -- Fake Trap
+77910045 3 -- Fatal Abacus
+71060915 3 -- Feather Wind
+81172176 3 -- Fiend Comedian
+81172177 3 -- Fiend Comedian
+58607704 3 -- Fiend's Hand Mirror
+50078509 3 -- Fiendish Chain
+52503575 3 -- Final Attack Orders
+92595643 3 -- Fine
+43061293 3 -- Fire Darts
+94804055 3 -- Firewall
+58873391 3 -- Fish Depth Charge
+60718396 3 -- Flamvell Counter
+9267769 3 -- Flashbang
+83778600 3 -- Foolish Revival
+43340443 3 -- Forced Back
+97806240 3 -- Forced Ceasefire
+74923978 3 -- Forced Requisition
+43889633 3 -- Forgotten Temple of the Deep
+26931058 3 -- Formation Union
+23869735 3 -- Fossil Excavation
+34351849 3 -- Froggy Forcefield
+57069605 3 -- Frozen Soul
+49998907 3 -- Fruits of Kozaky's Studies
+1781310 3 -- Fuh-Rin-Ka-Zan
+70865988 3 -- Full Salvo
+73026394 3 -- Fusion Guard
+37313786 3 -- Gamble
+57753602 3 -- Gem Flash Energy
+18096222 3 -- Gemini Booster
+81601517 3 -- Gemini Counter
+67045174 3 -- Gemini Trap Hole
+34460239 3 -- Generation Shift
+80723580 3 -- Giant Trap Hole
+39526584 3 -- Gift Card
+98299011 3 -- Gift of the Mystical Elf
+55465441 3 -- Give and Take
+96216229 3 -- Gladiator Beast War Chariot
+97234686 3 -- Gladiator Lash
+61962135 3 -- Glorious Illusion
+4149689 3 -- Goblin Fan
+69632396 3 -- Goblin Out of the Frying Pan
+9744376 3 -- Good Goblin Housekeeping
+52648457 3 -- Gorgon's Eye
+13504844 3 -- Gottoms' Emergency Call
+53334471 3 -- Gozen Match
+98273947 3 -- Graceful Revival
+57270476 3 -- Grave Lure
+83266092 3 -- Grave of the Super Ancient Organism
+61705417 3 -- Graverobber
+33737664 3 -- Graverobber's Retribution
+89405199 3 -- Greed
+55608151 3 -- Gryphon Wing
+73079365 3 -- Gust
+15552258 3 -- Half or Nothing
+88789641 3 -- Hallowed Life Barrier
+68875140 3 -- Hard-sellin' Goblin
+94374859 3 -- Hard-sellin' Zombie
+93895605 3 -- Hate Buster
+52417194 3 -- Heavy Slump
+44676200 3 -- Hero Barrier
+37412656 3 -- Hero Blast
+19024706 3 -- Hero Counterattack
+10489311 3 -- Hero Medal
+26647858 3 -- Hero Ring
+22020907 3 -- Hero Signal
+81167171 3 -- Hero Spirit
+85854214 3 -- Hero's Rule 2
+2047519 3 -- Hidden Soldiers
+21840375 3 -- Hidden Spellbook
+98069388 3 -- Horn of Heaven
+15083728 3 -- House of Adhesive Tape
+65396880 3 -- Huge Revolution
+30353551 3 -- Human-Wave Tactics
+11925569 3 -- Hunting Instinct
+77778835 3 -- Hysteric Party
+53567095 3 -- Icarus Attack
+9995766 3 -- Imperial Custom
+30459350 3 -- Imperial Iron Wall
+18712704 3 -- Infernity Force
+54109233 3 -- Infinite Dismissal
+20057949 3 -- Inherited Fortune
+59695933 3 -- Intercept
+36261276 3 -- Interdimensional Matter Transporter
+57384901 3 -- Interdimensional Warp
+69091732 3 -- Introduction to Gallantry
+79161790 3 -- Inverse Universe
+34545235 3 -- Iron Core Luster
+14730606 3 -- Ivy Shackles
+21558682 3 -- Jam Defender
+83968380 3 -- Jar of Greed
+55256016 3 -- Judgment of Anubis
+4869446 3 -- Judgment of the Desert
+55948544 3 -- Judgment of the Pharaoh
+85080048 3 -- Judgment of Thunder
+24068492 3 -- Just Desserts
+62271284 3 -- Justi-Break
+71587526 3 -- Karma Cut
+10759529 3 -- Kid Guard
+21908319 3 -- Kozaky's Self-Destruct Button
+37390589 3 -- Kunai with Chain
+37390590 3 -- Kunai with Chain
+66526672 3 -- Labyrinth of Nightmare
+81128478 3 -- Lair Wire
+97970833 3 -- Last Resort
+30461781 3 -- Legacy of Yata-Garasu
+84397023 3 -- Level Conversion Lab
+54976796 3 -- Level Limit - Area A
+86223870 3 -- Level Retuner
+14318794 3 -- Life Absorbing Machine
+17178486 3 -- Life Equalizer
+62867251 3 -- Light of Intervention
+44595286 3 -- Light of Judgment
+35577420 3 -- Light Spiral
+53341729 3 -- Light-Imprisoning Mirror
+49587034 3 -- Lightforce Sword
+22201234 3 -- Lightsworn Barrier
+82324105 3 -- Limit Impulse
+27551 3 -- Limit Reverse
+92450185 3 -- Limiter Overload
+29307554 3 -- Lineage of Destruction
+82452993 3 -- Lone Wolf
+96012004 3 -- Lucky Chance
+70406920 3 -- Machine King - 3000 B.C.
+30241314 3 -- Macro Cosmos
+59344077 3 -- Magic Drain
+77414722 3 -- Magic Jammer
+96008713 3 -- Magical Arm Shield
+81210420 3 -- Magical Hats
+53119267 3 -- Magical Thorn
+50755 3 -- Magician's Circle
+9074847 3 -- Major Riot
+1224927 3 -- Malevolent Catastrophe
+6137095 3 -- Malfunction
+29549364 3 -- Mask of Restrict
+57882509 3 -- Mask of Weakness
+21768554 3 -- Mass Hypnosis
+75646520 3 -- Metal Detector
+26905245 3 -- Metal Reflect Slime
+68540059 3 -- Metalmorph
+68540058 3 -- Metalmorph
+56856951 3 -- Meteor Flare
+64274292 3 -- Meteorain
+37580756 3 -- Michizure
+18190572 3 -- Micro Ray
+75392615 3 -- Mind Haxorz
+59718521 3 -- Mind Over Matter
+85519211 3 -- Minefield Eruption
+34815282 3 -- Miniaturize
+1918087 3 -- Minor Goblin Official
+55985014 3 -- Miracle Kids
+97168905 3 -- Miracle Locus
+68334074 3 -- Miracle Restoring
+80551130 3 -- Miraculous Descent
+43452193 3 -- Mirror Gate
+46656406 3 -- Mirror of Oaths
+22359980 3 -- Mirror Wall
+58392024 3 -- Mispolymerization
+92890308 3 -- Morphtransition
+85101228 3 -- Morphtronic Bind
+77229910 3 -- Morphtronic Forcefield
+14613029 3 -- Morphtronic Mix-up
+28284902 3 -- Morphtronic Monitron
+80863132 3 -- Muko
+49251811 3 -- Mystic Probe
+40172183 3 -- Narrow Pass
+18158397 3 -- Natural Disaster
+83467607 3 -- Nature's Reflection
+38411870 3 -- Needle Ceiling
+38299233 3 -- Needle Wall
+84968490 3 -- Needlebug Nest
+55117418 3 -- Nega-Ton Corepanel
+14315573 3 -- Negate Attack
+7076131 3 -- Next to be Lost
+42956963 3 -- Nightmare Archfiends
+54704216 3 -- Nightmare Wheel
+89628781 3 -- Ninjitsu Art of Decoy
+70861343 3 -- Ninjitsu Art of Transformation
+60306104 3 -- No Entry!!
+76848240 3 -- Non Aggression Area
+27581098 3 -- Non-Fusion Area
+2130625 3 -- Numinous Healer
+29389368 3 -- Nutrient Z
+82340056 3 -- Offering to the Immortals
+93217231 3 -- Offering to the Snake Deity
+56995655 3 -- Ominous Fortunetelling
+33248692 3 -- Option Hunter
+96875080 3 -- Orbital Bombardment
+39537362 3 -- Ordeal of a Traveler
+39019325 3 -- Order to Smash
+23282832 3 -- Over Limit
+87046457 3 -- Overdoom Line
+20140382 3 -- Overwhelm
+71272951 3 -- Overworked
+52228131 3 -- Parry
+967928 3 -- Penalty Game!
+63571750 3 -- Pharaoh's Treasure
+63356631 3 -- Phoenix Wing Wind Blast
+63442604 3 -- Physical Double
+74270067 3 -- Pikeru's Circle of Enchantment
+58015506 3 -- Pikeru's Second Sight
+90669991 3 -- Pineapple Blast
+34029630 3 -- Pitch-Black Power Stone
+46502013 3 -- Pixie Ring
+39163598 3 -- Planet Pollutant Virus
+54451023 3 -- Plant Food Chain
+73578229 3 -- Pole Position
+91078716 3 -- Pollinosis
+61840587 3 -- Portable Battery Pack
+4483989 3 -- Prepare to Strike Back
+66518841 3 -- Prideful Roar
+11373345 3 -- Proof of Powerlessness
+16678947 3 -- Psi-Curse
+82633308 3 -- Psychic Overload
+21488686 3 -- Psychic Rejuvenation
+33323657 3 -- Psychic Soul
+55673611 3 -- Psychic Trigger
+3891471 3 -- Psychic Tuning
+34717238 3 -- Pulling the Rug
+53569894 3 -- Pyramid of Light
+1082946 3 -- Pyro Clock of Destiny
+21481146 3 -- Radiant Mirror Force
+23639291 3 -- Raging Cloudian
+4178474 3 -- Raigeki Break
+45653036 3 -- Rain Storm
+63806265 3 -- Rainbow Gravity
+34002992 3 -- Rainbow Life
+7617253 3 -- Rainbow Path
+12503902 3 -- Rare Metalmorph
+82529174 3 -- Ray of Hope
+31785398 3 -- Ready for Intercepting
+28121403 3 -- Really Eternal Rest
+37576645 3 -- Reckless Greed
+11596936 3 -- Reckoned Power
+79544790 3 -- Regretful Rebirth
+10118318 3 -- Reinforce Truth
+17814387 3 -- Reinforcements
+26956670 3 -- Release from Stone
+37507488 3 -- Relieve Monster
+61656650 3 -- Remote Revenge
+94739788 3 -- Remove Brainwashing
+8951260 3 -- Respect Play
+46874015 3 -- Return of the Six Samurai
+10537981 3 -- Return Soul
+36690018 3 -- Reversal of Fate
+77622396 3 -- Reverse Trap
+93912845 3 -- Revival Gift
+39967326 3 -- Revival of the Immortals
+70344351 3 -- Riryoku Field
+16067089 3 -- Rise of the Snake Deity
+78211862 3 -- Rising Energy
+30450531 3 -- Rite of Spirit
+54094821 3 -- Ritual Buster
+9145181 3 -- Ritual Sealing
+90846359 3 -- Rivalry of Warlords
+56339050 3 -- Roar of the Earthbound Immortal
+88279736 3 -- Robbin' Goblin
+83258273 3 -- Robbin' Zombie
+20781762 3 -- Rock Bombardment
+91597389 3 -- Roll Out!
+93382620 3 -- Rope of Life
+33950246 3 -- Royal Command
+56058888 3 -- Royal Surrender
+86742443 3 -- Royal Writ of Taxation
+44901281 3 -- Saber Hole
+56120475 3 -- Sakuretsu Armor
+60627999 3 -- Sanguine Swamp
+98427577 3 -- Scrap-Iron Scarecrow
+79205581 3 -- Scrubbed Raid
+17874674 3 -- Seal of Wickedness
+27053506 3 -- Secret Barrel
+95096437 3 -- Secrets of the Gallant
+26533075 3 -- Security Orb
+79569173 3 -- Seismic Shockwave
+57585212 3 -- Self-Destruct Button
+19451302 3 -- Serpent Suppression
+3819470 3 -- Seven Tools of the Bandit
+58621589 3 -- Shadow of Eyes
+29267084 3 -- Shadow Spell
+99735427 3 -- Shadow-Imprisoning Mirror
+12117532 3 -- Shattered Axe
+3244563 3 -- Shield Spear
+59560625 3 -- Shift
+89563150 3 -- Shining Silver Force
+92219931 3 -- Simultaneous Loss
+60406591 3 -- Sinister Seeds
+73729209 3 -- Skill Successor
+126218 3 -- Skull Dice
+98139712 3 -- Skull Invitation
+6733059 3 -- Skull Lair
+72885174 3 -- Slip of Fortune
+94484482 3 -- Slip Summon
+80678380 3 -- Snake Deity's Command
+596051 3 -- Snake Fang
+81791932 3 -- Snake Whistle
+44472639 3 -- Solar Ray
+35346968 3 -- Solemn Wishes
+23471572 3 -- Solomon's Lawbook
+76297408 3 -- Soul Demolition
+92924317 3 -- Soul Resurrection
+37383714 3 -- Soul Rope
+97151365 3 -- Spacegate
+20644748 3 -- Spatial Collapse
+1669772 3 -- Spell Purification
+76137276 3 -- Spell Reclamation
+38275183 3 -- Spell Shield Type-8
+29735721 3 -- Spell Vanishing
+10069180 3 -- Spell-Stopping Statute
+18807109 3 -- Spellbinding Circle
+18807108 3 -- Spellbinding Circle
+56051648 3 -- Spider Egg
+53239672 3 -- Spirit Barrier
+16674846 3 -- Spirit Force
+92394653 3 -- Spirit's Invitation
+70156997 3 -- Spiritual Earth Art - Kurogane
+42945701 3 -- Spiritual Fire Art - Kurenai
+6540606 3 -- Spiritual Water Art - Aoi
+79333300 3 -- Spiritual Wind Art - Miyabi
+58120309 3 -- Starlight Road
+65810489 3 -- Statue of the Wicked
+92854392 3 -- Staunch Defender
+25173686 3 -- Straight Flush
+30643162 3 -- Strike Slash
+13955608 3 -- Stronghold the Moving Fortress
+81489939 3 -- Stygian Dirge
+6859683 3 -- Success Probability 0%
+23516703 3 -- Summon Limit
+29590905 3 -- Super Junior Confrontation
+97705809 3 -- Supercharge
+49980185 3 -- Supernatural Regeneration
+58419204 3 -- Survival Instinct
+10651797 3 -- Swallow Flip
+71934924 3 -- Swift Samurai Storm!
+84613836 3 -- Swiftstrike Armor
+21879581 3 -- Synchro Barrier
+24545464 3 -- Synchro Deflector
+30123142 3 -- Synchro Strike
+16946849 3 -- Synthetic Seraphim
+71983925 3 -- Talisman of Spell Sealing
+90740329 3 -- Taunt
+90740330 3 -- Taunt
+23323812 3 -- Telepathic Power
+26509612 3 -- Terra Firma Gravity
+69724380 3 -- Terrible Deal
+92408984 3 -- The Dragon's Bead
+68400115 3 -- The Emperor's Holiday
+34694160 3 -- The Eye of Truth
+31076103 3 -- The First Sarcophagus
+29826127 3 -- The Forces of Darkness
+5915629 3 -- The Gift of Greed
+84136000 3 -- The Grave of Enkindling
+55008284 3 -- The League of Uniform Nomenclature
+50470982 3 -- The Paths of Destiny
+296499 3 -- The Regulation of Tribe
+30888983 3 -- The Selection
+99517131 3 -- The Spell Absorbing Life
+36361633 3 -- Threatening Roar
+91781589 3 -- Thunder of Ruler
+80987696 3 -- Time Machine
+83675475 3 -- Token Feastevil
+43509019 3 -- Toon Defense
+18605135 3 -- Tornado Wall
+62784717 3 -- Tour of Doom
+94256039 3 -- Tower of Babel
+35686188 3 -- Tragedy
+35686187 3 -- Tragedy
+66100045 3 -- Transmigration Break
+4206964 3 -- Trap Hole
+19252988 3 -- Trap Jammer
+3055837 3 -- Trap of Board Eraser
+79766336 3 -- Trap of Darkness
+80955168 3 -- Trap of the Imperial Tomb
+2122975 3 -- Trap Reclamation
+59616123 3 -- Trap Stun
+99590524 3 -- Treacherous Trap Hole
+54762426 3 -- Treasure Map
+96148285 3 -- Triggered Summon
+63323539 3 -- Trojan Blast
+76384284 3 -- Trojan Gladiator Beast
+50951359 3 -- Tuner Capture
+5609226 3 -- Tuner's Barrier
+70284332 3 -- Tuner's Scheme
+3149764 3 -- Tutan Mask
+83887306 3 -- Two-Pronged Attack
+21237481 3 -- Type Zero Magic Crusher
+90557975 3 -- Updraft
+94634433 3 -- Urgent Tuning
+24838456 3 -- Vanity's Call
+32233746 3 -- Vanquishing Light
+4466015 3 -- Venom Burn
+54591086 3 -- Virus Cannon
+42175079 3 -- Volcanic Eruption
+33725271 3 -- Volcanic Recharge
+12607053 3 -- Waboku
+2779999 3 -- Wall of Thorns
+28604635 3 -- Weed Out
+43487744 3 -- White Hole
+23440062 3 -- Wicked Rebirth
+42167046 3 -- Widespread Dud
+77754944 3 -- Widespread Ruin
+77754945 3 -- Widespread Ruin
+59744639 3 -- Windstorm of Etaqua
+83546647 3 -- Wolf in Sheep's Clothing
+50684552 3 -- Wonder Garage
+12253117 3 -- World Suppression
+76515293 3 -- Xing Zhen Hu
+83133491 3 -- Zero Gravity
+79852326 3 -- Zoma the Spirit
+


### PR DESCRIPTION
Adds the edison format banlist to LFLists.

All information (card pool, forbidden cards, etc) has been taken from [this website](https://www.edisonformat.com/rules.html).

Includes the pre-errata version of the cards, such as Rescue Cat and Red-Eyes Darkness Metal Dragon.