### PR TITLE
updated speed duel banlist to 22 April 2023

### DIFF
--- a/Speed.lflist.conf
+++ b/Speed.lflist.conf
@@ -1,21 +1,34 @@
-#[2023.03 Speed Duel]
-!2023.03 Speed Duel
+#[2023.04 Speed Duel]
+!2023.04 Speed Duel
 $whitelist
 #limited
 77585513 1 --Jinzo
+19230408 1 --Offerings to the Doomed
 32807846 1 --Reinforcement of the Army	
 54704216 1 --Nightmare Wheel
 79852326 1 --Zoma the Spirit
 #semi limited
 300104004 2 --Cocoon of Ultra Evolution (Skill Card)
+87102774 2 --Golden Ladybug
 14457896 2 --Parasite Paranoid
+33365932 2 --Volcanic Shell
 1475311 2 --Allure of Darkness
 81439173 2 --Foolish Burial
 66399653 2 --Union Hangar
 #2023 unlimited
+300303012 3 --I'm Just Gonna Attack!(Skill Card)
+300205004 3 --Twisted Personality (Skill Card)
+77235086 3 --Cyber Angel Benten
+71413901 3 --Breaker the Magical Warrior
 70095154 3 --Cyber Dragon
 7572887 3 --D.D. Warrior Lady
+39996157 3 --Machine Angel Ritual
+14087893 3 --Book of Moon
+8267140 3 --Cosmic Cyclone
 96331676 3 --Crystal Raigeki
+69599136 3 --Floodgate Trap Hole
+58169731 3 --Wall of Disruption
+
 #unlimited
 86198326 3 --7 Completed
 24140059 3 --A Cat of Ill Omen
@@ -141,7 +154,6 @@ $whitelist
 300202008 3 --Flight of the Harpies
 75560629 3 --Flint
 83812099 3 --Flint Lock
-69599136 3 --Floodgate Trap Hole
 87430998 3 --Forest
 62337487 3 --Fortress Whale
 77454922 3 --Fortress Whale's Oath
@@ -160,7 +172,6 @@ $whitelist
 84620194 3 --Girochin Kuwagata
 63665875 3 --Goblin Zombie
 14472500 3 --Gokipon
-87102774 3 --Golden Ladybug
 74137509 3 --Graceful Dice
 22134079 3 --Gravekeeper's Ambusher
 25262697 3 --Gravekeeper's Assailant
@@ -436,7 +447,6 @@ $whitelist
 31034919 3 --Mad Reloader
 674561 3 --Dark Eruption
 78811937 3 --Creeping Darkness
-19230408 3 --Offerings to the Doomed
 300205001 3 --Inner Conflict (Skill Card)
 300205002 3 --Into the Darkness Below (Skill Card)
 --SS05 Marik
@@ -470,7 +480,6 @@ $whitelist
 26905245 3 --Metal Reflect Slime
 65830223 3 --Coffin Seller
 300205003 3 --Shadow Reborn (Skill Card)
-300205004 3 --Twisted Personality (Skill Card)
 --SS05 Pegasus
 28546905 3 --Illusionist Faceless Mage
 65570596 3 --Red Archery Girl
@@ -517,7 +526,6 @@ $whitelist
 16589042 3 --Swift Gaia the Fierce Knight
 88240808 3 --Kycoo the Ghost Destroyer
 46363422 3 --Skilled White Magician
-71413901 3 --Breaker the Magical Warrior
 65338781 3 --Skilled Red Magician
 99789342 3 --Dark Magic Curtain
 95286165 3 --De-Fusion
@@ -645,7 +653,6 @@ $whitelist
 71044499 3 --Nobleman of Crossout
 28106077 3 --Cestus of Dagla
 1353770 3 --Valhalla, Hall of the Fallen
-8267140 3 --Cosmic Cyclone
 12607053 3 --Waboku
 55773067 3 --Drop off
 74003290 3 --Lost Wind	
@@ -714,25 +721,20 @@ $whitelist
 300303009 3 --Magician's Act
 300303010 3 --Endless Traps
 300303011 3 --No More Mrs. Nice Mai!
-300303012 3 --I'm Just Gonna Attack!
 300303013 3 --Rise of the Fallen
 300303014 3 --Beasts of Phantom
 300303015 3 --Magnetic Attraction
 300303016 3 --Power of Friendship
 #STP5
 86188410 3 --Elemental HERO Wildheart
-77235086 3 --Cyber Angel Benten
 60493189 3 --Elemental HERO Plasma Vice
 76263644 3 --Destiny End Dragoon
-58169731 3 --Wall of Disruption
 53493204 3 --Goddess with the Third Eye
 10509340 3 --Ancient Gear Beast
 13093792 3 --Destiny HERO - Diamond Dude
 32933942 3 --Crystal Beast Amethyst Cat
-33365932 3 --Volcanic Shell
 20586572 3 --Exploder Dragon
 64627453 3 --Ojama Blue
-39996157 3 --Machine Angel Ritual
 #Duel Academy Box
 57116033 3 --Winged Kuriboh
 35809262 3 --Elemental HERO Flame Wingman

--- a/Speed.lflist.conf
+++ b/Speed.lflist.conf
@@ -1,6 +1,21 @@
-#[2020.05 Speed Duel]
-!2020.05 Speed Duel
+#[2023.03 Speed Duel]
+!2023.03 Speed Duel
 $whitelist
+#limited
+77585513 1 --Jinzo
+32807846 1 --Reinforcement of the Army	
+54704216 1 --Nightmare Wheel
+79852326 1 --Zoma the Spirit
+#semi limited
+300104004 2 --Cocoon of Ultra Evolution (Skill Card)
+14457896 2 --Parasite Paranoid
+1475311 2 --Allure of Darkness
+81439173 2 --Foolish Burial
+66399653 2 --Union Hangar
+#2023 unlimited
+70095154 3 --Cyber Dragon
+7572887 3 --D.D. Warrior Lady
+96331676 3 --Crystal Raigeki
 #unlimited
 86198326 3 --7 Completed
 24140059 3 --A Cat of Ill Omen
@@ -67,7 +82,6 @@ $whitelist
 18914778 3 --Change Slime
 92667214 3 --Clown Zombie
 40240595 3 --Cocoon of Evolution
-300104004 3 --Cocoon of Ultra Evolution (Skill Card)
 10375182 3 --Command Knight
 40465719 3 --Common Charity
 31000575 3 --Conscription
@@ -258,7 +272,6 @@ $whitelist
 78986941 3 --Order to Charge
 39019325 3 --Order to Smash
 300202006 3 --Pal-O'Mine-zation!
-14457896 3 --Parasite Paranoid
 62762898 3 --Parrot Dragon
 19153634 3 --Patrician of Darkness
 300202001 3 --Peak Performance
@@ -422,10 +435,8 @@ $whitelist
 74713516 3 --Dark Mimic LV1
 31034919 3 --Mad Reloader
 674561 3 --Dark Eruption
-1475311 3 --Allure of Darkness
 78811937 3 --Creeping Darkness
 19230408 3 --Offerings to the Doomed
-79852326 3 --Zoma the Spirit
 300205001 3 --Inner Conflict (Skill Card)
 300205002 3 --Into the Darkness Below (Skill Card)
 --SS05 Marik
@@ -457,7 +468,6 @@ $whitelist
 66518841 3 --Prideful Roar
 93382620 3 --Rope of Life
 26905245 3 --Metal Reflect Slime
-54704216 3 --Nightmare Wheel
 65830223 3 --Coffin Seller
 300205003 3 --Shadow Reborn (Skill Card)
 300205004 3 --Twisted Personality (Skill Card)
@@ -574,7 +584,6 @@ $whitelist
 56747793 3 --United We Stand
 46181000 3 --Frontline Base	
 25518020 3 --Machine Assembly Line
-66399653 3 --Union Hangar
 93377803 3 --Solitary Sword of Poison
 26931058 3 --Formation Union
 12503902 3 --Rare Metalmorph	
@@ -640,7 +649,6 @@ $whitelist
 12607053 3 --Waboku
 55773067 3 --Drop off
 74003290 3 --Lost Wind	
-77585513 3 --Jinzo
 66362965 3 --The Fiend Megacyber
 49681811 3 --Freed the Matchless General
 1347977 3 --Mysterious Guard
@@ -653,7 +661,6 @@ $whitelist
 303660 3 --Amplifier
 55226821 3 --Lightning Blade
 31036355 3 --Creature Swap
-32807846 3 --Reinforcement of the Army	
 95281259 3 --The Warrior Returning Alive
 26412047 3 --Hammer Shot
 52105192 3 --Hidden Armory	
@@ -693,7 +700,6 @@ $whitelist
 21843307 3 --Copy Knight
 50277973 3 --Swamp Mirrorer
 87772572 3 --Quantum Cat
-81439173 3 --Foolish Burial
 10000020 3 --Slifer the Sky Dragon
 10000000 3 --Obelisk the Tormentor
 10000010 3 --The Winged Dragon of Ra
@@ -706,10 +712,462 @@ $whitelist
 300303007 3 --Union Combination
 300303008 3 --Spell of Mask
 300303009 3 --Magician's Act
-300303010 3 --Guardians of the Tomb
+300303010 3 --Endless Traps
 300303011 3 --No More Mrs. Nice Mai!
 300303012 3 --I'm Just Gonna Attack!
 300303013 3 --Rise of the Fallen
 300303014 3 --Beasts of Phantom
 300303015 3 --Magnetic Attraction
 300303016 3 --Power of Friendship
+#STP5
+86188410 3 --Elemental HERO Wildheart
+77235086 3 --Cyber Angel Benten
+60493189 3 --Elemental HERO Plasma Vice
+76263644 3 --Destiny End Dragoon
+58169731 3 --Wall of Disruption
+53493204 3 --Goddess with the Third Eye
+10509340 3 --Ancient Gear Beast
+13093792 3 --Destiny HERO - Diamond Dude
+32933942 3 --Crystal Beast Amethyst Cat
+33365932 3 --Volcanic Shell
+20586572 3 --Exploder Dragon
+64627453 3 --Ojama Blue
+39996157 3 --Machine Angel Ritual
+#Duel Academy Box
+57116033 3 --Winged Kuriboh
+35809262 3 --Elemental HERO Flame Wingman
+83965310 3 --Destiny HERO - Plasma
+81866673 3 --DDestiny HERO - Dasher
+73879377 3 --Armed Dragon LV7"
+90140980 3 --Ojama King
+83104731 3 --Ancient Gear Golem
+12652643 3 --Ultimate Ancient Gear Golem
+10248389 3 --Cyber Blader
+79856792 3 --Rainbow Dragon
+7093411 3 --Crystal Beast Sapphire Pegasus
+1546123 3 --Cyber End Dragon
+32543380 3 --Volcanic Doomfire
+76459806 3 --Volcanic Rocket
+22587018 3 --Hydrogeddon
+21597117 3 --A Hero Emerges
+21844576 3 --Elemental HERO Avian
+59793705 3 --Elemental HERO Bladedge
+79979666 3 --Elemental HERO Bubbleman
+58932615 3 --Elemental HERO Burstinatrix
+84327329 3 --Elemental HERO Clayman
+41517968 3 --Elemental HERO Darkbright
+89252153 3 --Elemental HERO Necroshade
+47737087 3 --Elemental HERO Rampart Blaster
+20721928 3 --Elemental HERO Sparkman
+81197327 3 --Elemental HERO Steam Healer
+61204971 3 --Elemental HERO Thunder Giant
+26902560 3 --Fusion Sage
+22020907 3 --Hero Signal
+37318031 3 --R - Righteous Justice
+63035430 3 --Skyscraper
+6480253 3 --Wroughtweiler
+43405287 3 --D - Chain
+8698851 3 --D - Counter
+89899996 3 --D - Spirit
+53527835 3 --Dark City
+55461064 3 --Destiny HERO - Blade Master
+30757127 3 --Destiny HERO - Dangerous
+26964762 3 --Destiny HERO - Dark Angel
+17132130 3 --Destiny HERO - Dogma
+41613948 3 --Destiny HERO - Doom Lord
+80744121 3 --Destiny HERO - Fear Monger
+9411399 3 --Destiny HERO - Malicious
+35464895 3 --Destiny Signal
+37684215 3 --Fusion Sword Murasame Blade
+72204747 3 --Over Destiny
+980973 3 --Armed Dragon LV3
+46384672 3 --Armed Dragon LV5
+16956455 3 --Chiron the Mage
+79335209 3 --Ojama Black
+8251996 3 --Ojama Delta Hurricane!
+12482652 3 --Ojama Green
+40391316 3 --Ojama Knight
+37132349 3 --Ojama Red
+42941100 3 --Ojama Yellow
+24643836 3 --Ojamagic
+38395123 3 --Ojamatch
+6691855 3 --Spikeshield with Chain
+32854013 3 --Super Rush Recklessly
+84136000 3 --The Grave of Enkindling
+96383838 3 --Tri-Wight
+51638941 3 --V-Tiger Jet
+58859575 3 --VW-Tiger Catapult
+96300057 3 --W-Wing Catapult
+92001300 3 --Ancient Gear Castle
+1953925 3 --Ancient Gear Engineer
+18486927 3 --Ancient Gear Gadget
+39303359 3 --Ancient Gear Knight
+56094445 3 --Ancient Gear Soldier
+31557782 3 --Ancient Gear
+28378427 3 --Damage Condenser
+82828051 3 --Earthquake
+37694547 3 --Geartown
+7359741 3 --Mechanicalchaser
+34815282 3 --Miniaturize
+65810489 3 --Statue of the Wicked
+38479725 3 --The Trojan Horse
+52497105 3 --Berserk Scales
+97023549 3 --Blade Skater
+3629090 3 --Cyber Angel Idaten
+91668401 3 --Cyber Angel Izana
+76763417 3 --Cyber Gymnast
+2158562 3 --Cyber Prima
+49375719 3 --Cyber Tutu
+79997591 3 --Doble Passe
+11460577 3 --Etoile Cyber
+88789641 3 --Hallowed Life Barrier
+54351224 3 --Ritual Weapon
+5438492 3 --Warrior Lady of the Wasteland
+34487429 3 --Ancient City - Rainbow Ruins
+69937550 3 --Crystal Beast Amber Mammoth
+21698716 3 --Crystal Beast Cobalt Eagle
+68215963 3 --Crystal Beast Emerald Tortoise
+32710364 3 --Crystal Beast Ruby Carbuncle
+95600067 3 --Crystal Beast Topaz Tiger
+35486099 3 --Crystal Blessing
+87259933 3 --Crystal Conclave
+8275702 3 --Crystal Promise
+10004783 3 --Crystal Release
+47408488 3 --Crystal Tree
+48135190 3 --Gravelstorm
+63806265 3 --Rainbow Gravity
+34002992 3 --Rainbow Life
+37440988 3 --Rainbow Overdragon
+60876124 3 --Rare Value
+64599569 3 --Chimeratech Overdragon
+12670770 3 --Cyber Network
+3370104 3 --Cyber Phoenix
+90440725 3 --Cyber Shadow Gardna
+3657444 3 --Cyber Valley
+82562802 3 --Cyberdark Claw
+40418351 3 --Cyberdark Dragon
+77625948 3 --Cyberdark Edge
+41230939 3 --Cyberdark Horn
+80033124 3 --Cyberdark Impact!
+3019642 3 --Cyberdark Keel
+11961740 3 --Different Dimension Capsule
+77565204 3 --Future Fusion
+96005454 3 --Hunter Dragon
+71098407 3 --Memory Loss
+3659803 3 --Overload Fusion
+26439287 3 --Proto-Cyber Dragon
+25173686 3 --Straight Flush
+69537999 3 --Blaze Accelerator
+5464695 3 --Blazing Inpachi
+13179332 3 --Charcoal Inpachi
+74458486 3 --Covering Fire
+94804055 3 --Firewall
+90810762 3 --Raging Flame Sprite
+54040221 3 --Royal Firestorm Guards
+32268901 3 --Salamandra
+13522325 3 --Spirit of Flames
+21420702 3 --Tri-Blaze Accelerator
+60806437 3 --UFO Turtle
+81020140 3 --Volcanic Blaster
+54514594 3 --Volcanic Hammerer
+68815401 3 --Wild Fire
+12644061 3 --Advanced Dark
+42129512 3 --Big Koala
+50896944 3 --Black Brachios
+95326659 3 --Crystal Beacon
+78613627 3 --Des Kangaroo
+27967615 3 --Fusion Weapon
+18325492 3 --Gyroid
+8783685 3 --Hourglass of Life
+62271284 3 --Justi-Break
+27134689 3 --Master of Oz
+1965724 3 --Mokey Mokey Smackdown
+27288416 3 --Mokey Mokey
+90011152 3 --Ojama Country
+78211862 3 --Rising Energy
+7171149 3 --Toon Ancient Gear Golem
+84243274 3 --VWXYZ-Dragon Catapult Cannon
+300304001 3 --Here Goes Something!
+300304002 3 --Powerful Group of Guys
+300304003 3 --Land of the Ojamas
+300304004 3 --Ancient Fusion
+300304005 3 --Cyber Blade Fusion
+300304006 3 --Crystal Transcendance
+300304007 3 --Forbidden Cyber Style Technique
+300304008 3 --Blaze Accelerator Deployment
+300304009 3 --The Right Hero for the Job
+300304010 3 --Looking into the Future
+300304011 3 --Armed and Ready!
+300304012 3 --Middle-Aged Mechs
+300304013 3 --Machine Angel Ascension
+300304015 3 --Cyberdark Style
+300304016 3 --Volcanic Cannon
+300304017 3 --Energizing Elements
+300304018 3 --Room for Growth
+300304019 3 --I've Got Dino DNA!
+300304020 3 --Consumed By Darkness
+#Midterm Paradox
+8949584 3 --A Hero Lives
+93332803 3 --Dogoran, the Mad Flame Kaiju
+71218746 3 --Drillroid
+83121692 3 --Elemental HERO Tempest
+25833572 3 --Gate Guardian
+62340868 3 --Kazejin
+25955164 3 --Sanga of the Thunder
+98434877 3 --Suijin
+36256625 3 --Super Vehicroid Jumbo Drill
+32752319 3 --UFOroid Fighter
+85066822 3 --Water Dragon
+33875961 3 --Dark Catapulter
+63060238 3 --Elemental HERO Blazeman
+29343734 3 --Elemental HERO Electrum
+14225239 3 --Elemental HERO Mariner
+1945387 3 --Elemental HERO Nova Master
+55615891 3 --Elemental HERO Wild Wingman
+74825788 3 --H - Heated Heart
+19024706 3 --Hero Counterattack
+26647858 3 --Hero Ring
+80831721 3 --Sabatiel - The Philosopher's Stone
+47596607 3 --Skyscraper 2 - Hero City
+98927491 3 --Ambulance Rescueroid
+36378213 3 --Ambulanceroid
+45945685 3 --Cycroid
+70628672 3 --Emergeroid Call
+984114 3 --Expressroid
+22512237 3 --Mechanical Hound
+71340250 3 --Mixeroid
+24311595 3 --Rescueroid
+30683373 3 --Shield Crush
+98049038 3 --Stealthroid
+5368615 3 --Steam Gyroid
+44729197 3 --Steamroid
+99861526 3 --Submarineroid
+3897065 3 --Super Vehicroid - Stealth Union
+97705809 3 --Supercharge
+61538782 3 --Truckroid
+23299957 3 --Vehicroid Connection Zone
+10035717 3 --Weapon Change
+50684552 3 --Wonder Garage
+295517 3 --A Legendary Ocean
+79402185 3 --Bonding - D2O
+6890729 3 --Bonding - DHO
+45898858 3 --Bonding - H2O
+15981690 3 --Carboneddon
+58851034 3 --Cursed Seal of the Forbidden Spell
+43017476 3 --Duoterion
+62397231 3 --Hyozanryu
+71106375 3 --Jurrac Iguanon
+23927545 3 --Jurrac Protops
+34959756 3 --Living Fossil
+58071123 3 --Oxygeddon
+10352095 3 --Scroll of Bewitchment
+6022371 3 --Water Dragon Cluster
+93889755 3 --Crass Clown
+43422537 3 --Double Summon
+13215230 3 --Dream Clown
+97687912 3 --Fairy Meteor Crush
+94773007 3 --Jirai Gumo
+17444133 3 --Kaiser Sea Horse
+66526672 3 --Labyrinth of Nightmare
+67284908 3 --Labyrinth Wall
+42647539 3 --Ryu-Kishin Clown
+30778711 3 --Shadow Ghoul
+17444133 3 --Kaiser Sea Horse
+31812496 3 --Stone Statue of the Aztecs
+92084010 3 --Unshaven Angler
+15090429 3 --Whirlwind Prodigy
+69579761 3 --Des Koala
+9637706 3 --Des Wombat
+42149850 3 --Disposable Learner Device
+81003500 3 --Elemental HERO Necroid Shaman
+55428811 3 --Fifth Hope
+55589254 3 --Frost and Flame Dragon
+61465001 3 --Loud Cloud the Storm Serpent
+74270067 3 --Pikeru's Circle of Enchantment
+87685879 3 --Sea Koala
+81383947 3 --White Magician Piker
+300305001 3 --HEROES UNITE - FUSION!!
+300305002 3 --Chemistry in Motion
+300305003 3 --The Roids Are Right
+300305004 3 --Behold, Gate Guardian!
+300305005 3 --Under Pressure
+300305006 3 --Chillin' Outback
+300305007 3 --HERO World
+300305008 3 --Power Bond
+300305009 3 --Beware the Paradox Brothers!
+300305010 3 --Elements of Thunder, Water and Wind
+300305011 3 --Believe in Your Bro
+300305012 3 --Small Roid Big City
+
+#Duelists of Shadows
+15951532 3 --Amazoness Queen
+95132338 3 --Aqua Chorus
+59464593 3 --Armed Dragon LV10
+94820406 3 --Dark Fusion
+25366484 3 --Elemental HERO Shining Flare Wingman
+86676862 3 --Evil HERO Malicious Fiend
+6614221 3 --Fog King
+27408609 3 --Golden Homunculus
+54493213 3 --Helios - The Primordial Sun
+70595331 3 --Il Blud
+25773409 3 --Legendary Jujitsu Master
+30241314 3 --Macro Cosmos
+96561011 3 --Red-Eyes Darkness Dragon
+61370518 3 --Skull Archfiend of Lightning
+48130397 3 --Super Polymerization
+22056710 3 --Vampire Genesis
+80485722 3 --Vampire Hunter
+12071500 3 --Dark Calling
+65824822 3 --Dark Deal
+93554166 3 --Dark World Lightning
+58332301 3 --Evil HERO Dark Gaia
+95943058 3 --Evil HERO Infernal Gainer
+50304345 3 --Evil HERO Infernal Prodigy
+22160245 3 --Evil HERO Inferno Wing
+21947653 3 --Evil HERO Lightning Golem
+58554959 3 --Evil HERO Malicious Edge
+13293158 3 --Evil HERO Wild Cyclone
+18438874 3 --Evil Mind
+73648243 3 --Sand Moth
+50259460 3 --Versago the Destroyer
+36262024 3 --Black Dragon's Chick
+93969023 3 --Black Metal Dragon
+55991637 3 --Dragon's Gunfire
+54178050 3 --Dragon's Rage
+11091375 3 --Luster Dragon
+15960641 3 --Mirage Dragon
+67300516 3 --Red-Eyes Wyvern
+96765646 3 --Swing of Memories
+564541 3 --Totem Dragon
+77135531 3 --Vanguard of the Dragon
+4861205 3 --Call of the Mummy
+63665875 3 --Goblin Zombie
+34761062 3 --Heavy Knight of the Flame
+55696885 3 --Plague Wolf
+57281778 3 --Ryu Kokki
+31189536 3 --Vampire Awakening
+56387350 3 --Vampire Baby
+34250214 3 --Vampire Familiar
+26495087 3 --Vampire Lady
+70645913 3 --Vampire Retainer
+88728507 3 --Vampire Sorcerer
+34294855 3 --Vampire's Curse
+69700783 3 --Vampire's Desire
+55821894 3 --Amazoness Fighter
+36100154 3 --Amazoness Fighting Spirit
+47480070 3 --Amazoness Paladin
+71209500 3 --Amazoness Scouts
+81325903 3 --Amazoness Spellcaster
+10979723 3 --Amazoness Tiger
+22082163 3 --Amazoness Willpower
+64178868 3 --Battle Survivor
+80193355 3 --Dramatic Rescue
+6799227 3 --Half Counter
+58477767 3 --Queen's Pawn
+29603180 3 --Annihilator Archfiend
+48675364 3 --Archfiend General
+49881766 3 --Archfiend Soldier
+56246017 3 --Archfiend's Roar
+40619825 3 --Axe of Despair
+94463200 3 --Battle-Scarred
+69313735 3 --Checkmate
+35798491 3 --Darkbishop Archfiend
+72192100 3 --Desrook Archfiend
+24096228 3 --Double Spell
+73698349 3 --Giant Orc
+8581705 3 --Infernalqueen Archfiend
+28601770 3 --Mist Archfiend
+94585852 3 --Pandemonium
+9603356 3 --Shadowknight Archfiend
+35975813 3 --Terrorking Archfiend
+73219648 3 --Vilepawn Archfiend
+47829960 3 --Chaosrider Gustaph
+41398771 3 --Curse of Aging
+44792253 3 --D.D. Destroyer
+3773196 3 --D.D. Scout Plane
+48092532 3 --D.D. Survivor
+82112775 3 --D.D.M. - Different Dimension Master
+39900763 3 --Different Dimension Encounter
+56460688 3 --Different Dimension Gate
+41113025 3 --Diskblade Rider
+5133471 3 --Galaxy Cyclone
+38430673 3 --Grand Convergence
+36584821 3 --Gren Maju Da Eiza
+86361354 3 --Tribe-Shocking Virus
+47060347 3 --Aegis of Gaia
+53701259 3 --Awakening of the Sacred Beasts
+54828837 3 --Cerulean Skyfire
+79279397 3 --D-Boyz
+87917187 3 -Dark Summoning Beast
+13301895 3 --Fallen Paradise
+18590133 3 --Goblin King
+11448373 3 --Grave Protector
+29216198 3 --Gravitic Orb
+32491822 3 --Hamon, Lord of Striking Thunder
+69890967 3 --Raviel, Lord of Phantasms
+69452756 3 --Unending Nightmare
+6007213 3 --Uria, Lord of Searing Flames
+17810268 3 -Cloudian - Acid Cloud
+79703905 3 --Cloudian - Altus
+43318266 3 --Cloudian - Cirrostratus
+57610714 3 --Cloudian - Eye of the Typhoon
+83604828 3 --Cloudian - Ghost Fog
+20003527 3 --Cloudian - Nimbusman
+80825553 3 --Cloudian - Smoke Ball
+13474291 3 --Cloudian - Storm Dragon
+16197610 3 --Cloudian - Turbulence
+88210105 3 --Cloudian Aerosol
+90135989 3 --Cloudian Squall
+19980975 3 --Diamond-Dust Cyclone
+63741331 3 --Fog Control
+57839750 3 --Mother Grizzly
+23639291 3 --Raging Cloudian
+45653036 3 --Rain Storm
+553756843 --Summon Cloud
+7736719 3 --Vortex Trooper
+40916023 3 --Aqua Spirit
+44702857 3 --Bitelon
+6214884 3 --Brron, Mad King of Dark World
+11593137 3 --Chaos Trap Hole
+56597272 3 --Cloudian - Sheep Cloud
+38834303 3 --Counter Cleaner
+61587183 3 --Dark Scorpion - Chick the Yellow
+6967870 3 --Dark Scorpion - Cliff the Trap Remove
+39956951 3 --Flash of the Forbidden Spell
+49003308 3 --Gagagigo
+12800777 3 --Garuda the Wind Spirit
+17286057 3 --Helios Trice Megistus
+80887952 3 --Helios Duo Megistus
+30353551 3 --Human-Wave Tactics
+52248570 3 --Imprisoned Queen Archfiend
+90464188 3 --Obsidian Dragon
+52550973 3 --Pharaoh's Servant
+89959682 3 --Pharaonic Protector
+99458769 3 --Reign-Beaux, Overlord of Dark World
+25343280 3 --Spirit of the Pharaoh
+78060096 3 --Terrorking Salmon
+31076103 3 --The First Sarcophagus
+4081094 3 --The Second Sarcophagus
+78697395 3 --The Third Sarcophagus
+1371589 3 --Vampiric Koala
+7459013 3 --Zure, Knight of Dark World
+300306001 3 --Ruthless Means
+300306002 3 --Forged Steel
+300306003 3 --Vampire Aristocracy
+300306004 3 --Welcome to the Jungle
+300306005 3 --Archfiend's Conscription
+300306006 3 --Professor of Alchemy
+300306007 3 --Unlocking the Power
+300306008 3 --Fog Warning
+300306009 3 --Dark Unity
+300306010 3 --Dragon Force
+300306011 3 --Delicious Morsel
+300306012 3 --Order of the Queen
+300306013 3 --Archfiend's Promotion
+300306014 3 --Setting Sun
+300306015 3 --Victory of the Shadow Riders
+300306016 3 --Cloudy Skies of Grey
+300306017 3 --No One Suspects the Dark Scorpion Gang!
+300306018 3 --Ancient Ruler Rises
+300306019 3 --Cold-Blooded Tactician
+300306020 3 --Dark Creation


### PR DESCRIPTION
1. banlist updated up to Speed Duel Box : Duelist of Shadows
2. Updated January 2023 official Speed duel banlists