### PR TITLE
Added OCG-AE card pool, and its 2026-01 banlist

### DIFF
--- a/OCG-AE.lflist.conf
+++ b/OCG-AE.lflist.conf
@@ -1,0 +1,5765 @@
+#[OCG-AE Format]
+!2026.01 OCG-AE
+$whitelist
+
+#SDK
+89631139 3 -- Blue-Eyes White Dragon
+76184692 3 -- Hitotsu-Me Giant
+15303296 3 -- Ryu-Kishin
+6285791 3 -- The Wicked Worm Beast
+5053103 3 -- Battle Ox
+67724379 3 -- Koumori Dragon
+30113682 3 -- Judge Man
+91939608 3 -- Rogue Doll
+1184620 3 -- Kojikocy
+1784619 3 -- Uraby
+31122090 3 -- Gyakutenno Megami
+68516705 3 -- Mystic Horseman
+63308047 3 -- Terra the Terrible
+89494469 3 -- Dark Titan of Terror
+41949033 3 -- Dark Assailant
+75499502 3 -- Master & Expert
+97360116 3 -- Unknown Warrior of Fiend
+47060154 3 -- Mystic Clown
+45121025 3 -- Ogre of the Black Shadow
+4614116 3 -- Dark Energy
+98374133 3 -- Invigoration
+53129443 3 -- Dark Hole
+19523799 3 -- Ookazi
+24611934 3 -- Ryu-Kishin Powered
+50005633 3 -- Swordstalker
+97590747 3 -- La Jinn the Mystical Genie of the Lamp
+26378150 3 -- Rude Kaiser
+73481154 3 -- Destroyer Golem
+10202894 3 -- Skull Red Bird
+81057959 3 -- D. Human
+21263083 3 -- Pale Beast
+66788016 3 -- Fissure
+4206964 3 -- Trap Hole
+83887306 3 -- Two-Pronged Attack
+19159413 3 -- De-Spell
+83764718 1 -- Monster Reborn
+81820689 3 -- The Inexperienced Spy
+17814387 3 -- Reinforcements
+17092736 3 -- Ancient Telescope
+24068492 3 -- Just Desserts
+17985575 3 -- Lord of D.
+43973174 3 -- The Flute of Summoning Dragon
+54098121 3 -- Mysterious Puppeteer
+46461247 3 -- Trap Master
+86318356 3 -- Sogen
+7089711 3 -- Hane-Hane
+77622396 3 -- Reverse Trap
+51482758 3 -- Remove Trap
+44209392 3 -- Castle Walls
+80604091 0 -- Ultimate Offering
+#LOB
+39111158 3 -- Tri-Horned Dragon
+45231177 3 -- Flame Swordsman
+32274490 3 -- Skull Servant
+46986414 3 -- Dark Magician
+6368038 3 -- Gaia The Fierce Knight
+91152256 3 -- Celtic Guardian
+89091579 3 -- Basic Insect
+40374923 3 -- Mammoth Graveyard
+90357090 3 -- Silver Fang
+9159938 3 -- Dark Gray
+77827521 3 -- Trial of Nightmare
+90963488 3 -- Nemuriko
+32864 3 -- The 13th Grave
+37421579 3 -- Charubin the Fire Knight
+34460851 3 -- Flame Manipulator
+36121917 3 -- Monster Egg
+53293545 3 -- Firegrass
+17881964 3 -- Darkfire Dragon
+53375573 3 -- Dark King of the Abyss
+2863439 3 -- Fiend Reflection 2
+1641882 3 -- Fusionist
+37313348 3 -- Turtle Tiger
+75356564 3 -- Petit Dragon
+38142739 3 -- Petit Angel
+96851799 3 -- Hinotama Soul
+85639257 3 -- Aqua Madoor
+15401633 3 -- Kagemusha of the Blue Flame
+58528964 3 -- Flame Ghost
+57305373 3 -- Two-Mouth Darkruler
+40826495 3 -- Dissolverock
+39004808 3 -- Root Water
+18710707 3 -- The Furious Sea King
+22910685 3 -- Green Phantom King
+85309439 3 -- Ray & Temperature
+84686841 3 -- King Fog
+83464209 3 -- Mystical Sheep 2
+44287299 3 -- Masaki the Legendary Swordsman
+85705804 3 -- Kurama
+61854111 3 -- Legendary Sword
+46009906 3 -- Beast Fangs
+15052462 3 -- Violet Crystal
+91595718 3 -- Book of Secret Arts
+77027445 3 -- Power of Kaishin
+50045299 3 -- Dragon Capture Jar
+87430998 3 -- Forest
+23424603 3 -- Wasteland
+50913601 3 -- Mountain
+22702055 3 -- Umi
+59197169 3 -- Yami
+12580477 3 -- Raigeki
+38199696 3 -- Red Medicine
+76103675 3 -- Sparks
+46130346 3 -- Hinotama
+24094653 3 -- Polymerization
+15025844 3 -- Mystical Elf
+72842870 3 -- Tyhone
+32452818 3 -- Beaver Warrior
+82542267 3 -- Gravedigger Ghoul
+28279543 3 -- Curse of Dragon
+54541900 3 -- Karbonala Warrior
+13039848 3 -- Giant Soldier of Stone
+74677422 3 -- Red-Eyes B. Dragon
+33066139 3 -- Reaper of the Cards
+36304921 3 -- Witty Phantom
+94675535 3 -- Larvas
+20060230 3 -- Hard Armor
+93553943 3 -- Man Eater
+56342351 3 -- M-Warrior 1
+92731455 3 -- M-Warrior 2
+80770678 3 -- Spirit of the Harp
+53153481 3 -- Armaill
+98818516 3 -- Frenzied Panda
+56283725 3 -- Kumootoko
+76211194 3 -- Meda Bat
+75376965 3 -- Enchanting Mermaid
+71407486 3 -- Fireyarou
+70681994 3 -- Dragoness the Wicked Knight
+33064647 3 -- One-Eyed Shield Dragon
+77007920 3 -- Laser Cannon Armor
+39774685 3 -- Vile Germs
+1557499 3 -- Silver Bow and Arrow
+1435851 3 -- Dragon Treasure
+37820550 3 -- Electro-Whip
+36607978 3 -- Mystical Moon
+63102017 3 -- Stop Defense
+25769732 3 -- Machine Conversion Factory
+51267887 3 -- Raise Body Heat
+98252586 3 -- Follow Wind
+11868825 3 -- Goblin's Secret Remedy
+73134081 3 -- Final Flame
+72302403 3 -- Swords of Revealing Light
+9293977 3 -- Metal Dragon
+85326399 3 -- Spike Seadra
+45042329 3 -- Tripwire Beast
+9076207 3 -- Armed Ninja
+95952802 3 -- Flower Wolf
+54652250 3 -- Man-Eater Bug
+73051941 3 -- Sand Stone
+33178416 3 -- Misairuzame
+29172562 3 -- Steel Ogre Grotto 1
+55444629 3 -- Lesser Dragon
+43500484 3 -- Darkworld Thorns
+16353197 3 -- Drooling Lizard
+17535588 3 -- Armored Starfish
+55291359 3 -- Succubus Knight
+55144522 0 -- Pot of Greed
+8124921 3 -- Right Leg of the Forbidden One
+44519536 3 -- Left Leg of the Forbidden One
+70903634 3 -- Right Arm of the Forbidden One
+7902349 3 -- Left Arm of the Forbidden One
+33396948 3 -- Exodia the Forbidden One
+66889139 3 -- Gaia the Dragon Champion
+#SDY
+41392891 3 -- Feral Imp
+87796900 3 -- Winged Dragon, Guardian of the Fortress 1
+70781052 3 -- Summoned Skull
+13429800 3 -- Great White
+66672569 3 -- Dragon Zombie
+16972957 3 -- Doma The Angel of Silence
+48365709 3 -- Ansatsu
+41218256 3 -- Claw Reacher
+37120512 3 -- Sword of Dark Destruction
+84257639 3 -- Dian Keto the Cure Master
+93221206 3 -- Ancient Elf
+46474915 3 -- Magical Ghost
+4031928 3 -- Change of Heart
+87557188 3 -- The Stern Mystic
+13945283 3 -- Wall of Illusion
+50930991 3 -- Neo the Magic Swordsman
+86325596 3 -- Baron of the Fiend Sword
+13723605 3 -- Man-Eating Treasure Chest
+49218300 3 -- Sorcerer of the Doomed
+85602018 0 -- Last Will
+12607053 3 -- Waboku
+68005187 3 -- Soul Exchange
+72892473 3 -- Card Destruction
+#MRD
+25833572 3 -- Gate Guardian
+68846917 3 -- Rock Ogre Grotto 1
+15480588 3 -- Armored Lizard
+88979991 3 -- Killer Needle
+87756343 3 -- Larvae Moth
+76812113 3 -- Harpie Lady
+12206212 3 -- Harpie Lady Sisters
+40240595 3 -- Cocoon of Evolution
+67494157 3 -- Crawling Dragon
+20277860 3 -- Armored Zombie
+28933734 3 -- Mask of Darkness
+15150365 3 -- White Magical Hat
+16768387 3 -- Big Eye
+11901678 3 -- B. Skull Dragon
+10189126 3 -- Masked Sorcerer
+19066538 3 -- Roaring Ocean Snake
+2483611 3 -- Water Omotics
+58314394 3 -- Ground Attacker Bugroth
+58192742 3 -- Petit Moth
+90219263 3 -- Elegant Egotist
+25955164 3 -- Sanga of the Thunder
+62340868 3 -- Kazejin
+98434877 3 -- Suijin
+98049915 3 -- Mystic Lamp
+13599884 3 -- Steel Scorpion
+86088138 3 -- Ocubeam
+12472242 3 -- Leghul
+58861941 3 -- Ooguchi
+10538007 3 -- Leogun
+70138455 3 -- Blast Juggler
+32809211 3 -- Jinzo 7
+31560081 3 -- Magician of Faith
+28593363 3 -- Deepsea Shark
+81386177 3 -- Bottom Dweller
+9653271 3 -- Kaminari Attack
+21347810 3 -- Rainbow Flower
+55784832 3 -- Morinphen
+21817254 3 -- Mega Thunderball
+69572024 3 -- Tongyo
+15237615 3 -- Empress Judge
+55875323 3 -- Electric Lizard
+80141480 3 -- Hunter Spider
+43230671 3 -- Ancient Lizard Warrior
+5901497 3 -- Queen's Double
+78780140 3 -- Trent
+76446915 3 -- Disk Magician
+2118022 3 -- Hyosube
+64501875 3 -- Hibikime
+3027001 3 -- Fake Trap
+79759861 3 -- Tribute to The Doomed
+5758500 3 -- Soul Release
+41142615 3 -- The Cheerful Coffin
+88819587 3 -- Baby Dragon
+87564352 3 -- Blackland Fire Dragon
+40453765 3 -- Swamp Battleguard
+18246479 3 -- Battle Steer
+71625222 3 -- Time Wizard
+66602787 3 -- Saggi the Dark Clown
+55763552 3 -- Dragon Piper
+28546905 3 -- Illusionist Faceless Mage
+26202165 3 -- Sangan
+14141448 3 -- Great Moth
+40640057 3 -- Kuriboh
+14851496 3 -- Jellyfish
+62121 3 -- Castle of Dark Illusions
+69455834 3 -- King of Yamimakai
+95727991 3 -- Catapult Turtle
+94905343 3 -- Rabid Horseman
+93889755 3 -- Crass Clown
+29155212 3 -- Pumpking the King of Ghosts
+13215230 3 -- Dream Clown
+28725004 3 -- Tainted Wisdom
+42431843 3 -- Ancient Brain
+89272878 3 -- Guardian of the Labyrinth
+549481 3 -- Prevent Rat
+25109950 3 -- The Little Swordsman of Aile
+51371017 3 -- Princess of Tsurugi
+10071456 3 -- Protector of the Throne
+46918794 3 -- Tremendous Fire
+94773007 3 -- Jirai Gumo
+30778711 3 -- Shadow Ghoul
+99551425 3 -- Labyrinth Tank
+25655502 3 -- Bickuribox
+51828629 3 -- Giltia the D. Knight
+87322377 3 -- Launcher Spider
+8471389 3 -- Giga-Tech Wolf
+31786629 3 -- Thunder Dragon
+23771716 3 -- 7 Colored Fish
+84926738 3 -- The Immortal of Thunder
+74703140 3 -- Punished Eagle
+7019529 3 -- Insect Soldiers of the Sky
+67629977 3 -- Hoshiningen
+56907389 3 -- Musician King
+29380133 3 -- Yado Karu
+89112729 3 -- Cyber Saurus
+11384280 0 -- Cannon Soldier
+46657337 3 -- Muka Muka
+71107816 3 -- The Bistro Butcher
+8201910 3 -- Star Boy
+7489323 3 -- Milus Radiant
+60862676 3 -- Flame Cerebrus
+7805359 3 -- Niwatori
+21417692 3 -- Dark Elf
+93900406 3 -- Mushroom Man 2
+20394040 3 -- Lava Battleguard
+78010363 3 -- Witch of the Black Forest
+68658728 3 -- Little Chimera
+28470714 3 -- Bladefly
+17358176 3 -- Lady of Faith
+54752875 3 -- Twin-Headed Thunder Dragon
+80741828 3 -- Witch's Apprentice
+41396436 3 -- Blue-Winged Crown
+2504891 3 -- Skull Knight
+5818798 3 -- Gazelle the King of Mythical Beasts
+49888191 3 -- Garnecia Elefantis
+81480460 3 -- Barrel Dragon
+41420027 3 -- Solemn Judgment
+77414722 3 -- Magic Jammer
+3819470 3 -- Seven Tools of the Bandit
+98069388 3 -- Horn of Heaven
+52097679 3 -- Shield & Sword
+98495314 3 -- Sword of Deep-Seated
+25880422 3 -- Block Attack
+51275027 3 -- The Unhappy Maiden
+88279736 3 -- Robbin' Goblin
+24668830 3 -- Germ Infection
+50152549 3 -- Paralyzing Potion
+44095762 3 -- Mirror Force
+20436034 3 -- Ring of Magnetism
+56830749 3 -- Share the Pain
+83225447 3 -- Stim-Pack
+19613556 0 -- Heavy Storm
+41462083 3 -- Thousand Dragon
+#MRL
+53183600 3 -- Blue-Eyes Toon Dragon
+36039163 3 -- Penguin Knight
+40619825 3 -- Axe of Despair
+65169794 3 -- Black Pendant
+38552107 3 -- Horn of Light
+99597615 3 -- Malevolent Nuzzler
+18807108 3 -- Spellbinding Circle
+55998462 3 -- Metal Fish
+11324436 3 -- Electric Snake
+73081602 3 -- Queen Bird
+95174353 3 -- Ameba
+20624263 3 -- Peacock
+93013676 3 -- Maha Vailo
+47879985 3 -- Guardian of the Throne Room
+46534755 3 -- Fire Kraken
+32539892 3 -- Minar
+95744531 3 -- Griggle
+56789759 3 -- Tyhone 2
+14015067 3 -- Ancient One of the Deep Forest
+35565537 3 -- Dark Witch
+72053645 3 -- Weather Report
+34442949 3 -- Mechanical Snail
+96981563 3 -- Giant Turtle Who Feeds on Flames
+93108297 3 -- Liquid Beast
+81863068 3 -- Hiro's Shadow Scout
+54579801 3 -- High Tide Gyojin
+3056267 3 -- Invader of the Throne
+91996584 3 -- Whiptail Crow
+3797883 3 -- Slot Machine
+64631466 3 -- Relinquished
+65570596 3 -- Red Archery Girl
+16762927 3 -- Gravekeeper's Servant
+12470447 3 -- Curse of Fiend
+70368879 3 -- Upstart Goblin
+82003859 3 -- Toll
+18591904 3 -- Final Destiny
+45986603 3 -- Snatch Steal
+81380218 3 -- Chorus of Sanctuary
+17375316 0 -- Confiscation
+44763025 0 -- Delinquent Duo
+80168720 3 -- Darkness Approaches
+17653779 3 -- Fairy's Hand Mirror
+43641473 3 -- Tailor of the Fickle
+70046172 3 -- Rush Recklessly
+16430187 3 -- The Reliable Guardian
+42829885 0 -- The Forceful Sentry
+79323590 3 -- Chain Energy
+5318639 3 -- Mystical Space Typhoon
+42703248 0 -- Giant Trunade
+74191942 0 -- Painful Choice
+596051 3 -- Snake Fang
+41426869 3 -- Black Illusion Ritual
+74637266 3 -- Octoberser
+7892180 3 -- Psychic Kappa
+64047146 3 -- Horn of the Unicorn
+67284908 3 -- Labyrinth Wall
+63162310 3 -- Wall Shadow
+29692206 3 -- Twin Long Rods 2
+15023985 3 -- Stone Ogre Grotto
+64389297 3 -- Magical Labyrinth
+95051344 3 -- Eternal Rest
+22046459 3 -- Megamorph
+43417563 3 -- Commencement Dance
+80811661 3 -- Hamburger Recipe
+15083728 3 -- House of Adhesive Tape
+42578427 3 -- Eatgaboon
+76806714 3 -- Turtle Oath
+4849037 3 -- Performance of Sword
+30243636 3 -- Hungry Burger
+91782219 3 -- Crab Turtle
+2964201 3 -- Ryu-Ran
+38369349 3 -- Manga Ryu-Ran
+65458948 3 -- Toon Mermaid
+91842653 3 -- Toon Summoned Skull
+90020065 3 -- Jigen Bakudan
+62397231 3 -- Hyozanryu
+15259703 3 -- Toon World
+34124316 3 -- Cyber Jar
+61528025 3 -- Banisher of the Light
+97017120 3 -- Giant Rat
+23401839 3 -- Senju of the Thousand Hands
+60806437 3 -- UFO Turtle
+96890582 3 -- Flash Assailant
+23289281 3 -- Karate Man
+59784896 3 -- Dark Zebra
+95178994 3 -- Giant Germ
+22567609 3 -- Nimble Momonga
+58551308 3 -- Spear Cretin
+95956346 3 -- Shining Angel
+21340051 3 -- Boar Soldier
+57839750 3 -- Mother Grizzly
+84834865 3 -- Flying Kamakiri 1
+20228463 3 -- Ceremonial Bell
+57617178 3 -- Sonic Bird
+83011277 3 -- Mystic Tomato
+19406822 3 -- Kotodama
+56594520 3 -- Gaia Power
+82999629 3 -- Umiiruka
+19384334 3 -- Molten Destruction
+45778932 3 -- Rising Air Current
+81777047 3 -- Luminous Spark
+18161786 3 -- Mystic Plasma Zone
+44656491 3 -- Messenger of Peace
+66516792 3 -- Serpent Night Dragon
+#PSV
+77585513 3 -- Jinzo
+90908427 3 -- Steel Ogre Grotto 2
+78423643 3 -- Three-Headed Geedo
+27911549 3 -- Parasite Paracide
+86198326 3 -- 7 Completed
+49587034 3 -- Lightforce Sword
+1248895 3 -- Chain Destruction
+35316708 3 -- Time Seal
+61705417 3 -- Graverobber
+98299011 3 -- Gift of The Mystical Elf
+34694160 3 -- The Eye of Truth
+60082869 3 -- Dust Tornado
+97077563 3 -- Call of the Haunted
+23471572 3 -- Solomon's Lawbook
+60866277 3 -- Earthshaker
+96355986 3 -- Enchanted Javelin
+22359980 3 -- Mirror Wall
+73079365 3 -- Gust
+473469 3 -- Driving Snow
+36868108 3 -- Armored Glass
+12253117 3 -- World Suppression
+49251811 3 -- Mystic Probe
+75646520 3 -- Metal Detector
+2130625 3 -- Numinous Healer
+48539234 3 -- Appropriate
+74923978 3 -- Forced Requisition
+74701381 3 -- DNA Surgery
+296499 3 -- The Regulation of Tribe
+36280194 3 -- Backup Soldier
+9074847 3 -- Major Riot
+36468556 3 -- Ceasefire
+62867251 3 -- Light of Intervention
+8951260 3 -- Respect Play
+81210420 3 -- Magical Hats
+71044499 3 -- Nobleman of Crossout
+17449108 3 -- Nobleman of Extermination
+43434803 3 -- The Shallow Grave
+70828912 0 -- Premature Burial
+16227556 3 -- Inspection
+43711255 3 -- Prohibition
+79106360 3 -- Morphing Jar 2
+42599677 3 -- Flame Champion
+78984772 3 -- Twin-Headed Fire Dragon
+5388481 3 -- Darkfire Soldier 1
+31477025 3 -- Mr. Volcano
+78861134 3 -- Darkfire Soldier 2
+4266839 3 -- Kiseitai
+30655537 3 -- Cyber Falcon
+3134241 3 -- Flying Kamakiri 2
+30532390 3 -- Sky Scout
+78193831 3 -- Buster Blader
+37580756 3 -- Michizure
+1918087 3 -- Minor Goblin Official
+37313786 3 -- Gamble
+63689843 3 -- Attack and Receive
+35346968 3 -- Solemn Wishes
+98139712 3 -- Skull Invitation
+6104968 3 -- Bubonic Vermin
+67049542 3 -- Dark Bat
+66927994 3 -- Oni Tank T-34
+2311603 3 -- Overdrive
+24294108 3 -- Burning Land
+60682203 0 -- Cold Wave
+97687912 3 -- Fairy Meteor Crush
+23171610 3 -- Limiter Removal
+66719324 3 -- Rain of Mercy
+93108433 3 -- Monster Recovery
+59560625 3 -- Shift
+96965364 3 -- Insect Imitation
+22959079 3 -- Dimensionhole
+90502999 3 -- Ground Collapse
+59344077 3 -- Magic Drain
+54109233 3 -- Infinite Dismissal
+85742772 3 -- Gravity Bind
+21237481 3 -- Type Zero Magic Crusher
+58621589 3 -- Shadow of Eyes
+3643300 3 -- The Legendary Fisherman
+51345461 3 -- Sword Hunter
+88733579 3 -- Drill Bug
+24128274 3 -- Deepsea Warrior
+50122883 3 -- Bite Shoes
+87511987 3 -- Spikebot
+52675689 3 -- Invitation to a Dark Sleep
+27125110 3 -- Thousand-Eyes Idol
+63519819 3 -- Thousand-Eyes Restrict
+84620194 3 -- Girochin Kuwagata
+21015833 3 -- Hayabusa Knight
+57409948 3 -- Bombardment Beetle
+83994646 3 -- 4-Starred Ladybug of Doom
+10992251 3 -- Gradius
+56387350 3 -- Vampire Baby
+79870141 3 -- Mad Sword Beast
+5265750 3 -- Skull Mariner
+32269855 3 -- The All-Seeing White Tiger
+78658564 3 -- Goblin Attack Force
+4042268 3 -- Island Turtle
+31447217 3 -- Wingweaver
+67532912 3 -- Science Soldier
+4920010 3 -- Souls of the Forgotten
+30325729 3 -- Dokuroyaiba
+66362965 3 -- The Fiend Megacyber
+423705 3 -- Gearfried the Iron Knight
+23615409 3 -- Insect Barrier
+11761845 3 -- Beast of Talwar
+61740673 0 -- Imperial Order
+#LON
+69140098 3 -- Gemini Elf
+49064413 3 -- The Masked Beast
+3573512 3 -- Swordsman of Landstar
+46821314 3 -- Humanoid Slime
+73216412 3 -- Worm Drake
+5600127 3 -- Humanoid Worm Drake
+31709826 3 -- Revival Jam
+31987274 3 -- Flying Fish
+67371383 3 -- Amphibian Beast
+87303357 3 -- Shining Abyss
+86281779 3 -- Gadget Soldier
+13676474 3 -- Grand Tiki Elder
+86569121 3 -- Melchid the Four-Face Beast
+12953226 3 -- Nuvia the Wicked
+21888494 3 -- Chosen One
+57882509 3 -- Mask of Weakness
+94377247 3 -- Curse of the Masked Beast
+20765952 3 -- Mask of Dispel
+29549364 3 -- Mask of Restrict
+56948373 3 -- Mask of the Accursed
+82432018 3 -- Mask of Brutality
+19827717 3 -- Return of the Doomed
+55226821 3 -- Lightning Blade
+18605135 3 -- Tornado Wall
+21598948 3 -- Fairy Box
+53582587 3 -- Torrential Tribute
+21770260 3 -- Jam Breeding Machine
+94163677 3 -- Infinite Cards
+21558682 3 -- Jam Defender
+57953380 0 -- Card of Safe Return
+38480590 3 -- Lady Panther
+65475294 3 -- The Unfriendly Amazon
+91869203 0 -- Amazoness Archer
+28358902 3 -- Crimson Sentry
+64752646 3 -- Fire Princess
+90147755 3 -- Lady Assailant of Flames
+27132350 3 -- Fire Sorcerer
+53530069 3 -- Spirit of the Breeze
+90925163 3 -- Dancing Fairy
+22419772 3 -- Fairy Guardian
+58818411 3 -- Empress Mantis
+85802526 3 -- Cure Mermaid
+21297224 3 -- Hysteric Fairy
+58696829 3 -- Bio-Mage
+84080938 3 -- The Forgiving Maiden
+21175632 3 -- St. Joan
+57579381 3 -- Marie the Fallen One
+83968380 3 -- Jar of Greed
+10352095 3 -- Scroll of Bewitchment
+56747793 3 -- United We Stand
+83746708 3 -- Mage Power
+19230407 3 -- Offerings to the Doomed
+32541773 3 -- The Portrait's Secret
+68049471 3 -- The Gross Ghost of Fled Dreams
+5434080 3 -- Headless Knight
+67105242 3 -- Earthbound Spirit
+66989694 3 -- The Earl of Demise
+98456117 3 -- Boneheimer
+12883044 3 -- Flame Dancer
+52121290 3 -- Spherous Lady
+27671321 3 -- Lightning Conger
+41855169 3 -- Jowgen the Spiritualist
+88240808 3 -- Kycoo the Ghost Destroyer
+14644902 3 -- Summoner of Illusions
+40133511 3 -- Bazoo the Soul-Eater
+31829185 3 -- Dark Necrofear
+77527210 3 -- Soul of Purity and Light
+13522325 3 -- Spirit of Flames
+40916023 3 -- Aqua Spirit
+76305638 3 -- The Rock Spirit
+12800777 3 -- Garuda the Wind Spirit
+45894482 3 -- Gilasaurus
+71283180 3 -- Tornado Bird
+8687195 3 -- Dreamsprite
+88472456 3 -- Zombyra the Dark
+44072894 3 -- Supply
+71466592 3 -- Maryokutai
+86099788 3 -- The Last Warrior from Another Planet
+7565547 3 -- Collected Power
+93599951 3 -- Dark Spirit of the Silent
+33950246 3 -- Royal Command
+70344351 3 -- Riryoku Field
+6733059 3 -- Skull Lair
+33737664 3 -- Graverobber's Retribution
+69122763 3 -- Deal of Phantom
+5616412 3 -- Destruction Punch
+32015116 3 -- Blind Destruction
+68400115 3 -- The Emperor's Holiday
+94212438 3 -- Destiny Board
+31893528 3 -- Spirit Message "I
+67287533 3 -- Spirit Message "N
+94772232 3 -- Spirit Message "A
+30170981 3 -- Spirit Message "L
+30606547 3 -- The Dark Door
+15866454 3 -- Spiritualism
+5494820 3 -- Cyclon Laser
+7165085 3 -- Bait Doll
+95286165 3 -- De-Fusion
+33550694 3 -- Fusion Gate
+69954399 3 -- Ekibyo Drakmord
+6343408 3 -- Miracle Dig
+32437102 3 -- Dragonic Attack
+69832741 3 -- Spirit Elimination
+95220856 3 -- Vengeful Bog Spirit
+62279055 3 -- Magic Cylinder
+#WCS
+12829151 3 -- Kanan the Swordmistress
+#LOD
+3078576 3 -- Yata-Garasu
+53982768 3 -- Dark Ruler Ha Des
+80071763 3 -- Dark Balter the Terrible
+16475472 3 -- Lesser Fiend
+52860176 3 -- Possessed Dark Soul
+89258225 3 -- Winged Minion
+15653824 3 -- Skull Knight 2
+42647539 3 -- Ryu-Kishin Clown
+88132637 3 -- Twin-Headed Wolf
+14531242 3 -- Opticlops
+41925941 3 -- Bark of Dark Ruler
+77910045 3 -- Fatal Abacus
+14318794 3 -- Life Absorbing Machine
+40703393 3 -- The Puppet Magic of Dark Ruler
+76297408 3 -- Soul Demolition
+3682106 3 -- Double Snare
+49681811 3 -- Freed the Matchless General
+76075810 3 -- Throwstone Unit
+2460565 3 -- Marauding Captain
+49868263 3 -- Ryu Senshi
+75953262 3 -- Warrior Dai Grepher
+1347977 3 -- Mysterious Guard
+38742075 3 -- Frontier Wiseman
+74131780 3 -- Exiled Force
+1525329 3 -- The Hunter with 7 Weapons
+37620434 3 -- Shadow Tamer
+63018132 3 -- Dragon Manipulator
+403847 3 -- The A. Forces
+32807846 1 -- Reinforcement of the Army
+69296555 3 -- Array of Revealing Light
+95281259 3 -- The Warrior Returning Alive
+31785398 3 -- Ready for Intercepting
+68170903 3 -- A Feint Plan
+53046408 3 -- Emergency Provisions
+94568601 3 -- Tyrant Dragon
+31553716 3 -- Spear Dragon
+67957315 3 -- Spirit Ryu
+93346024 3 -- The Dragon Dwelling in the Cave
+20831168 3 -- Lizard Soldier
+66235877 3 -- Fiend Skull Dragon
+93220472 3 -- Cave Dragon
+29618570 3 -- Gray Wing
+55013285 3 -- Troop Dragon
+92408984 3 -- The Dragon's Bead
+28596933 3 -- A Wingbeat of Giant Dragon
+55991637 3 -- Dragon's Gunfire
+81385346 3 -- Stamping Destruction
+27770341 3 -- Super Rejuvenation
+54178050 3 -- Dragon's Rage
+80163754 3 -- Burst Breath
+17658803 3 -- Luster Dragon 2
+44203504 3 -- Robotic Knight
+56369281 3 -- Wolf Axwielder
+83764996 3 -- The Illusory Gentleman
+92421852 3 -- Robolady
+38916461 3 -- Roboyarou
+78706415 0 -- Fiber Jar
+71829750 3 -- Serpentine Princess
+19153634 3 -- Patrician of Darkness
+70797118 3 -- Thunder Nyan Nyan
+14291024 3 -- Gradius' Option
+6979239 3 -- Woodland Sprite
+18036057 3 -- Airknight Parshath
+43586926 3 -- Twin-Headed Behemoth
+40695128 3 -- Maharaghi
+77084837 3 -- Inaba White Rabbit
+40473581 3 -- Susa Soldier
+76862289 3 -- Yamata Dragon
+2356994 3 -- Great Long Nose
+39751093 3 -- Otohime
+75745607 3 -- Hino-Kagu-Tsuchi
+2134346 3 -- Asura Priest
+38538445 3 -- Fushi No Tori
+75923050 3 -- Super Robolady
+1412158 3 -- Super Roboyarou
+37406863 3 -- Fengsheng Mirror
+94425169 3 -- Spring of Rebirth
+64801562 3 -- Heart of Clear Water
+295517 3 -- A Legendary Ocean
+37684215 3 -- Fusion Sword Murasame Blade
+63789924 0 -- Smoke Grenade of the Thief
+31036355 3 -- Creature Swap
+99173029 3 -- Spiritual Energy Settle Machine
+36562627 3 -- Second Coin Toss
+62966332 3 -- Convulsion of Nature
+99351431 3 -- The Secret of the Bandit
+25345186 3 -- After Genocide
+61844784 3 -- Magic Reflector
+98239899 3 -- Blast with Chain
+24623598 3 -- Disappear
+61622107 3 -- Bubble Crash
+93016201 0 -- Royal Oppression
+29401950 3 -- Bottomless Trap Hole
+40633297 3 -- Bad Reaction to Simochi
+56995655 3 -- Ominous Fortunetelling
+92394653 3 -- Spirit's Invitation
+29389368 3 -- Nutrient Z
+55773067 3 -- Drop Off
+81172176 3 -- Fiend Comedian
+28566710 0 -- Last Turn
+79575620 3 -- Injection Fairy Lily
+#PGD
+83555666 3 -- Ring of Destruction
+17192817 3 -- Molten Behemoth
+4035199 3 -- Shapesnatch
+31242786 3 -- Souleater
+83986578 3 -- King Tiger Wanghu
+45547649 3 -- Birdface
+82642348 3 -- Kryuel
+42364374 3 -- Arsenal Bug
+17214465 3 -- Maiden of the Aqua
+5257687 3 -- Jowls of Dark Demise
+44913552 3 -- Timeater
+70307656 3 -- Mucus Yolk
+2792265 3 -- Servant of Catabolism
+75285069 3 -- Moisture Creature
+80233946 3 -- Gora Turtle
+16222645 3 -- Sasuke Samurai
+43716289 3 -- Poison Mummy
+89111398 3 -- Dark Dust Spirit
+16509093 3 -- Royal Keeper
+42994702 3 -- Wandering Mummy
+88989706 3 -- Great Dezard
+15383415 3 -- Swarm of Scarabs
+41872150 3 -- Swarm of Locusts
+78266168 3 -- Giant Axe Mummy
+14261867 3 -- 8-Claws Scorpion
+40659562 3 -- Guardian Sphinx
+77044671 3 -- Pyramid Turtle
+3549275 3 -- Dice Jar
+40933924 3 -- Dark Scorpion Burglars
+76922029 3 -- Don Zaloog
+2326738 3 -- Des Lacooda
+39711336 3 -- Fushioh Richie
+75109441 3 -- Cobraman Sakuzy
+2204140 3 -- Book of Life
+38699854 3 -- Book of Taiyou
+14087893 3 -- Book of Moon
+41482598 0 -- Mirage of Nightmare
+77876207 3 -- Secret Pass to the Treasures
+4861205 3 -- Call of the Mummy
+40350910 3 -- Timidity
+76754619 3 -- Pyramid Energy
+3149764 3 -- Tutan Mask
+39537362 3 -- Ordeal of a Traveler
+76532077 3 -- Bottomless Shifting Sand
+2926176 3 -- Curse of Royal
+38411870 3 -- Needle Ceiling
+65810489 3 -- Statue of the Wicked
+1804528 3 -- Dark Coffin
+38299233 3 -- Needle Wall
+64697231 0 -- Trap Dustshoot
+1082946 3 -- Pyro Clock of Destiny
+37576645 3 -- Reckless Greed
+63571750 3 -- Pharaoh's Treasure
+24530661 3 -- Master Kyonshee
+51934376 3 -- Kabazauls
+97923414 3 -- Inpachi
+90980792 3 -- Dark Jeroid
+4335645 3 -- Newdoria
+76052811 3 -- Helpoemer
+24317029 3 -- Gravekeeper's Spy
+50712728 3 -- Gravekeeper's Curse
+37101832 3 -- Gravekeeper's Guard
+63695531 3 -- Gravekeeper's Spear Soldier
+99690140 3 -- Gravekeeper's Vassal
+26084285 3 -- Gravekeeper's Watcher
+62473983 3 -- Gravekeeper's Chief
+99877698 3 -- Gravekeeper's Cannonholder
+25262697 3 -- Gravekeeper's Assailant
+51351302 3 -- A Man with Wdjat
+98745000 3 -- Mystical Knight of Jackal
+24140059 3 -- A Cat of Ill Omen
+51534754 3 -- Yomi Ship
+87523462 3 -- Winged Sage Falcos
+23927567 3 -- An Owl of Luck
+50412166 3 -- Charm of Shabti
+86801871 3 -- Cobra Jar
+23205979 3 -- Spirit Reaper
+59290628 3 -- Nightmare Horse
+85684223 3 -- Reaper on the Nightmare
+78053598 3 -- Dark Designator
+12183332 3 -- Card Shuffle
+58577036 3 -- Reasoning
+85562745 3 -- Dark Room of Nightmare
+11961740 3 -- Different Dimension Capsule
+47355498 3 -- Necrovalley
+84740193 3 -- Buster Rancher
+10248192 3 -- Hieroglyph Lithograph
+47233801 3 -- Dark Snake Syndrome
+73628505 1 -- Terraforming
+10012614 3 -- Banner of Courage
+46411259 0 -- Metamorphosis
+72405967 3 -- Royal Tribute
+5990062 3 -- Reversal Quiz
+65830223 3 -- Coffin Seller
+41398771 3 -- Curse of Aging
+78783370 3 -- Barrel Behind the Door
+4178474 3 -- Raigeki Break
+40172183 3 -- Narrow Pass
+77561728 3 -- Disturbance Strategy
+3055837 3 -- Trap of Board Eraser
+30450531 3 -- Rite of Spirit
+76848240 3 -- Non Aggression Area
+2833249 3 -- D. Tribe
+17597059 3 -- Byser Shock
+38723936 3 -- Question
+93382620 3 -- Rope of Life
+54704216 3 -- Nightmare Wheel
+102380 3 -- Lava Golem
+#MFC
+38033121 3 -- Dark Magician Girl
+12143771 3 -- People Running About
+58538870 3 -- Oppressed People
+85936485 3 -- United Resistance
+62651957 3 -- X-Head Cannon
+65622692 3 -- Y-Dragon Head
+64500000 3 -- Z-Metal Tank
+11321183 3 -- Dark Blade
+47415292 3 -- Pitch-Dark Dragon
+84814897 3 -- Kiryu
+10209545 3 -- Decayed Commander
+47693640 3 -- Zombie Tiger
+73698349 3 -- Giant Orc
+19086954 3 -- Second Goblin
+46571052 3 -- Vampire Orchis
+12965761 3 -- Des Dendle
+59364406 3 -- Burning Beast
+85359414 3 -- Freezing Beast
+11743119 3 -- Union Rider
+48148828 3 -- D.D. Crazy Beast
+84636823 3 -- Spell Canceller
+11021521 3 -- Neko Mane King
+47025270 3 -- Helping Robo for Combat
+73414375 3 -- Dimension Jar
+10809984 3 -- Great Phantom Thief
+46303688 3 -- Roulette Barrel
+73398797 3 -- Paladin of White Dragon
+9786492 3 -- White Dragon Ritual
+46181000 3 -- Frontline Base
+72575145 3 -- Demotion
+8964854 3 -- Combination Attack
+35059553 0 -- Kaiser Colosseum
+71453557 3 -- Autonomous Action Unit
+8842266 3 -- Poison of the Old Man
+34236961 3 -- Ante
+70231910 3 -- Dark Core
+7625614 3 -- Raregold Armor
+33114323 3 -- Metalsilver Armor
+60519422 3 -- Kishido Spirit
+2903036 3 -- Tribute Doll
+38992735 3 -- Wave-Motion Cannon
+65396880 3 -- Huge Revolution
+91781589 3 -- Thunder of Ruler
+38275183 3 -- Spell Shield Type-8
+64274292 3 -- Meteorain
+90669991 3 -- Pineapple Blast
+27053506 3 -- Secret Barrel
+63442604 3 -- Physical Double
+90846359 1 -- Rivalry of Warlords
+26931058 3 -- Formation Union
+62325062 3 -- Adhesion Trap Hole
+2111707 3 -- XY-Dragon Cannon
+91998119 3 -- XYZ-Dragon Cannon
+99724761 3 -- XZ-Tank Cannon
+25119460 3 -- YZ-Tank Dragon
+11813953 3 -- Great Angus
+48202661 3 -- Aitsu
+84696266 3 -- Sonic Duck
+11091375 3 -- Luster Dragon
+47480070 3 -- Amazoness Paladin
+55821894 3 -- Amazoness Fighter
+94004268 3 -- Amazoness Swords Woman
+73574678 3 -- Amazoness Blowpiper
+10979723 3 -- Amazoness Tiger
+46363422 3 -- Skilled White Magician
+73752131 3 -- Skilled Dark Magician
+9156135 3 -- Apprentice Magician
+45141844 3 -- Old Vindictive Magician
+72630549 3 -- Chaos Command Magician
+8034697 3 -- Magical Marionette
+35429292 3 -- Pixie Knight
+71413901 3 -- Breaker the Magical Warrior
+7802006 3 -- Magical Plant Mandragola
+34206604 0 -- Magical Scientist
+70791313 3 -- Royal Magical Library
+7180418 3 -- Armor Exe
+33184167 3 -- Tribe-Infecting Virus
+69579761 3 -- Des Koala
+6967870 3 -- Dark Scorpion - Cliff the Trap Remover
+32362575 3 -- Magical Merchant
+69456283 3 -- Koitsu
+95841282 3 -- Cat's Ear Tribe
+32240937 3 -- Ultimate Obedient Fiend
+8634636 3 -- Dark Cat with White Tail
+81325903 3 -- Amazoness Spellcaster
+68057622 3 -- Continuous Destruction Punch
+61127349 3 -- Big Bang Shot
+7512044 3 -- Gather Your Mind
+34906152 0 -- Mass Driver
+60391791 3 -- Senri Eye
+6390406 3 -- Emblem of Dragon Destroyer
+33784505 3 -- Jar Robber
+69279219 3 -- My Body as a Shield
+96677818 3 -- Spellbook Organization
+32062913 3 -- Mega Ton Magical Cannon
+34029630 3 -- Pitch-Black Power Stone
+67987611 3 -- Amazoness Archers
+80193355 3 -- Dramatic Rescue
+95451366 3 -- Exhausting Spell
+21840375 3 -- Hidden Spellbook
+68334074 3 -- Miracle Restoring
+94739788 3 -- Remove Brainwashing
+20727787 3 -- Disarmament
+53112492 3 -- Anti-Spell
+99517131 3 -- The Spell Absorbing Life
+98502113 3 -- Dark Paladin
+24096228 3 -- Double Spell
+87880531 3 -- Diffusion Wave-Motion
+#DCR
+53839837 3 -- Vampire Lord
+48094997 3 -- Battle Footballer
+11987744 3 -- Nin-Ken Dog
+47372349 3 -- Acrobat Monkey
+85489096 3 -- Arsenal Summoner
+74367458 3 -- Guardian Elma
+10755153 3 -- Guardian Ceal
+47150851 3 -- Guardian Grarl
+73544866 3 -- Guardian Baou
+9633505 3 -- Guardian Kay'est
+46037213 3 -- Guardian Tryce
+39978267 3 -- Cyber Raider
+2851070 3 -- Reflect Bounder
+90790253 3 -- Little-Winguard
+81985784 3 -- Des Feral Imp
+50939127 3 -- Different Dimension Dragon
+86327225 3 -- Shinato, King of a Higher Plane
+13722870 3 -- Dark Flare Knight
+49217579 3 -- Mirage Knight
+85605684 3 -- Berserk Dragon
+12600382 3 -- Exodia Necross
+9817927 3 -- Gyaku-Gire Panda
+35215622 3 -- Blindly Loyal Goblin
+71200730 3 -- Despair from the Dark
+8794435 3 -- Maju Garzett
+34193084 3 -- Fear from the Dark
+61587183 3 -- Dark Scorpion - Chick the Yellow
+7572887 3 -- D.D. Warrior Lady
+33977496 3 -- Thousand Needles
+60365591 3 -- Shinato's Ark
+6850209 3 -- A Deal with Dark Ruler
+33244944 3 -- Contract with Exodia
+69243953 0 -- Butterfly Dagger - Elma
+95638658 3 -- Shooting Star Bow - Ceal
+32022366 3 -- Gravity Axe - Grarl
+68427465 3 -- Wicked-Breaking Flamberge - Baou
+95515060 3 -- Rod of Silence - Kay'est
+21900719 3 -- Twin Swords of Flashing Light - Tryce
+68304813 3 -- Precious Cards from Beyond
+94793422 3 -- Rod of the Mind's Eye
+20188127 3 -- Fairy of the Spring
+57182235 3 -- Token Thanksgiving
+93671934 3 -- Morale Boost
+20065549 3 -- Non-Spellcasting Area
+56460688 3 -- Different Dimension Gate
+52503575 3 -- Final Attack Orders
+92854392 3 -- Staunch Defender
+29843091 3 -- Ojama Trio
+55348096 3 -- Arsenal Robber
+82732705 1 -- Skill Drain
+28121403 3 -- Really Eternal Rest
+52824910 3 -- Kaiser Glider
+36261276 3 -- Interdimensional Matter Transporter
+23265313 3 -- Cost Down
+49003308 3 -- Gagagigo
+86498013 3 -- D.D. Trainer
+12482652 3 -- Ojama Green
+49881766 3 -- Archfiend Soldier
+75375465 3 -- Pandemonium Watchbear
+11760174 3 -- Sasuke Samurai 2
+48768179 3 -- Dark Scorpion - Gorg the Strong
+74153887 3 -- Dark Scorpion - Meanae the Thorn
+11548522 3 -- Outstanding Dog Marron
+47942531 3 -- Great Maju Garzett
+73431236 3 -- Iron Blacksmith Kotetsu
+425934 3 -- Goblin of Greed
+46820049 3 -- Mefist the Infernal General
+73219648 3 -- Vilepawn Archfiend
+9603356 3 -- Shadowknight Archfiend
+35798491 3 -- Darkbishop Archfiend
+72192100 3 -- Desrook Archfiend
+8581705 3 -- Infernalqueen Archfiend
+35975813 3 -- Terrorking Archfiend
+61370518 3 -- Skull Archfiend of Lightning
+7369217 3 -- Metallizing Parasite - Lunatite
+34853266 3 -- Tsukuyomi
+82108372 3 -- Mudora
+80441106 3 -- Keldo
+54878498 3 -- Kelbek
+16268841 3 -- Zolga
+16135253 3 -- Agido
+60258960 3 -- Legendary Flame Lord
+97642679 3 -- Dark Master - Zorc
+29228529 3 -- Spell Reproduction
+16435215 3 -- Dragged Down into the Grave
+33031674 3 -- Incandescent Ordeal
+69035382 3 -- Contract with the Abyss
+96420087 3 -- Contract with the Dark Master
+32919136 3 -- Falling Down
+69313735 3 -- Checkmate
+28106077 3 -- Cestus of Dagla
+95308449 3 -- Final Countdown
+22796548 3 -- Archfiend's Oath
+68191243 3 -- Mustering of the Dark Scorpions
+94585852 3 -- Pandemonium
+21070956 3 -- Altar for Tribute
+57069605 3 -- Frozen Soul
+94463200 3 -- Battle-Scarred
+20858318 3 -- Dark Scorpion Combination
+56246017 3 -- Archfiend's Roar
+83241722 3 -- Dice Re-Roll
+29735721 3 -- Spell Vanishing
+56120475 3 -- Sakuretsu Armor
+82529174 3 -- Ray of Hope
+89041555 3 -- Blast Held by a Tribute
+55256016 3 -- Judgment of Anubis
+#WCS-AE4
+76232340 3 -- Sengenjin
+#IOC-AE
+82301904 3 -- Chaos Emperor Dragon - Envoy of the End
+42941100 3 -- Ojama Yellow
+79335209 3 -- Ojama Black
+15734813 3 -- Soul Tiger
+42129512 3 -- Big Koala
+78613627 3 -- Des Kangaroo
+14618326 3 -- Crimson Ninja
+41006930 3 -- Strike Ninja
+77491079 3 -- Gale Lizard
+4896788 3 -- Spirit of the Pot of Greed
+40884383 3 -- Chopman the Desperate Outlaw
+77379481 3 -- Sasuke Samurai 3
+3773196 3 -- D.D. Scout Plane
+39168895 3 -- Berserk Gorilla
+16556849 3 -- Freed the Brave Wanderer
+42541548 3 -- Coach Goblin
+75946257 3 -- Witch Doctor of Chaos
+1434352 3 -- Chaos Necromancer
+47829960 3 -- Chaosrider Gustaph
+74823665 3 -- Inferno
+218704 3 -- Fenrir
+47606319 3 -- Gigantes
+73001017 3 -- Silpheed
+9596126 3 -- Chaos Sorcerer
+36584821 3 -- Gren Maju Da Eiza
+72989439 3 -- Black Luster Soldier - Envoy of the Beginning
+99050989 3 -- Drillago
+62543393 3 -- Lekunga
+40320754 3 -- Lord Poison
+52090844 3 -- Bowganian
+13944422 3 -- Granadora
+9373534 3 -- Fuhma Shuriken
+35762283 3 -- Heart of the Underdog
+61166988 3 -- Wild Nature's Release
+8251996 3 -- Ojama Delta Hurricane!!
+34646691 3 -- Stumbling
+61044390 3 -- Chaos End
+4542651 3 -- Yellow Luster Shield
+97439308 3 -- Chaos Greed
+33423043 3 -- D.D. Designator
+60912752 3 -- D.D. Borderline
+96316857 3 -- Recycle
+23701465 3 -- Primal Seed
+69196160 3 -- Thunder Crash
+95194279 3 -- Dimension Distortion
+22589918 3 -- Reload
+68073522 3 -- Soul Absorption
+95472621 3 -- Big Burn
+21466326 3 -- Blasting the Ruins
+58851034 3 -- Cursed Seal of the Forbidden Spell
+94256039 3 -- Tower of Babel
+20644748 3 -- Spatial Collapse
+57139487 3 -- Chain Disappearance
+83133491 3 -- Zero Gravity
+20522190 3 -- Dark Mirror Force
+56916805 3 -- Energy Drain
+43793530 3 -- Giga Gagagigo
+79182538 3 -- Mad Dog of Darkness
+16587243 3 -- Neo Bug
+42071342 3 -- Sea Serpent Warrior of Darkness
+78060096 3 -- Terrorking Salmon
+5464695 3 -- Blazing Inpachi
+41859700 3 -- Burning Algae
+78243409 3 -- The Thing in the Crater
+4732017 3 -- Molten Zombie
+40737112 3 -- Dark Magician of Chaos
+42868711 3 -- Gora Turtle of Illusion
+77121851 3 -- Manticore of Darkness
+3510565 3 -- Stealth Bird
+30914564 3 -- Sacred Crane
+76909279 3 -- Enraged Battle Ox
+3493978 3 -- Don Turtle
+39892082 3 -- Balloon Lizard
+65287621 3 -- Dark Driceratops
+2671330 3 -- Hyper Hammerhead
+38670435 3 -- Black Tyranno
+65064143 3 -- Anti-Aircraft Flower
+91559748 3 -- Prickle Fairy
+26185991 3 -- Pinch Hopper
+64306248 3 -- Skull-Mark Ladybug
+37957847 3 -- Insect Princess
+64342551 3 -- Amphibious Bugroth MK-3
+90337190 3 -- Torpedo Fish
+37721209 3 -- Levia-Dragon - Daedalus
+63120904 3 -- Orca Mega-Fortress of Darkness
+95614612 3 -- Cannonball Spear Shellfish
+22609617 3 -- Mataza the Zapper
+68007326 3 -- Guardian Angel Joan
+95492061 3 -- Manju of the Ten Thousand Hands
+21887179 3 -- Getsu Fuhma
+57281778 3 -- Ryu Kokki
+34370473 3 -- Gryphon's Feather Duster
+60764581 3 -- Stray Lambs
+97169186 3 -- Smashing Ground
+23557835 0 -- Dimension Fusion
+69542930 3 -- Dedication through Light and Darkness
+96947648 3 -- Salvage
+22431243 3 -- Ultra Evolution Pill
+22493811 3 -- Multiplication of Ants
+59820352 3 -- Earth Chant
+95214051 3 -- Jade Insect Whistle
+21219755 3 -- Destruction Ring
+58607704 3 -- Fiend's Hand Mirror
+94192409 3 -- Compulsory Evacuation Device
+21597117 3 -- A Hero Emerges
+57585212 3 -- Self-Destruct Button
+84970821 3 -- Curse of Darkness
+20374520 3 -- Begone, Knave!
+56769674 3 -- DNA Transplant
+83258273 3 -- Robbin' Zombie
+19252988 3 -- Trap Jammer
+56647086 3 -- Invader of Darkness
+#AST-AE
+65403020 3 -- The End of Anubis
+39674352 3 -- Gogiga Gagagigo
+66073051 3 -- Warrior of Zera
+2468169 3 -- Sealmaster Meisei
+39552864 3 -- Mystical Shine Ball
+65957473 3 -- Metal Armored Bug
+91345518 3 -- The Agent of Judgment - Saturn
+38730226 3 -- The Agent of Wisdom - Mercury
+64734921 3 -- The Agent of Creation - Venus
+91123920 3 -- The Agent of Force - Mars
+27618634 3 -- The Unhappy Girl
+63012333 3 -- Soul-Absorbing Bone Tower
+90407382 3 -- The Kick Man
+26495087 3 -- Vampire Lady
+31812496 3 -- Stone Statue of the Aztecs
+53890795 3 -- Rocket Jumper
+99284890 3 -- Avatar of The Pot
+25773409 3 -- Legendary Jujitsu Master
+30190809 3 -- Gear Golem the Moving Fortress
+52768103 3 -- KA-2 Des Scissors
+98162242 3 -- Needle Burrower
+84550200 3 -- Sonic Jammer
+25551951 3 -- Blowback Dragon
+51945556 3 -- Zaborg the Thunder Monarch
+87340664 3 -- Atomic Firefly
+24435369 3 -- Mermaid Knight
+50823978 3 -- Piranha Army
+83228073 3 -- Two Thousand Needles
+19612721 3 -- Disc Fighter
+55001420 3 -- Arcane Archer of the Forest
+82005435 3 -- Lady Ninja Yae
+18590133 3 -- Goblin King
+45985838 3 -- Solar Flare Dragon
+81383947 3 -- White Magician Pikeru
+18378582 3 -- Archlord Zerato
+44762290 3 -- Opti-Camouflage Armor
+80161395 3 -- Mystik Wok
+98045062 3 -- Enemy Controller
+17655904 3 -- Burst Stream of Destruction
+43040603 3 -- Monster Gate
+303660 3 -- Amplifier
+10035717 3 -- Weapon Change
+56433456 3 -- The Sanctuary in the Sky
+82828051 3 -- Earthquake
+19312169 3 -- Talisman of Trap Sealing
+45311864 3 -- Goblin Thief
+82705573 3 -- Backfire
+18190572 3 -- Micro Ray
+44595286 3 -- Light of Judgment
+71983925 3 -- Talisman of Spell Sealing
+17078030 3 -- Wall of Revealing Light
+44472639 3 -- Solar Ray
+70861343 3 -- Ninjitsu Art of Transformation
+16255442 3 -- Beckoning Light
+43250041 3 -- Draining Shield
+79649195 3 -- Armor Break
+53776525 3 -- Gigobyte
+27288416 3 -- Mokey Mokey
+99171160 3 -- Kozaky
+26566878 3 -- Fiend Scorpion
+52550973 3 -- Pharaoh's Servant
+89959682 3 -- Pharaonic Protector
+25343280 3 -- Spirit of the Pharaoh
+51838385 3 -- Theban Nightmare
+88236094 3 -- Aswan Apparition
+24221739 3 -- Protector of the Sanctuary
+51616747 3 -- Nubian Guard
+87010442 3 -- Legacy Hunter
+13409151 3 -- Desertapir
+50593156 3 -- Sand Gambler
+86988864 3 -- 3-Hump Lacooda
+13386503 3 -- Ghost Knight of Jackal
+49771608 3 -- Absorbing Kid from the Sky
+85166216 3 -- Elephant Statue of Blessing
+12160911 3 -- Elephant Statue of Disaster
+48659020 3 -- Spirit Caller
+75043725 3 -- Emissary of the Afterlife
+11448373 3 -- Grave Protector
+44436472 3 -- Double Coston
+70821187 3 -- Regenerating Mummy
+16226786 3 -- Night Assailant
+43714890 3 -- Man-Thro' Tro'
+79109599 3 -- King of the Swamp
+6103294 3 -- Emissary of the Oasis
+42598242 3 -- Special Hurricane
+78986941 3 -- Order to Charge
+5371656 3 -- Sword of the Soul-Eater
+31476755 3 -- Dust Barrier
+78864369 3 -- Soul Reversal
+4259068 3 -- Spell Economics
+30653113 3 -- Blessings of the Nile
+67048711 3 -- 7
+3136426 3 -- Level Limit - Area B
+30531525 3 -- Enchanting Fitting Room
+66926224 3 -- The Law of the Normal
+2314238 3 -- Dark Magic Attack
+39719977 3 -- Delta Attacker
+5703682 3 -- Thousand Energy
+32298781 3 -- Triangle Power
+78697395 3 -- The Third Sarcophagus
+4081094 3 -- The Second Sarcophagus
+31076103 3 -- The First Sarcophagus
+67464807 3 -- Dora of Fate
+4869446 3 -- Judgment of the Desert
+30353551 3 -- Human-Wave Tactics
+66742250 3 -- Curse of Anubis
+93747864 3 -- Desert Sunlight
+39131963 3 -- Des Counterblow
+66526672 3 -- Labyrinth of Nightmare
+92924317 3 -- Soul Resurrection
+39019325 3 -- Order to Smash
+6133894 3 -- Mazera DeVille
+#SOD-AE
+13179332 3 -- Charcoal Inpachi
+49563947 3 -- Neo Aqua Madoor
+86652646 3 -- Skull Dog Marron
+12057781 3 -- Goblin Calligrapher
+49441499 3 -- Ultimate Insect LV1
+75830094 3 -- Horus the Black Flame Dragon LV4
+11224103 3 -- Horus the Black Flame Dragon LV6
+48229808 3 -- Horus the Black Flame Dragon LV8
+74713516 3 -- Dark Mimic LV1
+1102515 3 -- Dark Mimic LV3
+47507260 3 -- Mystic Swordsman LV2
+74591968 3 -- Mystic Swordsman LV4
+980973 3 -- Armed Dragon LV3
+46384672 3 -- Armed Dragon LV5
+73879377 3 -- Armed Dragon LV7
+9264485 3 -- Horus' Servant
+36262024 3 -- Black Dragon's Chick
+72657739 3 -- Malice Doll of Demise
+4041838 3 -- Ninja Grandmaster Sasuke
+31440542 3 -- Rafflesia Seduction
+67934141 3 -- Ultimate Baseball Kid
+4929256 3 -- Mobius the Frost Monarch
+30314994 3 -- Element Dragon
+66712593 3 -- Element Soldier
+93107608 3 -- Howling Insect
+39191307 3 -- Masked Dragon
+66690411 3 -- Mind on Air
+92084010 3 -- Unshaven Angler
+38479725 3 -- The Trojan Horse
+65878864 3 -- Nobleman-Eater Bug
+91862578 3 -- Enraged Muka Muka
+28357177 3 -- Hade-Hane
+64751286 3 -- Penumbral Soldier Lady
+90140980 3 -- Ojama King
+27134689 3 -- Master of Oz
+53539634 3 -- Sanwitch
+90928333 3 -- Dark Factory of Mass Production
+26412047 3 -- Hammer Shot
+52817046 3 -- Mind Wipe
+89801755 3 -- Abyssal Designator
+25290459 3 -- Level Up!
+52684508 3 -- Inferno Fire Blast
+97342942 3 -- Ectoplasmer
+88089103 3 -- The Graveyard in the Fourth Dimension
+25578802 3 -- Two-Man Cell Battle
+51562916 3 -- Big Wave Small Wave
+27967615 3 -- Fusion Weapon
+54351224 3 -- Ritual Weapon
+90740329 3 -- Taunt
+27744077 3 -- Absolute End
+53239672 3 -- Spirit Barrier
+89628781 3 -- Ninjitsu Art of Decoy
+26022485 3 -- Enervating Mist
+52417194 3 -- Heavy Slump
+89405199 3 -- Greed
+15800838 3 -- Mind Crush
+80863132 3 -- Null and Void
+52648457 3 -- Gorgon's Eye
+51394546 3 -- Cemetary Bomb
+88789641 3 -- Hallowed Life Barrier
+#RDS-AE
+35322812 3 -- Woodborg Inpachi
+62327910 3 -- Mighty Guard
+8715625 3 -- Bokoichi the Freightening Car
+34100324 3 -- Harpie Girl
+61505339 3 -- The Creator
+97093037 3 -- The Creator Incarnate
+34088136 3 -- Ultimate Insect LV3
+60482781 3 -- Mystic Swordsman LV6
+1995985 3 -- Silent Swordsman LV3
+81306586 3 -- Nightmare Penguin
+23265594 3 -- Heavy Mech Support Platform
+18891691 3 -- Perfect Machine King
+65260293 3 -- Element Magician
+92755808 3 -- Element Saurus
+28143906 3 -- Roc from the Valley of Haze
+64538655 3 -- Sasuke Samurai 4
+91932350 3 -- Harpie Lady 1
+27927359 3 -- Harpie Lady 2
+54415063 3 -- Harpie Lady 3
+90810762 3 -- Raging Flame Sprite
+26205777 3 -- Thestalos the Firestorm Monarch
+53693416 3 -- Eagle Eye
+89698120 3 -- Tactical Espionage Expert
+26082229 3 -- Invasion of Flames
+52571838 3 -- Creeping Doom Manta
+88975532 3 -- Pitch-Black Warwolf
+15960641 3 -- Mirage Dragon
+51355346 3 -- Gaia Soul the Combustible Collective
+88753985 3 -- Fox Fire
+14148099 3 -- Big Core
+51632798 3 -- Fusilier Dragon, the Dual-Mode Beast
+87621407 3 -- Dekoichi the Battlechanted Locomotive
+13026402 3 -- A-Team: Trap Disposal Unit
+40410110 3 -- Homunculus the Alchemic Being
+86805855 3 -- Dark Blade the Dragon Knight
+13803864 3 -- Mokey Mokey King
+49398568 3 -- Serial Spell
+75782277 3 -- Harpies' Hunting Ground
+12181376 3 -- Triangle Ecstasy Spark
+48576971 3 -- Necklace of Command
+63995093 3 -- Machine Duplication
+75560629 3 -- Flint
+1965724 3 -- Mokey Mokey Smackdown
+47453433 3 -- Back to Square One
+74848038 3 -- Monster Reincarnation
+242146 3 -- Ballista of Rampart Smashing
+37231841 3 -- Lighten the Load
+13626450 3 -- Malice Dispersion
+35686187 3 -- Tragedy
+49010598 3 -- Divine Wrath
+76515293 3 -- Xing Zhen Hu
+12503902 3 -- Rare Metalmorph
+49998907 3 -- Fruits of Kozaky's Studies
+75392615 3 -- Mind Haxorz
+1781310 3 -- Fuh-Rin-Ka-Zan
+48276469 3 -- Chain Burst
+74270067 3 -- Pikeru's Circle of Enchantment
+1669772 3 -- Spell Purification
+37053871 3 -- Astral Barrier
+74458486 3 -- Covering Fire
+#WCS-AE5
+27054370 3 -- Firewing Pegasus
+#FET-AE
+36119641 3 -- Space Mambo
+62113340 3 -- Divine Dragon Ragnarok
+8508055 3 -- Chu-Ske the Mouse Fighter
+35052053 3 -- Insect Knight
+61441708 3 -- Sacred Phoenix of Nephthys
+98446407 3 -- Hand of Nephthys
+34830502 3 -- Ultimate Insect LV5
+74388798 3 -- Silent Swordsman LV5
+60229110 3 -- Granmarg the Rock Monarch
+97623219 3 -- Element Valkyrie
+23118924 3 -- Element Doom
+60102563 3 -- Maji-Gire Panda
+96501677 3 -- Catnipped Kitty
+22996376 3 -- Behemoth the King of All Animals
+59380081 3 -- Big-Tusked Mammoth
+95789089 3 -- Kangaroo Champ
+22873798 3 -- Hyena
+58268433 3 -- Blade Rabbit
+94667532 3 -- Mecha-Dog Marron
+21051146 3 -- Blast Magician
+16956455 3 -- Chiron the Mage
+57046845 3 -- Gearfried the Swordmaster
+84430950 3 -- Armed Samurai - Ben Kei
+20939559 3 -- Shadowslayer
+52323207 3 -- Golem Sentry
+89718302 3 -- Abare Ushioni
+15717011 3 -- The Light - Hex-Sealed Fusion
+52101615 3 -- The Dark - Hex-Sealed Fusion
+88696724 3 -- The Earth - Hex-Sealed Fusion
+15090429 3 -- Whirlwind Prodigy
+41089128 3 -- Flame Ruler
+87473172 3 -- Firebird
+14878871 3 -- Rescue Cat
+40267580 3 -- Brain Jacker
+87751584 3 -- Gatling Dragon
+13756293 3 -- King Dragun
+49140998 3 -- A Feather of the Phoenix
+76539047 3 -- Poison Fangs
+51481927 3 -- Spell Absorption
+69162969 3 -- Lightning Vortex
+33767325 3 -- Meteor of Destruction
+12923641 3 -- Swords of Concealing Light
+49328340 3 -- Spiral Spear Strike
+75417459 3 -- Release Restraint
+1801154 3 -- Centrifugal Field
+48206762 3 -- Fulfillment of the Contract
+74694807 3 -- Re-Fusion
+1689516 3 -- The Big March of Animals
+37083210 3 -- Cross Counter
+73578229 3 -- Pole Position
+967928 3 -- Penalty Game!
+36361633 3 -- Threatening Roar
+63356631 3 -- Phoenix Wing Wind Blast
+9744376 3 -- Good Goblin Housekeeping
+35149085 3 -- Beast Soul Swap
+62633180 3 -- Assault on GHQ
+8628798 3 -- D.D. Dynamite
+35027493 3 -- Deck Devastation Virus
+61411502 3 -- Elemental Burst
+97806240 3 -- Forced Ceasefire
+#TLM-AE
+21844576 3 -- Elemental HERO Avian
+58932615 3 -- Elemental HERO Burstinatrix
+84327329 3 -- Elemental HERO Clayman
+20721928 3 -- Elemental HERO Sparkman
+57116033 3 -- Winged Kuriboh
+83104731 3 -- Ancient Gear Golem
+10509340 3 -- Ancient Gear Beast
+56094445 3 -- Ancient Gear Soldier
+82482194 3 -- Millennium Scorpion
+19877898 3 -- Ultimate Insect LV7
+45871897 3 -- Lost Guardian
+82260502 3 -- Hieracosphinx
+18654201 3 -- Criosphinx
+45159319 3 -- Moai Interceptor Cannons
+71544954 3 -- Megarock Dragon
+13532663 3 -- Dummy Golem
+40937767 3 -- Grave Ohja
+76321376 3 -- Mine Golem
+3810071 3 -- Monk Fighter
+49814180 3 -- Master Monk
+75209824 3 -- Guardian Statue
+2694423 3 -- Medusa Worm
+48092532 3 -- D.D. Survivor
+75487237 3 -- Mid Shield Gardna
+1571945 3 -- White Ninja
+37970940 3 -- Aussa the Earth Charmer
+74364659 3 -- Eria the Water Charmer
+759393 3 -- Hiita the Fire Charmer
+37744402 3 -- Wynn the Wind Charmer
+63142001 3 -- Batteryman AA
+9637706 3 -- Des Wombat
+36021814 3 -- King of the Skull Servants
+62420419 3 -- Reshef the Dark Being
+99414168 3 -- Elemental Mistress Doriado
+35809262 3 -- Elemental HERO Flame Wingman
+61204971 3 -- Elemental HERO Thunder Giant
+42664989 3 -- Card of Sanctity
+87910978 3 -- Brain Control
+98792570 3 -- Gift of the Martyr
+34187685 3 -- Double Attack
+61181383 3 -- Battery Charger
+97570038 3 -- Kaminote Blow
+23965037 3 -- Doriado's Blessing
+60369732 3 -- Final Ritual of the Ancients
+96458440 3 -- Legendary Black Belt
+23842445 3 -- Nitro Unit
+59237154 3 -- Shifting Shadows
+96631852 3 -- Impenetrable Formation
+22020907 3 -- Hero Signal
+58015506 3 -- Pikeru's Second Sight
+85519211 3 -- Minefield Eruption
+21908319 3 -- Kozaky's Self-Destruct Button
+58392024 3 -- Mispolymerization
+84397023 3 -- Level Conversion Lab
+20781762 3 -- Rock Bombardment
+57270476 3 -- Grave Lure
+83675475 3 -- Token Feastevil
+10069180 3 -- Spell-Stopping Statute
+56058888 3 -- Royal Surrender
+82452993 3 -- Lone Wolf
+#CRV-AE
+45945685 3 -- Cycroid
+60246171 3 -- Soitsu
+97240270 3 -- Mad Lobster
+23635815 3 -- Jerry Beans Man
+98585345 3 -- Winged Kuriboh LV10
+71930383 3 -- Patroid
+18325492 3 -- Gyroid
+44729197 3 -- Steamroid
+71218746 3 -- Drillroid
+7602840 3 -- UFOroid
+43697559 3 -- Jetroid
+6480253 3 -- Wroughtweiler
+33875961 3 -- Dark Catapulter
+79979666 3 -- Elemental Hero Bubbleman
+70095154 3 -- Cyber Dragon
+59023523 3 -- Cybernetic Magician
+96428622 3 -- Cybernetic Cyclopean
+22512237 3 -- Mechanical Hound
+59907935 3 -- Cyber Archfiend
+85306040 3 -- Goblin Elite Attack Force
+22790789 3 -- B.E.S. Crystal Core
+58185394 3 -- Giant Kozaky
+84173492 3 -- Indomitable Fighter Lei Lei
+11678191 3 -- Protective Soul Ailin
+57062206 3 -- Doitsu
+84451804 3 -- Des Frog
+10456559 3 -- T.A.D.P.O.L.E.
+56840658 3 -- Poison Draw Frog
+83235263 3 -- Tyranno Infinity
+19733961 3 -- Batteryman C
+46128076 3 -- Ebon Magician Curran
+82112775 3 -- D.D.M. - Different Dimension Master
+5368615 3 -- Steam Gyroid
+32752319 3 -- UFOroid Fighter
+74157028 3 -- Cyber Twin Dragon
+1546123 3 -- Cyber End Dragon
+37630732 3 -- Power Bond
+18511384 3 -- Fusion Recovery
+45906428 3 -- Miracle Fusion
+71490127 3 -- Dragon's Mirror
+18895832 3 -- System Down
+44883830 3 -- Des Croaking
+70278545 3 -- Pot of Generosity
+7672244 3 -- Shien's Spy
+25573054 3 -- Transcendent Wings
+61968753 3 -- Bubble Shuffle
+97362768 3 -- Spark Blaster
+63035430 3 -- Skyscraper
+43061293 3 -- Fire Darts
+70156997 3 -- Spiritual Earth Art - Kurogane
+6540606 3 -- Spiritual Water Art - Aoi
+42945701 3 -- Spiritual Fire Art - Kurenai
+79333300 3 -- Spiritual Wind Art - Miyabi
+5728014 3 -- A Rival Appears!
+32723153 0 -- Magical Explosion
+78211862 3 -- Rising Energy
+5606466 3 -- D.D. Trap Hole
+31000575 3 -- Conscription
+67095270 3 -- Dimension Wall
+4483989 3 -- Prepare to Strike Back
+#WCPS-AE6
+6740720 3 -- Seiyaryu
+#EEN-AE
+7459013 3 -- Zure, Knight of Dark World
+51638941 3 -- V-Tiger Jet
+97023549 3 -- Blade Skater
+25652259 3 -- Queen's Knight
+90876561 3 -- Jack's Knight
+64788463 3 -- King's Knight
+59793705 3 -- Elemental HERO Bladedge
+86188410 3 -- Elemental HERO Wildheart
+23421244 3 -- Reborn Zombie
+50916353 3 -- Chthonian Soldier
+96300057 3 -- W-Wing Catapult
+23309606 3 -- Infernal Incinerator
+22587018 3 -- Hydrogeddon
+58071123 3 -- Oxygeddon
+85066822 3 -- Water Dragon
+11460577 3 -- Etoile Cyber
+44954628 3 -- B.E.S. Tetran
+70948327 3 -- Nanobreaker
+6337436 3 -- Rapid-Fire Magician
+33731070 3 -- Beiige, Vanguard of Dark World
+79126789 3 -- Broww, Huntsman of Dark World
+6214884 3 -- Brron, Mad King of Dark World
+32619583 3 -- Sillva, Warlord of Dark World
+78004197 3 -- Goldd, Wu-Lord of Dark World
+5498296 3 -- Scarr, Scout of Dark World
+31887905 3 -- Familiar-Possessed - Aussa
+68881649 3 -- Familiar-Possessed - Eria
+4376658 3 -- Familiar-Possessed - Hiita
+31764353 3 -- Familiar-Possessed - Wynn
+58859575 3 -- VW-Tiger Catapult
+84243274 3 -- VWXYZ-Dragon Catapult Cannon
+10248389 3 -- Cyber Blader
+47737087 3 -- Elemental HERO Rampart Blaster
+83121692 3 -- Elemental HERO Tempest
+10526791 3 -- Elemental HERO Wildedge
+25366484 3 -- Elemental HERO Shining Flare Wingman
+67169062 3 -- Pot of Avarice
+93554166 3 -- Dark World Lightning
+61850482 3 -- Level Modulation
+24643836 3 -- Ojamagic
+98259197 3 -- Ojamuscle
+19394153 3 -- Feather Shot
+45898858 3 -- Bonding - H2O
+46910446 3 -- Chthonian Alliance
+90374791 3 -- Armed Changer
+30548775 3 -- Branch!
+66947414 3 -- Boss Rush
+93431518 3 -- Gateway to Dark World
+44676200 3 -- Hero Barrier
+18271561 3 -- Chthonian Blast
+29826127 3 -- The Forces of Darkness
+65824822 3 -- Dark Deal
+92219931 3 -- Simultaneous Loss
+28604635 3 -- Weed Out
+55008284 3 -- The League of Uniform Nomenclature
+91597389 3 -- Roll Out!
+72287557 3 -- Chthonian Polymer
+71060915 3 -- Feather Wind
+27581098 3 -- Non-Fusion Area
+54976796 3 -- Level Limit - Area A
+#SOI-AE
+6007213 3 -- Uria, Lord of Searing Flames
+32491822 3 -- Hamon, Lord of Striking Thunder
+69890967 3 -- Raviel, Lord of Phantasms
+5285665 3 -- Elemental Hero Neo Bubbleman
+32679370 3 -- Hero Kid
+68774379 3 -- Cyber Barrier Dragon
+4162088 3 -- Cyber Laser Dragon
+31557782 3 -- Ancient Gear
+80045583 3 -- Ancient Gear Cannon
+26439287 3 -- Proto-Cyber Dragon
+53828396 3 -- Adhesive Explosive
+89222931 3 -- Machine King Prototype
+15317640 3 -- B.E.S. Covered Core
+52702748 3 -- D.D. Guide
+88190453 3 -- Chain Thrasher
+15595052 3 -- Disciple of the Forbidden Spell
+41589166 3 -- Tenkabito Shien
+87978805 3 -- Parasitic Ticky
+14472500 3 -- Gokipon
+40867519 3 -- Silent Insect
+77252217 3 -- Chainsaw Insect
+13250922 3 -- Anteatereatingant
+49645921 3 -- Saber Beetle
+76039636 3 -- Doom Dozer
+12538374 3 -- Treeborn Frog
+49522489 3 -- Beelze Frog
+75917088 3 -- Princess Pikeru
+2316186 3 -- Princess Curran
+48700891 3 -- Memory Crusher
+14255590 3 -- Malice Ascendant
+41249545 3 -- Grass Phantom
+73648243 3 -- Sand Moth
+10032958 3 -- Divine Dragon - Excelion
+46427957 3 -- Ruin, Queen of Oblivion
+72426662 3 -- Demise, King of Armageddon
+9910360 3 -- D.3.S. Frog
+67951831 3 -- Hero Heart
+94940436 3 -- Magnet Circle LV2
+30435145 3 -- Ancient Gear Factory
+67829249 3 -- Ancient Gear Drill
+93224848 3 -- Phantasmal Martyrs
+29612557 3 -- Cyclone Boomerang
+45305419 3 -- Symbol of Heritage
+72709014 3 -- Trial of the Princesses
+66607691 3 -- Photon Generator Unit
+8198712 3 -- End of the World
+92001300 3 -- Ancient Gear Castle
+44182827 3 -- Samsara
+29590905 3 -- Super Junior Confrontation
+55985014 3 -- Miracle Kids
+91989718 3 -- Attack Reflector Unit
+28378427 3 -- Damage Condenser
+71587526 3 -- Karma Cut
+7076131 3 -- Next to be Lost
+34460239 3 -- Generation Shift
+70865988 3 -- Full Salvo
+6859683 3 -- Success Probability 0%
+33248692 3 -- Option Hunter
+69632396 3 -- Goblin Out of the Frying Pan
+6137095 3 -- Malfunction
+#EOJ-AE
+41613948 3 -- Destiny HERO - Doom Lord
+77608643 3 -- Destiny HERO - Captain Tenacious
+13093792 3 -- Destiny HERO - Diamond Dude
+40591390 3 -- Destiny HERO - Dreadmaster
+49375719 3 -- Cyber Tutu
+76763417 3 -- Cyber Gymnast
+2158562 3 -- Cyber Prima
+76986005 3 -- Cyber Kirin
+3370104 3 -- Cyber Phoenix
+67646312 3 -- Searchlightman
+93130021 3 -- Victory Viper XX03
+81896370 3 -- Swift Birdman Joe
+6924874 3 -- Harpie's Pet Baby Dragon
+32918479 3 -- Majestic Mech - Senku
+69303178 3 -- Majestic Mech - Ohka
+95701283 3 -- Majestic Mech - Goryu
+68280530 3 -- Royal Knight
+21074344 3 -- Herald of Green Light
+94689635 3 -- Herald of Purple Light
+32296881 3 -- Bountiful Artemis
+67468948 3 -- Layard the Liberator
+94853057 3 -- Banisher of the Radiance
+20951752 3 -- Voltanis the Adjudicator
+57346400 3 -- Guard Dog
+93730409 3 -- Whirlwind Weasel
+29139104 3 -- Avalanching Aussa
+56524813 3 -- Raging Eria
+92518817 3 -- Blazing Hiita
+29013526 3 -- Storming Wynn
+55401221 3 -- Batteryman D
+20529766 3 -- Super-Electromagnetic Voltech Dragon
+41436536 3 -- Elemental HERO Phoenix Enforcer
+88820235 3 -- Elemental HERO Shining Phoenix Enforcer
+14225239 3 -- Elemental HERO Mariner
+55615891 3 -- Elemental HERO Wild Wingman
+81003500 3 -- Elemental HERO Necroid Shaman
+1036974 3 -- Misfortune
+74825788 3 -- H - Heated Heart
+213326 3 -- E - Emergency Call
+37318031 3 -- R - Righteous Justice
+63703130 3 -- O - Oversoul
+191749 3 -- Hero Flash!!
+54289683 3 -- Power Capsule
+28890974 3 -- Celestial Transformation
+48653261 3 -- Guard Penalty
+38430673 3 -- Grand Convergence
+81674782 3 -- Dimensional Fissure
+75041269 3 -- Clock Tower Prison
+17178486 0 -- Life Equalizer
+36586443 3 -- Elemental Recharge
+62980542 3 -- Destruction of Destiny
+35464895 3 -- Destiny Signal
+99075257 3 -- D - Time
+62868900 3 -- D - Shield
+53567095 3 -- Icarus Attack
+94253609 3 -- Elemental Absorber
+30241314 3 -- Macro Cosmos
+80551130 3 -- Miraculous Descent
+12117532 3 -- Shattered Axe
+43340443 3 -- Forced Back
+#CRMS-AE
+88559132 3 -- Turret Warrior
+14943837 3 -- Debris Dragon
+40348946 3 -- Hyper Synchron
+77336644 3 -- Red Dragon Archfiend/Assault Mode
+13821299 3 -- Trap Eater
+40225398 3 -- Twin-Sword Marauder
+76614003 3 -- Dark Tinker
+2009101 3 -- Blackwing - Gale the Whirlwind
+49003716 3 -- Blackwing - Bora the Spear
+75498415 3 -- Blackwing - Sirocco the Dawn
+2986553 3 -- Twilight Rose Knight
+89493368 3 -- Summon Reactor・SK
+52286175 3 -- Trap Reactor・Y FI
+15175429 3 -- Spell Reactor・RE
+88671720 3 -- Black Salvo
+16898077 3 -- Flying Fortress SKY FIRE
+48381268 3 -- Morphtronic Boarden
+75775867 3 -- Morphtronic Slingen
+1764972 3 -- Doomkaiser Dragon/Assault Mode
+37169670 3 -- Hyper Psychic Blaster/Assault Mode
+14553285 3 -- Arcanite Magician/Assault Mode
+40048324 3 -- Arcane Apprentice
+77036039 3 -- Assault Mercenary
+3431737 3 -- Assault Beast
+49826746 3 -- Night Wing Sorceress
+76214441 3 -- Lifeforce Harmonizer
+2619149 3 -- Gladiator Beast Samnite
+46239604 3 -- Dupe Frog
+81278754 3 -- Flip Flop Frog
+75937826 3 -- B.E.S. Big Core MK-2
+39703254 3 -- Inmato
+75198893 3 -- Scanner
+1596508 3 -- Dimension Fortress Weapon
+38981606 3 -- Desert Protector
+74976215 3 -- Cross-Sword Beetle
+1474910 3 -- Bee List Soldier
+37869028 3 -- Hydra Viper
+63253763 3 -- Alien Overlord
+652362 3 -- Alien Ammonite
+32646477 3 -- Dark Strike Fighter
+69031175 3 -- Blackwing Armor Master
+95526884 3 -- Hyper Psychic Blaster
+31924889 3 -- Arcanite Magician
+68319538 3 -- Cosmic Fortress Gol'gar
+94303232 3 -- Prevention Star
+21702241 3 -- Vengeful Servant
+67196946 3 -- Star Blast
+94681654 3 -- Raptor Wing Strike
+20686759 3 -- Morphtronic Rusty Engine
+56074358 3 -- Morphtronic Map
+93469007 3 -- Assault Overload
+29863101 3 -- Assault Teleport
+56252810 3 -- Assault Revival
+92346415 3 -- Psychic Sword
+28741524 3 -- Telekinetic Power Well
+55136228 3 -- Indomitable Gladiator Beast
+81524977 3 -- Seed Cannon
+28529976 3 -- Super Solar Nutrient
+54913680 3 -- Six Scrolls of the Samurai
+80402389 3 -- Verdant Sanctuary
+17896384 3 -- Arcane Barrier
+53291093 3 -- Mysterious Triangle
+80280737 3 -- Assault Mode Activate
+16674846 3 -- Spirit Force
+42079445 3 -- Descending Lost Star
+89563150 3 -- Shining Silver Force
+15552258 3 -- Half or Nothing
+42956963 3 -- Nightmare Archfiends
+88341502 3 -- Ebon Arrow
+14730606 3 -- Ivy Shackles
+41234315 3 -- Fake Explosion
+77229910 3 -- Morphtronic Forcefield
+14613029 3 -- Morphtronic Mix-up
+40012727 3 -- Assault Slash
+76407432 3 -- Assault Counter
+3891471 3 -- Psychic Tuning
+49980185 3 -- Metaphysical Regeneration
+76384284 3 -- Trojan Gladiator Beast
+2779999 3 -- Wall of Thorns
+39163598 3 -- Planet Pollutant Virus
+#SD16-AE
+40732515 3 -- Endymion, the Master Magician
+76137614 3 -- Disenchanter
+2525268 3 -- Defender, the Magical Knight
+5640330 3 -- Hannibal Necromancer
+73665146 3 -- Silent Magician LV4
+72443568 3 -- Silent Magician LV8
+423585 3 -- Summoner Monk
+45462639 3 -- Dark Red Enchanter
+55424270 3 -- Mythical Beast Cerberus
+47731128 3 -- Mei-Kou, Master of Barriers
+82099401 3 -- Crystal Seer
+39910367 3 -- Magical Citadel of Endymion
+75014062 3 -- Spell Power Grasp
+36045450 3 -- Magicians Unite
+47529357 3 -- Mist Body
+91819979 3 -- Magical Blast
+28553439 3 -- Magical Dimension
+45939841 3 -- Twister
+50755 3 -- Magician's Circle
+50323155 3 -- Black Horn of Heaven
+#RGBT-AE
+51987571 3 -- Rockstone Warrior
+97385276 3 -- Level Warrior
+23770284 3 -- Strong Wind Dragon
+50164989 3 -- Dark Verger
+96553688 3 -- Phoenixian Seed
+23558733 3 -- Phoenixian Cluster Amaryllis
+41160533 3 -- Rose Tentacles
+59042331 3 -- Hedge Guard
+85431040 3 -- Evil Thorn
+22835145 3 -- Blackwing - Blizzard the Far North
+58820853 3 -- Blackwing - Shura the Blue Flame
+85215458 3 -- Blackwing - Kalut the Moon Shadow
+11613567 3 -- Blackwing - Elphin the Raven
+57108202 3 -- Morphtronic Remoten
+84592800 3 -- Morphtronic Videon
+10591919 3 -- Morphtronic Scopen
+47985614 3 -- Gadget Arms
+83370323 3 -- Torapart
+10875327 3 -- Earthbound Immortal Aslla piscu
+46263076 3 -- Earthbound Immortal Ccapac Apu
+72258771 3 -- Koa'ki Meiru Valafar
+19642889 3 -- Koa'ki Meiru Powerhand
+45041488 3 -- Koa'ki Meiru Guardian
+12435193 3 -- Koa'ki Meiru Drago
+54520292 3 -- Koa'ki Meiru Ice
+80925836 3 -- Koa'ki Meiru Doom
+17313545 3 -- Brain Golem
+43708640 3 -- Minoan Centaur
+80102359 3 -- Reinforced Human Psychic Borg
+16191953 3 -- Master Gig
+42685062 3 -- Emissary from Pandemonium
+79080761 3 -- Gigastone Omega
+15475415 3 -- Alien Dog
+42463414 3 -- Spined Gillman
+78868119 3 -- Deep Sea Diva
+4252828 3 -- Mermaid Archer
+41741922 3 -- Lava Dragon
+77135531 3 -- Vanguard of the Dragon
+4130270 3 -- G.B. Hunter
+40529384 3 -- Exploder Dragonwing
+76913983 3 -- Blackwing Armed Wing
+2403771 3 -- Power Tool Dragon
+39402797 3 -- Trident Dragion
+76891401 3 -- Sea Dragon Lord Gishilnodon
+2295440 2 -- One for One
+38680149 3 -- Mind Trust
+65079854 3 -- Thorn of Malice
+1073952 3 -- Magic Planter
+38568567 3 -- Wonder Clover
+64952266 3 -- Against the Wind
+91351370 3 -- Black Whirlwind
+37745919 3 -- Junk Box
+63730624 3 -- Double Tool C&D
+90239723 3 -- Morphtronic Repair Unit
+36623431 3 -- Iron Core of Koa'ki Meiru
+63018036 3 -- Iron Core Immediate Disposal
+99002135 3 -- Urgent Synthesis
+25401880 3 -- Psychic Path
+62896588 3 -- Natural Tune
+98380593 3 -- Supremacy Berry
+25789292 3 -- Forbidden Chalice
+51773900 3 -- Calming Magic
+97168905 3 -- Miracle Locus
+24566654 3 -- Crimson Fire
+50951359 3 -- Tuner Capture
+87046457 3 -- Overdoom Line
+23440062 3 -- Wicked Rebirth
+59839761 3 -- Delta Crow - Anti Reverse
+86223870 3 -- Level Retuner
+22628574 3 -- Fake Feather
+59616123 3 -- Trap Stun
+85101228 3 -- Morphtronic Bind
+11596936 3 -- Reckoned Power
+58990631 3 -- Automatic Laser
+84389640 3 -- Attack of the Cornered Rat
+11373345 3 -- Proof of Powerlessness
+47778083 3 -- Bone Temple Block
+83266092 3 -- Grave of the Super Ancient Organism
+10651797 3 -- Swallow Flip
+46656406 3 -- Mirror of Oaths
+#SSD1-AE
+92125819 3 -- Noble Knight Artorigus
+48305365 3 -- Axe Raider
+44430454 3 -- Chamberlain of the Six Samurai
+20871001 3 -- Blue Medicine
+42534368 3 -- Silent Doom
+29267084 3 -- Shadow Spell
+53413628 3 -- Code Talker
+#SSD2-AE
+94119974 3 -- Two-Headed King Rex
+96005454 3 -- Hunter Dragon
+11066358 3 -- Galaxy Serpent
+38520918 3 -- Ancient Dragon
+57568840 3 -- Delta Flyer
+36750412 3 -- Magna Drago
+51925772 3 -- Dread Dragon
+81510157 3 -- Soul Taker
+96765646 3 -- Swing of Memories
+3244563 3 -- Shield Spear
+50321796 3 -- Brionac, Dragon of the Ice Barrier
+#SDID-AE
+35191415 3 -- Magician of Dark Illusion
+71696014 3 -- Magician's Robe
+7084129 3 -- Magician's Rod
+97631303 3 -- Magicians' Souls
+30603688 3 -- Apprentice Illusion Magician
+31699677 3 -- Magikuriboh
+77683371 3 -- Dimension Conjurer
+8487449 3 -- Jester Confit
+25280974 3 -- Legion the Fiend Jester
+14824019 3 -- Spellbook Magician of Prophecy
+28985331 3 -- Armageddon Knight
+48048590 3 -- Keeper of Dragon Magic
+11074235 3 -- Mana Dragon Zirnitron
+47222536 3 -- Dark Magical Circle
+73616671 3 -- Illusion Magic
+111280 3 -- Dark Magic Expanded
+41735184 3 -- Dark Magic Inheritance
+23020408 3 -- Soul Servant
+59514116 3 -- Secrets of Dark Magic
+68462976 3 -- Secret Village of the Spellcasters
+67775894 3 -- Wonder Wand
+74335036 3 -- Fusion Substitute
+89739383 3 -- Spellbook of Secrets
+23314220 3 -- Spellbook of Knowledge
+6498706 3 -- Fusion Deployment
+48680970 3 -- Eternal Soul
+7922915 3 -- Magician Navigation
+86509711 3 -- Magicians' Combination
+75380687 3 -- Amulet Dragon
+41721210 3 -- Dark Magician the Dragon Knight
+#SDID-AEP
+24508238 3 -- D.D. Crow
+94145021 3 -- Droll & Lock Bird
+59438930 3 -- Ghost Ogre & Snow Rabbit
+12266229 3 -- Illusion of Chaos
+11321089 3 -- Guardian Chimera
+3078380 3 -- Timaeus the United Dragon
+96471335 3 -- Ebon Illusion Magician
+85551711 3 -- Ebon High Magician
+63391643 3 -- Thousand Knives
+1784686 3 -- The Eye of Timaeus
+21082832 3 -- Chaos Form
+21862633 3 -- Piercing the Darkness
+73915051 3 -- Scapegoat
+1475311 3 -- Allure of Darkness
+9287078 3 -- Dark Renewal
+#SDRB-AE
+62514770 3 -- Labradorite Dragon
+43096270 3 -- Alexandrite Dragon
+21615956 3 -- Flamvell Guard
+88241506 3 -- Maiden with Eyes of Blue
+72855441 3 -- Protector with Eyes of Blue
+8240199 3 -- Sage with Eyes of Blue
+45644898 3 -- Master with Eyes of Blue
+14235211 3 -- Rider of the Storm Winds
+66752837 3 -- Keeper of the Shrine
+79814787 3 -- The White Stone of Legend
+71039903 3 -- The White Stone of Ancients
+34627841 3 -- Kaibaman
+66961194 3 -- Dictator of D.
+68473226 3 -- Hardened Armed Dragon
+41639001 3 -- Hieratic Dragon of Nuit
+8972398 3 -- Omni Dragon Brotaur
+55878038 3 -- Chaos Dragon Levianeer
+37742478 3 -- Honest
+15981690 3 -- Carboneddon
+41620959 3 -- Dragon Shrine
+87025064 3 -- Silver's Cry
+2783661 3 -- Majesty with Eyes of Blue
+35659410 3 -- Vision with Eyes of Blue
+24382602 3 -- Mausoleum of White
+50371210 3 -- Beacon of White
+48800175 3 -- The Melody of Awakening Dragon
+71867500 3 -- Dragon Revival Rhapsody
+62265044 3 -- Dragon Ravine
+38120068 3 -- Trade-In
+39701395 3 -- Cards of Consonance
+62089826 3 -- True Light
+13513663 3 -- Castle of Dragon Souls
+82382815 3 -- Champion's Vigilance
+40908371 3 -- Azure-Eyes Silver Dragon
+59822133 3 -- Blue-Eyes Spirit Dragon
+#SDRB-AEP
+38517737 3 -- Blue-Eyes Alternative White Dragon
+45467446 3 -- Dragon Spirit of White
+5560911 3 -- Destrudo the Lost Dragon's Frisson
+30576089 3 -- Blue-Eyes Jet Dragon
+56920308 3 -- The Ultimate Creature of Destruction
+36734924 3 -- Priestess with Eyes of Blue
+57043986 3 -- Blue-Eyes Solid Dragon
+83994433 3 -- Stardust Spark Dragon
+33698022 3 -- Black Rose Moonlight Dragon
+93437091 3 -- Bingo Machine, Go!!!
+6853254 3 -- Return of the Dragon Lords
+18144506 1 -- Harpie's Feather Duster
+81439173 1 -- Foolish Burial
+27243130 3 -- Forbidden Lance
+51405049 3 -- Where Arf Thou?
+36975314 3 -- Crackdown
+77538567 3 -- Dark Bribe
+#CR01-AE
+9742784 3 -- Jet Synchron
+53855409 3 -- Doppelwarrior
+62125438 3 -- Synchron Carrier
+11069680 3 -- Junk Converter
+63977008 3 -- Junk Synchron
+71971554 3 -- Road Synchron
+50091196 3 -- Formula Synchron
+60800381 3 -- Junk Warrior
+286392 3 -- Jet Warrior
+37675907 3 -- Accel Synchron
+2322421 3 -- Road Warrior
+44508094 3 -- Stardust Dragon
+30983281 3 -- Accel Synchro Stardust Dragon
+24696097 3 -- Shooting Star Dragon
+21123811 3 -- Cosmic Blazar Dragon
+32441317 3 -- De-Synchro
+96363153 3 -- Tuning
+98427577 3 -- Scrap-Iron Scarecrow
+81823360 3 -- Megalosmasher X
+6631034 3 -- Frostosaurus
+98022050 3 -- Animadorned Archosaur
+36042004 3 -- Babycerasaurus
+82946847 3 -- Petiteranodon
+80280944 3 -- Giant Rex
+38572779 3 -- Miscellaneousaurus
+44335251 3 -- Souleating Oviraptor
+41782653 3 -- Overtex Qoatlus
+18940556 3 -- Ultimate Conductor Tyranno
+38179121 3 -- Double Evolution Pill
+17228908 3 -- Lost World
+44612603 3 -- Survival's End
+25533642 3 -- Altergeist Meluseek
+57769391 3 -- Altergeist Pixiel
+89538537 3 -- Altergeist Silquitous
+12977245 3 -- Altergeist Fifinellag
+42790071 3 -- Altergeist Multifaker
+53143898 3 -- Altergeist Marionetter
+52927340 3 -- Altergeist Kunquery
+21187631 3 -- Altergeist Dragvirion
+1508649 3 -- Altergeist Hexstia
+76685519 3 -- Altergeist Kidolga
+93503294 3 -- Altergeist Primebanshee
+80143954 3 -- Altergeist Camouflage
+27541563 3 -- Altergeist Protocol
+53936268 3 -- Personal Spoofing
+35146019 3 -- Altergeist Manifestation
+86885905 3 -- Altergeist Emulatelf
+2547033 3 -- Altergeist Haunted Rock
+98753320 3 -- Altergeist Failover
+56099748 3 -- Visas Starfrost
+21570001 3 -- Clear New World
+7436169 3 -- Trivikarma
+83488497 3 -- Scareclaw Astra
+19882096 3 -- Scareclaw Belone
+46877100 3 -- Scareclaw Acro
+82361809 3 -- Scareclaw Reichheart
+59120809 3 -- Scareclaw Tri-Heart
+53776969 3 -- Scareclaw Light-Heart
+56063182 3 -- Primitive Planet Reichphobia
+83558891 3 -- Scareclaw Arrival
+41619242 3 -- Scareclaw Straddle
+32152870 3 -- Scareclaw Decline
+7236721 3 -- Scareclaw Defanging
+79552283 3 -- Scareclaw Sclash
+5941982 3 -- Scareclaw Alternative
+95245571 3 -- Scareclaw Twinsaw
+71277255 3 -- Mannadium Riumheart
+17272964 3 -- Mannadium Fearless
+44760562 3 -- Mannadium Meek
+90465153 3 -- Mannadium Prime-Heart
+19671433 3 -- Mannadium Imaginings
+45065541 3 -- Mannadium Abscission
+82460246 3 -- Peaceful Planet Calarium
+71164684 3 -- Mannadium Breakheart
+18158393 3 -- Mannadium Reframing
+81570454 3 -- Infernoble Knight - Roland
+56824871 3 -- Infernoble Knight - Renaud
+95953557 3 -- Infernoble Knight Astolfo
+21351206 3 -- Infernoble Knight Ogier
+58346901 3 -- Infernoble Knight Oliver
+94730900 3 -- Infernoble Knight Maugis
+40251688 3 -- Infernoble Knight Captain Roland
+77656797 3 -- Infernoble Knight Emperor Charles
+65398390 3 -- Infernoble Knight Captain Oliver
+37478723 3 -- "Infernoble Arms - Durendal"
+64867422 3 -- "Infernoble Arms - Hauteclere"
+90861137 3 -- "Infernoble Arms - Joyeuse"
+55749927 3 -- Horn of Olifant
+70155677 3 -- Dreaming Nemleria
+17550376 3 -- Nemleria Dream Defender - Oreiller
+43944080 3 -- Nemleria Dream Defender - Couette
+18458255 3 -- Dream Tower of Princess Nemleria
+44843954 3 -- Sweet Dreams, Nemleria
+13046291 3 -- Evoltile Megachirella
+28877602 3 -- Evoltile Odonto
+88095331 3 -- Evoltile Najasho
+91903221 3 -- Evoltile Elginero
+81873903 3 -- Evoltile Westlo
+56240989 3 -- Evoltile Casinerio
+54266211 3 -- Evolsaur Vulcano
+17045014 3 -- Evolsaur Diplo
+23234094 3 -- Evolsaur Elias
+74294676 3 -- Evolzar Laggia
+42752141 3 -- Evolzar Dolkka
+18511599 3 -- Evolzar Solda
+5338223 3 -- Evo-Force
+88760522 3 -- Evo-Diversity
+93504463 3 -- Evolutionary Bridge
+24362891 3 -- Evo-Instant
+74100225 3 -- Evo-Singularity
+26236560 3 -- Unchained Twins - Aruha
+53624265 3 -- Unchained Twins - Rakea
+31588572 3 -- Unchained Twins - Sarama
+89019964 3 -- Unchained Soul of Disaster
+1966438 3 -- Abominable Unchained Soul
+67680512 3 -- Unchained Soul of Rage
+93084621 3 -- Unchained Soul of Anguish
+29479265 3 -- Unchained Abomination
+27412542 3 -- Abomination's Prison
+54807656 3 -- Wailing of the Unchained Souls
+53417695 3 -- Escape of the Unchained
+80801743 3 -- Abominable Chamber of the Unchained
+29537493 3 -- Ursarctic Mikpolar
+55936191 3 -- Ursarctic Miktanus
+81321206 3 -- Ursarctic Mikbilis
+28715905 3 -- Ursarctic Megapolar
+54700519 3 -- Ursarctic Megatanus
+81108658 3 -- Ursarctic Megabilis
+27693363 3 -- Ursarctic Polari
+53087962 3 -- Ursarctic Septentrion
+80086070 3 -- Ursarctic Grand Chariot
+16471775 3 -- Ursarctic Departure
+53865474 3 -- Ursarctic Slider
+89264428 3 -- Ursarctic Big Dipper
+32692693 3 -- Ursarctic Radiation
+15758127 3 -- Ursarctic Quint Charge
+49131917 3 -- Shinonome the Vaylantz Priestess
+15130912 3 -- Saion the Vaylantz Archer
+41525660 3 -- Nazuki the Vaylantz Ninja
+88919365 3 -- Hojo the Vaylantz Warrior
+14418464 3 -- Vaylantz Buster Baron
+41802073 3 -- Vaylantz Voltage Viscount
+87897777 3 -- Vaylantz Mad Marquess
+13291886 3 -- Vaylantz Dominator Duke
+40680521 3 -- Mamonaka the Vaylantz United
+76075139 3 -- Vaylantz Genesis Grand Duke
+13179234 3 -- Vaylantz Wars - The Place of Beginning
+49568943 3 -- Vaylantz World - Shinra Bansho
+75952542 3 -- Vaylantz World - Konig Wissen
+60095092 3 -- Vaylantz Wakening - Solo Activation
+63394872 3 -- Senet Switch
+92107604 1 -- Runick Fountain
+29595202 3 -- Runick Allure
+31562086 3 -- Runick Tip
+68957034 3 -- Runick Flashing Fire
+94445733 3 -- Runick Destruction
+30430448 3 -- Runick Freezing Curses
+67835547 3 -- Runick Slumber
+93229151 3 -- Runick Smiting Storm
+20618850 3 -- Runick Golden Droplet
+66712905 3 -- Runick Dispelling
+55990317 3 -- Hugin the Runick Wings
+92385016 3 -- Munin the Runick Wings
+28373620 3 -- Geri the Runick Fangs
+38339996 3 -- Rescue-ACE Impulse
+65734501 3 -- Rescue-ACE Air Lifter
+91222209 3 -- Rescue-ACE Monitor
+37617348 3 -- Rescue-ACE Hydrant
+64612053 3 -- Rescue-ACE Fire Attacker
+90000652 3 -- Rescue-ACE Fire Engine
+37495766 3 -- Rescue-ACE Turbulence
+63899465 3 -- Rescue-ACE HQ
+99984170 3 -- RESCUE!
+26372118 3 -- ALERT!
+62777823 3 -- CONTAIN!
+99162522 3 -- EXTINGUISH!
+25550531 3 -- Purrely
+52645235 3 -- Epurrely Happiness
+98049934 3 -- Epurrely Beauty
+24434049 3 -- Epurrely Plump
+51822687 3 -- Expurrely Happiness
+83827392 3 -- Expurrely Noir
+20212491 3 -- Stray Purrely Street
+56700100 3 -- My Friend Purrely
+82105704 3 -- Purrely Happy Memory
+29599813 3 -- Purrely Pretty Memory
+55584558 3 -- Purrely Delicious Memory
+82983267 3 -- Purrelyeap!?
+18377261 3 -- Ha-Re the Sword Mikanko
+54862960 3 -- Ni-Ni the Mirror Mikanko
+81260679 3 -- Ohime the Manifested Mikanko
+17255673 3 -- Heavenly Gate of the Mikanko
+44649322 3 -- The Great Mikanko Ceremony
+80044027 3 -- Mikanko Fire Dance
+16433136 3 -- Mikanko Purification Dance
+43527730 3 -- Mikanko Water Arabesque
+79912449 3 -- Mikanko Reflection Rondo
+16310544 3 -- Mikanko Kagura
+42705243 3 -- Mikanko Promise
+78199891 3 -- Mikanko Rivalry
+#DUNE-AE
+15845914 3 -- Magicians of Bonds and Unity
+60283232 3 -- Wheel Synchron
+97682931 3 -- Revolution Synchron
+23076639 3 -- Gazelle the King of Mythical Claws
+55461744 3 -- Big-Winged Berfomet
+92565383 3 -- Cornfield Coatl
+28954097 3 -- Mirror Swordknight
+55349196 3 -- Double-Headed Dino King Rex
+81743801 3 -- Mighty Dino King Rex
+27132400 3 -- Altergeist Malwisp
+54126514 3 -- Altergeist Peritrator
+80621253 3 -- Mannadium Torrid
+27015862 3 -- Veda Kalanta
+53404966 3 -- Infernoble Knight Ricciardetto
+89809665 3 -- Infernoble Knight Turpin
+16893370 3 -- Dreaming Reality of Nemleria, Realized
+52382379 3 -- Nemleria Dream Devourer - Reveil
+89776023 3 -- Evoltile Pholis
+15171722 3 -- Evolsaur Lios
+41165831 3 -- Unchained Soul of Sharvara
+88554436 3 -- Unchained Soul of Shyama
+14959144 3 -- Ultimate Bright Knight Ursatron Alpha
+41443249 3 -- Rescue-ACE Preventer
+77832858 3 -- Thestalos the Shadowfire Monarch
+13836592 3 -- Behemoth the King of a Hundred Battles
+40221691 3 -- Nightmare Magician
+76615300 3 -- Hiita the Fire Channeler
+13014905 3 -- Agnimal Candle
+49109013 3 -- Doomstar Ulka
+76593718 3 -- Greed Jar
+2992467 3 -- Click & Echo
+48386462 3 -- The Cuckoo Commanded to Croon
+75771170 3 -- Arahime the Manifested Mikanko
+1769875 3 -- Chimera the King of Phantom Beasts
+38264974 3 -- Chimera the Illusion Beast
+74659582 3 -- Sleipnir the Runick Mane
+43227 3 -- Magnum the Reliever
+37442336 3 -- Cosmic Quasar Dragon
+63436931 3 -- Crimson Dragon
+821049 3 -- Visas Amritara
+36320744 3 -- Angelica, Princess of Noble Arms
+62714453 3 -- Ursarctic Polar Star
+9709452 3 -- Gaia Blaze, the Force of the Sun
+35103106 3 -- Evolzar Lars
+62592805 3 -- Epurrely Noir
+98986900 3 -- Thelematech Clatis
+34481518 3 -- Grenosaurus Giga-Cannon
+61470213 3 -- Altergeist Adminia
+97864322 3 -- Emperor Charles the Great
+24269961 3 -- Unchained Soul Lord of Yama
+653675 3 -- Synchro Overtop
+36742774 3 -- Synchro World
+63136489 3 -- Chimera Fusion
+99531088 3 -- Jurassic Power
+36920182 3 -- Realm Resonance
+62314831 3 -- New World - Amritara
+98319530 3 -- "Infernoble Arms - Almace"
+25807544 3 -- Noble Arms Museum
+61292243 3 -- EMERGENCY!
+98696958 3 -- Dark Corridor
+24081957 3 -- Sinful Spoils of Subversion - Snake-Eye
+61070601 3 -- Fusion Armament
+97474300 3 -- Duelist Genesis
+23969415 3 -- Beta Evolution Pill - Ultranscendance
+50357013 3 -- Tokusano Shinkyojin
+96352712 3 -- Overexaggeration
+23746827 3 -- Million-Century Ice Prison
+59131526 3 -- Aqua Chorus Round
+85520170 3 -- Scrap-Iron Sacred Statue
+22024279 3 -- Altergeist Revitalization
+58019984 3 -- New World Formation
+85407683 3 -- New World Stars
+11802691 3 -- The Continuing Epic of Charles
+57296396 3 -- Nemleria Louve
+84281045 3 -- Vaylantz Wave - Master Phase
+10780049 3 -- Purrely Sharely!?
+53174748 3 -- Mikanko Spiritwalk
+89569453 3 -- Banishing Trap Hole
+15967552 3 -- Small Scuffle
+42952160 3 -- Split Mirror of the Underworld
+88346805 3 -- You're Finished
+77207191 3 -- Berfomet
+68543408 3 -- Stardust Xiaolong
+60071928 3 -- Righty Driver
+23571046 3 -- Quillbolt Hedgehog
+44935634 3 -- Lefty Driver
+25148255 3 -- Junk Anchor
+57458399 3 -- Satellite Synchron
+83295594 3 -- Steam Synchron
+37799519 3 -- Stardust Synchron
+63184227 3 -- Stardust Trail
+59185998 3 -- Altergeist Pookuery
+85673903 3 -- Altergeist Fijialert
+91479482 3 -- Courageous Crimson Chevalier Bradamante
+80651316 3 -- Evolsaur Cerato
+79933029 3 -- Purrelyly
+6327734 3 -- Hu-Li the Jewel Mikanko
+5852388 3 -- Xeno Meteorus
+31241087 3 -- Transcendosaurus Meteorus
+4796100 3 -- Chimera the Flying Mythical Beast
+47219274 3 -- Freki the Runick Fangs
+50687050 3 -- Arktos XII - Chronochasm Vaylantz
+67745632 3 -- Transcendosaurus Gigantozowler
+84664085 3 -- Satellite Warrior
+35952884 3 -- Shooting Quasar Dragon
+94130731 3 -- Transcendosaurus Glaciasaurus
+30128445 3 -- Transcendosaurus Drillygnathus
+23790299 3 -- Altergeist Memorygant
+26194151 3 -- Necroid Synchro
+37750912 3 -- Stardust Illumination
+31006879 3 -- On Your Mark, Get Set, DUEL!
+14154221 3 -- Evo-Price
+21347668 3 -- Purrely Sleepy Memory
+57736667 3 -- Mikanko Dance - Mayowashidori
+67523044 3 -- Ground Xeno
+50947142 3 -- Scrap-Iron Signal
+71948047 3 -- REINFORCE!
+93918159 3 -- Supersoaring
+#24AT-AE1
+87188910 3 -- Ravenous Crocodragon Archethys
+63845230 3 -- Eater of Millions
+00581014 3 -- Daigusto Emeral
+46457856 3 -- Tomozaurus
+92676637 3 -- Tuningware
+80457744 3 -- Boost Warrior
+98978921 3 -- Link Spider
+84808313 3 -- Big Evolution Pill
+79816536 3 -- Summoner's Art
+19578592 3 -- Axe of Fools
+88616795 3 -- Spellbook of Wisdom
+51412776 3 -- Heritage of the Chalice
+19508728 3 -- Moon Mirror Shield
+23442438 3 -- Synchro Chase
+23869735 3 -- Fossil Excavation
+30459350 3 -- Imperial Iron Wall
+#RC04-AE
+48686504 3 -- Lonefire Blossom
+97268402 3 -- Effect Veiler
+18094166 3 -- Vision HERO Faris
+23434538 2 -- Maxx "C"
+10802915 3 -- Tour Guide From the Underworld
+34267821 3 -- Artifact Lancea
+10000080 3 -- The Winged Dragon of Ra - Sphere Mode
+14558127 2 -- Ash Blossom & Joyous Spring
+86937530 3 -- Fairy Tail - Luna
+15397015 3 -- Inspector Boarder
+73642296 3 -- Ghost Belle & Haunted Mansion
+81470373 3 -- Blackwing - Simoon the Poison Wind
+43694650 3 -- Danger!? Jackalope?
+91800273 1 -- Dimension Shifter
+27204311 3 -- Nibiru, the Primal Being
+64202399 3 -- Blue-Eyes Abyss Dragon
+62968263 3 -- Galaxy-Eyes Afterglow Dragon
+86395581 3 -- Wynn the Wind Channeler
+95440946 3 -- Eldlich the Golden Lord
+60303688 3 -- Dogmatika Ecclesia, the Virtuous
+68468459 3 -- Fallen of Albaz
+73304257 3 -- Alpha, the Master of Beasts
+62849088 3 -- The Iris Swordsoul
+77235086 3 -- Cyber Angel Benten
+58481572 3 -- Masked HERO Dark Law
+80532587 3 -- Elder Entity N'tss
+69946549 3 -- Predaplant Dragostapelia
+54757758 3 -- Mudragon of the Swamp
+42166000 3 -- Egyptian God Slime
+25862681 3 -- Ancient Fairy Dragon
+79606837 1 -- Herald of the Arc Light
+77075360 3 -- Junk Speeder
+27548199 3 -- Borreload Savage Dragon
+84815190 3 -- Baronne de Fleur
+72167543 3 -- Downerd Magician
+53334641 3 -- Ghostrick Angel of Mischief
+39030163 3 -- Galaxy-Eyes Full Armor Photon Dragon
+44405066 3 -- Red-Eyes Flare Metal Dragon
+57314798 3 -- Number 100: Numeron Dragon
+93854893 3 -- Dingirsu, the Orcust of the Evening Star
+55285840 3 -- Time Thief Redoer
+58699500 3 -- Cherubini, Ebon Angel of the Burning Abyss
+38342335 3 -- Knightmare Unicorn
+21887175 3 -- Mekk-Knight Crusadia Avramax
+45462149 3 -- Code Talker Inverted
+73539069 3 -- Striker Dragon
+45819647 3 -- Selene, Queen of the Master Magicians
+61245672 3 -- Decode Talker Heatsoul
+34755994 3 -- Artemis, the Magistus Moon Maiden
+47325505 3 -- Fossil Dig
+46448938 3 -- Spellbook of Judgment
+13048472 1 -- Pre-Preparation of Rites
+35261759 3 -- Pot of Desires
+24224830 2 -- Called by the Grave
+11827244 3 -- Magicalized Fusion
+49238328 2 -- Pot of Extravagance
+54693926 3 -- Dark Ruler No More
+14532163 3 -- Lightning Storm
+1984618 3 -- Nadir Servant
+25311006 3 -- Triple Tactics Talent
+24299458 3 -- Forbidden Droplet
+99266988 3 -- Chaos Space
+84211599 2 -- Pot of Prosperity
+89558743 3 -- Small World
+95477924 3 -- Magician's Salvation
+23516703 0 -- Summon Limit
+34293667 3 -- Ice Barrier
+83326048 3 -- Dimensional Barrier
+87639778 3 -- Harpie's Feather Storm
+15693423 3 -- Evenly Matched
+10045474 3 -- Infinite Impermanence
+82956214 3 -- Dogmatika Punishment
+21011044 3 -- Shaddoll Schism
+20899496 3 -- Ice Dragon's Prison
+40975243 3 -- Tri-Brigade Revolt
+#CR02-AE
+76794549 3 -- Astrograph Sorcerer
+12289247 3 -- Chronograph Sorcerer
+96227613 3 -- Supreme King Gate Zero
+22211622 3 -- Supreme King Gate Infinity
+69610326 3 -- Supreme King Dragon Darkwurm
+96733134 3 -- Supreme King Dragon Odd-Eyes
+43387895 3 -- Supreme King Dragon Starving Venom
+70771599 3 -- Supreme King Dragon Clear Wing
+42160203 3 -- Supreme King Dragon Dark Rebellion
+86238081 3 -- Odd-Eyes Raging Dragon
+74850403 3 -- Star Pendulumgraph
+1344018 3 -- Time Pendulumgraph
+84869738 3 -- Supreme Rage
+92428405 3 -- Soul of the Supreme King
+94415058 3 -- Stargazer Magician
+20409757 3 -- Timegazer Magician
+54941203 3 -- Tuning Magician
+80335817 3 -- Timebreaker Magician
+72714461 3 -- Wisdom-Eye Magician
+73941492 3 -- Harmonizing Magician
+49684352 3 -- Double Iris Magician
+75672051 3 -- Black Fang Magician
+11067666 3 -- White Wing Magician
+48461764 3 -- Purple Poison Magician
+47349116 3 -- Timestar Magician
+67865534 3 -- Magician of Hope
+22125101 3 -- Beyond the Pendulum
+14105623 3 -- Odd-Eyes Arc Pendulum Dragon
+16178681 3 -- Odd-Eyes Pendulum Dragon
+53025096 3 -- Odd-Eyes Dragon
+85497611 3 -- Odd-Eyes Wizard Dragon
+67754901 3 -- Odd-Eyes Mirage Dragon
+21250202 3 -- Odd-Eyes Persona Dragon
+93149655 3 -- Odd-Eyes Phantom Dragon
+16306932 3 -- Odd-Eyes Revolution Dragon
+23851033 3 -- Odd-Eyes Gravity Dragon
+66425726 3 -- Odd-Eyes Pendulumgraph Dragon
+1516510 3 -- Rune-Eyes Pendulum Dragon
+88305705 3 -- Brave-Eyes Pendulum Dragon
+72378329 3 -- Beast-Eyes Pendulum Dragon
+53262004 3 -- Odd-Eyes Vortex Dragon
+80696379 3 -- Odd-Eyes Meteorburst Dragon
+16691074 3 -- Odd-Eyes Absolute Dragon
+27813661 3 -- Sky Iris
+82768499 3 -- Spiral Flame Strike
+16494704 3 -- Odd-Eyes Advent
+53208660 3 -- Pendulum Call
+64910482 3 -- T.G. Cyber Magician
+48633301 3 -- T.G. Booster Raptor
+74627016 3 -- T.G. Tank Grub
+94350039 3 -- T.G. Gear Zombie
+30348744 3 -- T.G. Drill Fish
+1315120 3 -- T.G. Striker
+64898834 3 -- T.G. Catapult Dragon
+66733743 3 -- T.G. Metal Skeleton
+37300735 3 -- T.G. Jet Falcon
+293542 3 -- T.G. Warwolf
+36687247 3 -- T.G. Rush Rhino
+11234702 3 -- T.G. Screw Serpent
+62560742 3 -- T.G. Recipro Dragonfly
+98558751 3 -- T.G. Wonder Magician
+24943456 3 -- T.G. Power Gladiator
+90953320 3 -- T.G. Hyper Librarian
+99937842 3 -- T.G. Star Guardian
+51447164 3 -- T.G. Blade Blaster
+63180841 3 -- Shooting Star Dragon T.G. EX
+97836203 3 -- T.G. Halberd Cannon
+50750868 3 -- T.G. Trident Launcher
+11264180 3 -- TGX1-HL
+58258899 3 -- TGX300
+3868277 3 -- TGX3-DX2
+40253382 3 -- TG-SX1
+76641981 3 -- TG1-EM1
+61380658 3 -- Watthopper
+46897277 3 -- Wattfox
+18407024 3 -- Wattbetta
+45801022 3 -- Wattlemur
+97885363 3 -- Wattdragonfly
+12296376 3 -- Wattwoodpecker
+24996659 3 -- Wattkiwi
+23274061 3 -- Wattsquirrel
+5554990 3 -- Wattberyx
+32548609 3 -- Wattmole
+402568 3 -- Wattgiraffe
+81896771 3 -- Wattpheasant
+88205593 3 -- Wattcobra
+2772236 3 -- Wattchimera
+29765339 3 -- Watthydra
+65612454 3 -- Wattcube
+1834107 3 -- Wattcine
+58924378 3 -- Wattcastle
+84428023 3 -- Wattjustment
+53193261 3 -- Wattkey
+56577312 3 -- Wattrain
+95084054 3 -- Wattcannon
+32061744 3 -- Wattkeeper
+56993276 3 -- Wattcancel
+36010310 3 -- Nunu, the Ogdoadic Remnant
+62405028 3 -- Nauya, the Ogdoadic Remnant
+9400127 3 -- Flogos, the Ogdoadic Boundless
+35998832 3 -- Zohah, the Ogdoadic Boundless
+62383431 3 -- Keurse, the Ogdoadic Light
+98787535 3 -- Aleirtt, the Ogdoadic Dark
+34172284 3 -- Aron, the Ogdoadic King
+61160289 3 -- Amunessia, the Ogdoadic Queen
+97565997 3 -- Ogdoabyss, the Ogdoadic Overlord
+24050692 3 -- Ogdoadic Water Lily
+60448701 3 -- Ogdoadic Origin
+96203584 3 -- Ogdoadic Serpent Strike
+96433300 3 -- Ogdoadic Hollow
+23837054 3 -- Ogdoadic Calling
+2511 3 -- Labrynth Cooclock
+74018812 3 -- Labrynth Stovie Torbie
+37629703 3 -- Labrynth Chandraglier
+75730490 3 -- Ariane the Labrynth Servant
+1225009 3 -- Arianna the Labrynth Servant
+48745395 3 -- Labrynth Archfiend
+2347656 3 -- Lovely Labrynth of the Silver Castle
+81497285 3 -- Lady Labrynth of the Silver Castle
+33407125 3 -- Labrynth Labyrinth
+69895264 3 -- Labrynth Set-Up
+5380979 3 -- Welcome Labrynth
+32785578 3 -- Farewelcome Labrynth
+68779682 3 -- Labrynth Barrage
+92714517 3 -- Big Welcome Labrynth
+29302858 2 -- Vanquish Soul Razen
+66401502 3 -- Vanquish Soul Pantera
+92895501 3 -- Vanquish Soul Heavy Borger
+29280200 3 -- Vanquish Soul Dr. Mad Love
+55688914 3 -- Vanquish Soul Pluton HG
+91073013 3 -- Vanquish Soul Caesar Valius
+28168628 3 -- Rock of the Vanquisher
+54562327 3 -- Stake your Soul!
+91951471 3 -- Vanquish Soul Dust Devil
+27345070 3 -- Vanquish Soul - Continue?
+53330789 3 -- Vanquish Soul Trinity Burst
+80738884 3 -- Vanquish Soul Calamity Caesar
+26223582 3 -- Buerillabaisse de Nouvelles
+53618197 3 -- Confiras de Nouvelles
+89016236 3 -- Poeltis de Nouvelles
+15001940 3 -- Foie Glasya de Nouvelles
+52495649 3 -- Balameuniere de Nouvelles
+88890658 3 -- Baelgrill de Nouvelles
+15388353 3 -- Nouvelles Restaurant "At Table"
+41773061 3 -- Voici la Carte (Today's Menu)
+87778106 3 -- Recette de Poisson (Fish Recipe)
+14166715 3 -- Recette de Viande (Meat Recipe)
+40551410 3 -- Recette de Personnel (Staff Recipe)
+87955518 3 -- Chef's Special Recipe
+46939151 3 -- Earthbound Prisoner Ground Keeper
+72323266 3 -- Earthbound Prisoner Stone Sweeper
+19322865 3 -- Earthbound Prisoner Line Walker
+45716579 3 -- Earthbound Servant Geo Kraken
+71101678 3 -- Earthbound Servant Geo Grasha
+8690387 3 -- Earthbound Servant Geo Gremlin
+44094981 3 -- Earthbound Servant Geo Gryphon
+71089030 3 -- Earthbound Prison
+7473735 3 -- Harmonic Synchro Fusion
+33365932 3 -- Volcanic Shell
+69750546 3 -- Volcanic Scattershot
+81020140 3 -- Volcanic Blaster
+66436257 3 -- Volcanic Counter
+17415895 3 -- Volcanic Slicer
+76459806 3 -- Volcanic Rocket
+54514594 3 -- Volcanic Hammerer
+63014935 3 -- Volcanic Queen
+32543380 3 -- Volcanic Doomfire
+69537999 3 -- Blaze Accelerator
+95026693 3 -- Soul of Fire
+21420702 3 -- Tri-Blaze Accelerator
+68815401 3 -- Wild Fire
+33725271 3 -- Volcanic Recharge
+52198054 3 -- Blaze Accelerator Reload
+94046012 3 -- Orcust Brass Bombard
+21441617 3 -- Orcust Cymbal Skeleton
+57835716 3 -- Orcust Harp Horror
+93920420 3 -- World Legacy - "World Wand"
+4055337 3 -- Orcust Knightmare
+69811710 3 -- Girsu, the Orcust Mekk-Knight
+30741503 3 -- Galatea, the Orcust Automaton
+76145142 3 -- Longirsu, the Orcust Orchestrator
+3134857 3 -- Orcustrion
+90351981 3 -- Orcustrated Babel
+26845680 3 -- Orcustrated Return
+62834295 3 -- Orcustrated Einsatz
+29666221 3 -- Orcustrated Attack
+55051920 3 -- Orcustrated Core
+47171541 3 -- Orcustrated Release
+703897 3 -- Orcust Crescendo
+74889525 3 -- Eldlich the Mad Golden Lord
+31434645 3 -- Cursed Eldland
+68829754 3 -- Eldlixir of Black Awakening
+94224458 3 -- Eldlixir of White Destiny
+95034141 3 -- Seven Cities of the Golden Land
+20612097 3 -- Eldlixir of Scarlet Sanguine
+67007102 3 -- Guardian of the Golden Land
+93191801 3 -- Huaquero of the Golden Land
+20590515 3 -- Conquistador of the Golden Land
+56984514 3 -- Golden Land Forever!
+92379223 3 -- El Dorado Adelantado
+#AGOV-AE
+14513273 3 -- Supreme King Gate Magician
+41908872 3 -- Supreme King Dragon Lightwurm
+77392987 3 -- T.G. Rocket Salamander
+14391625 3 -- Visas Samsara
+40785230 3 -- Veda Kalarcanum
+72270339 1 -- Diabellstar the Black Witch
+9674034 1 -- Snake-Eye Ash
+45663742 3 -- Snake-Eye Oak
+12058741 3 -- Snake-Eye Birch
+48452496 3 -- Snake-Eyes Flamberge Dragon
+84941194 3 -- Imsety, Glory of Horus
+11335209 3 -- Duamutef, Blessing of Horus
+47330808 3 -- Hapi, Guidance of Horus
+74725513 3 -- Qebehsenuef, Protection of Horus
+10113611 3 -- Wattuna
+46518210 3 -- Nephilabyss, the Ogdoadic Overlord
+73602965 3 -- Arias the Labrynth Butler
+9091064 3 -- Vanquish Soul Jiaolong
+46485778 3 -- Poissonniere de Nouvelles
+72880377 3 -- Dark Hole Dragon
+9275482 3 -- UFOLight
+35263180 3 -- Seed-Spitting Saplings
+71768839 3 -- I.A.S. -Invasive Alien Species-
+8152834 3 -- Tarai
+34541543 3 -- Master Tao the Chanter
+71545247 3 -- Cursed Bride Doll
+7930346 3 -- Origami Goddess
+33325951 3 -- Shinobaroness Shade Peacock
+60823690 3 -- Shinobaron Shade Peacock
+6218704 3 -- Odd-Eyes Arcray Dragon
+33202303 3 -- Earthbound Servant Geo Gremlina
+69601012 3 -- Berfomet the Mythical King of Phantom Beasts
+95095116 3 -- Gaia Prominence, the Fierce Force
+32480825 3 -- T.G. Mighty Striker
+68989420 3 -- T.G. Over Dragonar
+95973569 3 -- T.G. Glaive Blaster
+21368273 3 -- Mannadium Trisukta
+67752972 3 -- Wattkyuki
+94151981 3 -- Xyz Armor Torpedo
+20145685 3 -- Xyz Armor Fortress
+67630394 3 -- Full Armored Dark Knight Lancer
+93039339 3 -- Super Starslayer TY-PHON - Sky Crisis
+29423048 3 -- Infernal Flame Banshee
+56818742 3 -- Transcendosaurus Exaraptor
+92812851 3 -- Exceed the Pendulum
+29301450 3 -- S:P Little Knight
+55795155 3 -- Pendulum Evolution
+82190203 3 -- Wings of Light
+28189908 3 -- T.G. Limiter Removal
+54573517 3 -- T.G. All Clear
+81978611 3 -- Xyz Entrust
+17462320 3 -- Realm Elegy
+54851325 3 -- Realm Eulogy
+80845034 1 -- WANTED: Seeker of Sinful Spoils
+16240772 3 -- Sinful Spoils of Doom - Rciela
+53639887 3 -- Divine Temple of the Snake-Eye
+89023486 3 -- Original Sinful Spoils - Snake-Eye
+16528181 3 -- King's Sarcophagus
+42516299 3 -- Fire Recovery
+88901994 3 -- Synchro Rumble
+15306543 3 -- Stars Align Above the Shrine
+41790641 3 -- Wattkingdom
+78789356 3 -- Ogdoadic Daybreak
+14283055 3 -- Concours de Cuisine (Culinary Confrontation)
+40678060 3 -- Angelica's Angelic Ring
+77066768 3 -- Card Scanner
+3461403 3 -- The Immortal Bushi Mourns the Mortal Body
+40456412 3 -- Miracle of the Supreme King
+76840111 3 -- Soul of the Supreme Celestial King
+2339825 3 -- T.G. Close
+39733924 3 -- Full-Armored Xyz
+75728539 3 -- Sharv Sarga
+2116237 3 -- Loka Samsara
+38511382 3 -- Sinful Spoils of Betrayal - Silvera
+74906081 3 -- Startling Stare of the Snake-Eyes
+1490690 3 -- Canopic Protector
+33499794 3 -- Nemleria Repeter
+60883493 3 -- Vanquish Soul Snow Devil
+6278008 3 -- Starry Dragon's Cycle
+33676146 3 -- Escapegoat
+47075569 3 -- Performapal Pendulum Sorcerer
+40318957 3 -- Performapal Skullcrobat Joker
+17330916 3 -- Performapal Monkeyboard
+46136942 3 -- Performapal Odd-Eyes Dissolver
+82224646 3 -- Performapal Odd-Eyes Synchron
+19619755 3 -- Performapal Five-Rainbow Magician
+58092907 3 -- Performapal Celestial Magician
+56677752 3 -- Performapal Odd-Eyes Butler
+82661461 3 -- Performapal Odd-Eyes Valet
+21949879 3 -- Performapal Gentrude
+58938528 3 -- Performapal Ladyange
+92644052 3 -- Performapal Duelist Extraordinaire
+4836680 3 -- Performapal Odd-Eyes Seer
+39817919 3 -- Shinobird Crow
+66815913 3 -- Shinobird Crane
+92200612 3 -- Shinobird Pigeon
+59805313 3 -- Volcanic Rimfire
+22411609 3 -- Volcanic Trooper
+46412900 3 -- Volcanic Emperor
+25415052 3 -- Shinobaroness Peacock
+52900000 3 -- Shinobaron Peacock
+13331639 3 -- Supreme King Z-ARC
+26435595 3 -- Patissciel Couverture
+59123194 3 -- Enlightenment Paladin
+80896940 3 -- Nirvana High Paladin
+77855162 3 -- Tilting Entrainment
+39943352 3 -- Daidaratant the Ooze Giant
+37803970 3 -- Amazing Pendulum
+37469904 3 -- Duelist Alliance
+73055622 3 -- Shinobird's Calling
+9553721 3 -- Shinobird Power Spot
+85250352 3 -- Volcanic Blaze Accelerator
+11654067 3 -- Fire Ejection
+23446369 3 -- Eye of Illusion
+73046708 3 -- Armored Xyz
+276357 3 -- Shinobird Salvation
+20417688 3 -- Stars Align across the Milky Way
+58143766 3 -- Volcanic Emission
+84138874 3 -- Volcanic Inferno
+#CR03-AE
+31034919 3 -- Mad Reloader
+48343627 3 -- Grave Squirmer
+27439792 3 -- Chaos Summoning Beast
+81034083 3 -- Dark Beckoning Beast
+54040484 3 -- Chaos Core
+30312361 3 -- Phantom of Chaos
+12958919 3 -- Phantom Skyblaster
+87917187 3 -- Dark Summoning Beast
+28651380 3 -- Raviel, Lord of Phantasms - Shimmering Scraper
+43378048 3 -- Armityle the Chaos Phantasm
+13301895 3 -- Fallen Paradise
+54828837 3 -- Cerulean Skyfire
+80312545 3 -- Opening of the Spirit Gates
+89190953 3 -- Dimension Fusion Destruction
+16317140 3 -- Hyper Blaze
+53701259 3 -- Awakening of the Sacred Beasts
+46589034 3 -- Raidraptor - Pain Lanius
+97219708 3 -- Raidraptor - Last Strix
+45184165 3 -- Raidraptor - Skull Eagle
+51933043 3 -- Raidraptor - Heel Eagle
+53251824 3 -- Raidraptor - Vanishing Lanius
+60950180 3 -- Raidraptor - Sharp Lanius
+96345188 3 -- Raidraptor - Mimicry Lanius
+83236601 3 -- Raidraptor - Tribute Lanius
+5929801 3 -- Raidraptor - Fuzzy Lanius
+31314549 3 -- Raidraptor - Singing Lanius
+51814159 3 -- Raidraptor - Necro Vulture
+10194329 3 -- Raidraptor - Avenge Vulture
+73977033 3 -- Raidraptor - Booster Strix
+60508057 3 -- Raidraptor - Napalm Dragonius
+6552938 3 -- Raidraptor - Rudder Strix
+87321742 3 -- Raidraptor - Strangle Lanius
+8785161 3 -- Raidraptor - Wild Vulture
+52323874 3 -- Raidraptor - Fiend Eagle
+73887236 3 -- Raidraptor - Rise Falcon
+73347079 3 -- Raidraptor - Force Strix
+96592102 3 -- Raidraptor - Blade Burner Falcon
+45533023 3 -- Raidraptor - Blaze Falcon
+15092394 3 -- Raidraptor - Stranger Falcon
+81927732 3 -- Raidraptor - Revolution Falcon
+79985120 3 -- Raidraptor - Revolution Falcon - Air Raid
+96157835 3 -- Raidraptor - Arsenal Falcon
+23603403 3 -- Raidraptor - Satellite Cannon Falcon
+86221741 3 -- Raidraptor - Ultimate Falcon
+43047672 3 -- Raidraptor - Final Fortress Falcon
+36429703 3 -- Raidraptor - Wise Strix
+8559793 3 -- Raidraptor - Nest
+43476205 3 -- Rank-Up-Magic Revolution Force
+43383478 3 -- Rank-Up-Magic Raptor's Force
+41201386 3 -- Rank-Up-Magic Raid Force
+87609391 3 -- Raptor's Ultimate Mace
+50692511 3 -- Raidraptor - Call
+86196216 3 -- Rank-Up-Magic Doom Double Force
+23581825 3 -- Rank-Up-Magic Soul Shave Force
+58988903 3 -- Rank-Up-Magic Skip Force
+21648584 3 -- Raidraptor - Readiness
+30500113 3 -- Raidraptor - Return
+66994718 3 -- Raptor's Gust
+54423935 3 -- Raidraptor Replica
+32825095 3 -- White Moray
+49930315 3 -- White Stingray
+78229193 3 -- White Aura Dolphin
+63731062 3 -- White Aura Monoceros
+5614808 3 -- White Aura Whale
+89907227 3 -- White Aura Bihamut
+63509474 3 -- Whitefish Salvage
+19885332 3 -- White Mirror
+62487836 3 -- White Howling
+46037983 3 -- Paces, Light of the Ghoti
+73421698 3 -- Shif, Fairy of the Ghoti
+76133574 3 -- Zep, Ruby of the Ghoti
+3137279 3 -- Ixeep, Omen of the Ghoti
+9416697 3 -- Eanoc, Sentry of the Ghoti
+39522887 3 -- Snopios, Shade of the Ghoti
+65910922 3 -- Arionpos, Serpent of the Ghoti
+46815301 3 -- Askaan, the Bicorned Ghoti
+2405631 3 -- Guoglim, Spear of the Ghoti
+72309040 3 -- Ghoti of the Deep Beyond
+8794055 3 -- The Most Distant, Deepest Depths
+45792753 3 -- Ghoti Chain
+38409239 3 -- Ghoti Cosmos
+65898344 3 -- Ghoti Fury
+21452275 3 -- Aroma Jar
+16759958 3 -- Aromaseraphy Angelica
+14169843 3 -- Aromage Laurel
+96789758 3 -- Aromage Jasmine
+22174866 3 -- Aromage Cananga
+58569561 3 -- Aromage Rosemary
+40663548 3 -- Aromage Marjoram
+85967160 3 -- Aromage Bergamot
+38148100 3 -- Aromaseraphy Rosemary
+79656239 3 -- Aromaseraphy Sweet Marjoram
+21200905 3 -- Aromaseraphy Jasmine
+5050644 3 -- Aroma Garden
+29189613 3 -- Aroma Gardening
+92266279 3 -- Humid Winds
+28265983 3 -- Dried Winds
+15177750 3 -- Blessed Winds
+92746535 3 -- Luster Pendulum, the Dracoslayer
+69512157 3 -- Vector Pendulum, the Dracoverlord
+24131534 3 -- Igknight Squire
+61639289 3 -- Igknight Crusader
+97024987 3 -- Igknight Templar
+24019092 3 -- Igknight Paladin
+50407691 3 -- Igknight Margrave
+67273917 3 -- Igknight Cavalier
+96802306 3 -- Igknight Gallant
+93662626 3 -- Igknight Veteran
+23296404 3 -- Igknight Lancer
+59785059 3 -- Igknight Champion
+79555535 3 -- Ignition Phoenix
+76751255 3 -- Igknight Reload
+38848158 3 -- Igknights Unite
+65872270 3 -- Igknight Burst
+18239909 3 -- Ignister Prominence, the Blasting Dracoslayer
+5506791 3 -- Majespecter Cat - Nekomata
+31991800 3 -- Majespecter Raccoon - Bunbuku
+68395509 3 -- Majespecter Crow - Yata
+94784213 3 -- Majespecter Fox - Kyubi
+645794 3 -- Majespecter Toad - Ogama
+31178212 3 -- Majespecter Unicorn - Kirin
+76473843 3 -- Majesty's Pegasus
+13972452 3 -- Majespecter Storm
+49366157 3 -- Majespecter Cyclone
+13611090 3 -- Majespecter Sonics
+36183881 3 -- Majespecter Tornado
+2572890 3 -- Majespecter Tempest
+78949372 3 -- Majespecter Supercell
+5153769 3 -- Majespecter Gust
+88722973 3 -- Majester Paladin, the Ascending Dracoslayer
+1580833 3 -- Dinomist Stegosaur
+38988538 3 -- Dinomist Plesios
+64973287 3 -- Dinomist Pteran
+32134638 3 -- Dinomist Ankylos
+368382 3 -- Dinomist Brachion
+37752990 3 -- Dinomist Ceratops
+63251695 3 -- Dinomist Rex
+5067884 3 -- Dinomist Spinos
+41128647 3 -- Dinomic Powerload
+77116346 3 -- Dinomist Charge
+41554273 3 -- Dinomist Rush
+74582050 3 -- Dinomist Eruption
+60675348 3 -- Dinomists Howling
+22638495 3 -- Dinoster Power, the Mighty Dracoslayer
+34522216 3 -- Amorphage Gluttony
+70917315 3 -- Amorphage Lechery
+7305060 3 -- Amorphage Greed
+33300669 3 -- Amorphage Envy
+79794767 3 -- Amorphage Wrath
+6283472 3 -- Amorphage Pride
+32687071 3 -- Amorphage Sloth
+69072185 3 -- Amorphage Goliath
+23160024 3 -- Amorphous Persona
+50554729 3 -- Amorphage Infection
+47598941 3 -- Amorphage Lysis
+98287529 3 -- Amorphactor Pain, the Imagination Dracoverlord
+75195825 3 -- Master Pendulum, the Dracoslayer
+7127502 3 -- Lector Pendulum, the Dracoverlord
+14733538 3 -- Draco Face-Off
+71734607 3 -- Rikka Petal
+8129306 3 -- Primula the Rikka Fairy
+34614910 3 -- Cyclamen the Rikka Fairy
+132308 3 -- Rikka Princess
+71002019 3 -- Mudan the Rikka Fairy
+7407724 3 -- Erica the Rikka Fairy
+33491462 3 -- Snowdrop the Rikka Fairy
+60880471 3 -- Hellebore the Rikka Fairy
+3828844 3 -- Rikka Queen Strenna
+6284176 3 -- Kanzashi the Rikka Queen
+33779875 3 -- Teardrop the Rikka Queen
+69164989 3 -- Rikka Glamour
+96162588 3 -- Rikka Flurries
+76869711 3 -- Rikka Konkon
+32557233 3 -- Rikka Tranquility
+68941332 3 -- Rikka Sheet
+27520594 3 -- Sunseed Genius Loci
+53618293 3 -- Sunvine Maiden
+30013902 3 -- Sunseed Shadow
+66407907 3 -- Sunseed Twin
+93896655 3 -- Sunavalon Dryas
+39880350 3 -- Sunavalon Dryades
+7984540 3 -- Sunavalon Daphne
+65285459 3 -- Sunavalon Dryanome
+44478599 3 -- Sunavalon Melias
+92770064 3 -- Sunavalon Dryatrentiay
+28168762 3 -- Sunvine Gardna
+65563871 3 -- Sunvine Healer
+91557476 3 -- Sunvine Thrasher
+27946124 3 -- Sunvine Shrine
+70473293 3 -- Sunvine Cross Breed
+53286626 3 -- Sunvine Sowing
+54340229 3 -- Sunavalon Bloom
+#PHNI-AE
+90829280 3 -- Spirit of Yubel
+26913989 3 -- Geistgrinder Golem
+62318994 3 -- Samsara D Lotus
+99707692 3 -- Raidraptor - Noir Lanius
+25191307 3 -- Raidraptor - Bloom Vulture
+52596406 3 -- White Sunfish
+98684051 3 -- White Sardine
+24079759 3 -- Goblin Biker Dugg Charger
+51473858 3 -- Goblin Biker Clatter Sploder
+27868563 3 -- Goblin Biker Boom Mach
+64257161 3 -- Goblin Biker Mean Merciless
+90241276 1 -- Snake-Eyes Poplar
+26746975 3 -- Dark Guardian
+53134520 3 -- Phantasmal Summoning Beast
+99529628 3 -- Keaf, Murk of the Ghoti
+26523337 3 -- Psiics, Moonlight of the Ghoti
+52918032 3 -- Mementotlan Ghattic
+99307040 3 -- Horus the Black Flame Deity
+25801745 3 -- Lo, the Prayers of the Voiceless Voice
+51296484 3 -- Saffira, Dragon Queen of the Voiceless Voice
+88284599 3 -- Sauravis, Dragon Sage of the Voiceless Voice
+24689197 3 -- Aromalilith Rosalina
+51073802 3 -- Majespecter Porcupine - Yamarashi
+87462901 3 -- Emissary from the House of Wax
+13567610 3 -- Carnot the Eternal Machine
+50951254 3 -- Magmacho Dragon
+86346363 3 -- Time Reloader
+13744068 3 -- Berserk Archfiend
+49139666 3 -- E Stranger Big Bang
+85123771 3 -- Goblin Freefall Squad
+12612470 3 -- Procession of the Tea Jar
+48017189 3 -- EM:P Meowmine
+85401123 3 -- Mokomoko
+11496832 3 -- Principug
+47894537 3 -- Jongleur-Ghoul Illusionist
+74289646 3 -- Royal Rhino with Deceitful Dice
+10774240 3 -- Skull Guardian, Protector of the Voiceless Voice
+47172959 3 -- Yubel - The Loving Defender Forever
+73167098 3 -- Aromalilith Magnolia
+9551692 3 -- Master of Ham
+46956301 3 -- White Aura Porpoise
+72444406 3 -- Enigmaster Packbit
+9839115 3 -- Vagnawa the Moon-Eating Dragon
+35834119 3 -- Fish Lamp
+71222868 3 -- Raidraptor - Rising Rebellion Falcon
+8617563 3 -- Raidraptor - Brave Strix
+34001672 3 -- Goblin Biker Big Gabonga
+71100270 3 -- Goblin's Crazy Beast
+3594985 3 -- Majespecter Draco - Ryu
+30989084 3 -- Aromalilith Rosemary
+66384688 3 -- Majespecter Orthrus - Nue
+2772337 3 -- Promethean Princess, Bestower of Flames
+39767432 3 -- Sorcerer of Sebek
+65261141 3 -- Nightmare Pain
+92650749 3 -- Mature Chronicle
+38044854 3 -- Rise Rank-Up-Magic Raidraptor's Force
+64049553 3 -- Raidraptor - Roost
+91434208 3 -- White Reincarnation
+27822206 3 -- Ages of Stars and Frost
+64327901 3 -- Goblin Biker Grand Bash
+90711610 3 -- Goblin Biker Grand Entrance
+26700718 3 -- Dramatic Snake-Eye Chase
+53194323 3 -- Dark Element
+99599062 3 -- Earthbound Fusion
+26984177 3 -- Walls of the Imperial Tomb
+52472775 3 -- Prayers of the Voiceless Voice
+98477480 3 -- Barrier of the Voiceless Voice
+25861589 3 -- Aroma Blend
+51250293 3 -- Majespecter Wind
+88654892 3 -- Mutamorphosis
+24649931 3 -- Materialization
+50134646 3 -- Flock Together
+87532344 3 -- Eternal Favorite
+13927359 3 -- Raidraptor - Glorious Bright
+50311058 3 -- Goblin Biker Grand Stampede
+86310763 3 -- Radiance of the Voiceless Voice
+12804701 3 -- Aroma Healing
+49299410 3 -- The Black Goat Laughs
+85698115 3 -- Terrors of the Afterroot
+12682213 3 -- Iron Thunder
+78371393 3 -- Yubel
+4779091 3 -- Yubel - Terror Incarnate
+31764700 3 -- Yubel - The Ultimate Nightmare
+52159691 3 -- Raider's Wing
+35026117 3 -- Labyrinth Heavy Tank
+62411811 3 -- Shadow Ghoul of the Labyrinth
+56347375 3 -- Ignis Phoenix, the Dracoslayer
+92332424 3 -- Majesty Pegasus, the Dracoslayer
+28720123 3 -- Dinomight Powerload, the Dracoslayer
+11747708 3 -- Spore
+31615285 3 -- Cactus Bouncer
+44928016 3 -- World Carrotweight Champion
+88307361 3 -- Superancient Deepsea King Coelacanth
+89617515 3 -- Lifeless Leaffish
+8576764 3 -- Gluttonous Reptolphin Greethys
+31059809 3 -- Silent Sea Nettle
+3627449 3 -- Skull Guardian
+56350972 3 -- Saffira, Queen of Dragons
+4810828 3 -- Sauravis, the Ancient and Ascended
+60110982 3 -- Armityle the Chaos Phantasm - Phantom of Fury
+8505920 3 -- Gate Guardians Combined
+34904525 3 -- Gate Guardian of Thunder and Wind
+61398234 3 -- Gate Guardian of Wind and Water
+97783338 3 -- Gate Guardian of Water and Thunder
+28781003 3 -- Raider's Knight
+67557908 3 -- Number 4: Stealth Kragen
+94942656 3 -- Stealth Kragen Spawn
+82184400 3 -- Abyss Keeper
+74402414 3 -- Spell Chronicle
+34771947 3 -- Labyrinth Wall Shadow
+60176682 3 -- Double Attack! Wind and Thunder!!
+96661780 3 -- Riryoku Guardian
+43694075 3 -- Novox's Prayer
+80566312 3 -- Hymn of Light
+37626500 3 -- Sprite's Blessing
+71817640 3 -- Dragonic Pendulum
+73244186 3 -- Moray of Avarice
+85106525 1 -- Bonfire
+87091930 3 -- Raider's Unbreakable Mind
+33055499 3 -- Prey of the Jirai Gumo
+#24AT-AE2
+41517789 3 -- Star Eater
+63086455 3 -- Terrors of the Overroot
+52035300 3 -- The Immortal Bushi
+67441435 3 -- Glow-Up Bulb
+1833916 3 -- Heroic Challenger - Thousand Blades
+97273514 3 -- Inzektor Picofalena
+74974229 3 -- Alien Shocktrooper M-Frame
+39996157 3 -- Machine Angel Ritual
+48712195 3 -- Card Trader
+46253216 3 -- Bad Aim
+5168381 3 -- Archfiend's Ghastly Glitch
+11110218 3 -- Terrors of the Underroot
+#CR04-AE
+15180041 3 -- Silent Swordsman
+37267041 3 -- Silent Swordsman LV7
+41175645 3 -- Silent Magician
+19502505 3 -- Silent Paladin
+18563744 3 -- Silent Sword Slash
+44968459 3 -- Silent Burning
+39303359 3 -- Ancient Gear Knight
+18486927 3 -- Ancient Gear Gadget
+60953949 3 -- Ancient Gear Box
+17663375 3 -- Ancient Gear Wyvern
+1953925 3 -- Ancient Gear Engineer
+86321248 3 -- Ancient Gear Gadjiltron Chimera
+81269231 3 -- Ancient Gear Hydra
+50933533 3 -- Ancient Gear Gadjiltron Dragon
+44874522 3 -- Ancient Gear Reactor Dragon
+12652643 3 -- Ultimate Ancient Gear Golem
+37457534 3 -- Ancient Gear Tank
+4446672 3 -- Ancient Gear Explosive
+40830387 3 -- Ancient Gear Fist
+59811955 3 -- Ancient Gear Workshop
+313513 3 -- Spell Gear
+37694547 3 -- Geartown
+44052074 3 -- Ancient Gear Catapult
+70147689 3 -- Ancient Gear Fortress
+41767843 3 -- Score the Melodious Diva
+76990617 3 -- Sonata the Melodious Diva
+40502912 3 -- Aria the Melodious Diva
+16021142 3 -- Canon the Melodious Diva
+42029847 3 -- Serenade the Melodious Diva
+62895219 3 -- Soprano the Melodious Songstress
+43268675 3 -- Opera the Melodious Diva
+79757784 3 -- Tamtam the Melodious Diva
+14763299 3 -- Solo the Melodious Songstress
+79514956 3 -- Elegy the Melodious Diva
+5908650 3 -- Shopina the Melodious Maestra
+3395226 3 -- Mozarta the Melodious Maestra
+57594700 3 -- Schuberta the Melodious Maestra
+84988419 3 -- Bloom Diva the Melodious Choir
+24672164 3 -- Bloom Prima the Melodious Choir
+34974462 3 -- Bloom Harmonist the Melodious Composer
+44256816 3 -- 1st Movement Solo
+11493868 3 -- Fortissimo
+9113513 3 -- Ostinato
+63804637 3 -- Melodious Illusion
+23512906 3 -- Gold Pride - Leon
+96305350 3 -- Gold Pride - Captain Carrie
+92003832 3 -- Gold Pride - Roller Baller
+59900655 3 -- Gold Pride - Nytro Head
+28497830 3 -- Gold Pride - Pin Baller
+22390469 3 -- Gold Pride - Star Leon
+65892585 3 -- Gold Pride - Chariot Carrie
+58884063 3 -- Gold Pride - Nytro Blaster
+95283172 3 -- Gold Pride - The Crowd Goes Wild!
+91286284 3 -- Gold Pride - That Came Out of Nowhere!
+27275398 3 -- Gold Pride - Pedal to the Metal!
+54670997 3 -- Gold Pride - Better Luck Next Time!
+90164606 3 -- Gold Pride - It's Neck and Neck!
+21677871 3 -- Gold Pride - Start Your Engines!
+23288411 3 -- Mementoal Tecuhtlica - Combined Creation
+55272555 3 -- Mementotlan-Horned Dragon
+81677154 3 -- Mementotlan Tatsunootoshigo
+18165869 3 -- Mementotlan Dark Blade
+54550967 3 -- Mementotlan Angwitch
+81945676 3 -- Mementotlan Mace
+17943271 3 -- Mementotlan Goblin
+43338320 3 -- Mementomictlan
+80722024 3 -- Mementotlan Bone Party
+16227633 3 -- Mementotlan Bone Back
+43215738 3 -- Mementotlan Fracture Dance
+79600447 3 -- Mementotlan Cranium Burst
+15005145 3 -- Centur-Ion Primera
+42493140 3 -- Centur-Ion Trudea
+78888899 3 -- Centur-Ion Emeth VI
+15982593 3 -- Centur-Ion Legatia
+41371602 3 -- Stand Up Centur-Ion!
+77765207 3 -- Emblema Oath
+4160316 3 -- Centur-Ion Bonds
+40155014 3 -- Centur-Ion Phalanx
+77543769 3 -- Centur-Ion True Awakening
+3048768 3 -- Angello Vaalmonica
+30432463 3 -- Dimonno Vaalmonica
+76821171 3 -- Duralume, Vaalmonican Heathen Hallow
+2815176 3 -- Zebufera, Vaalmonican Hallow Heathen
+39210885 3 -- Vaalmonica, the Agathokakological Voice
+5605529 3 -- Vaalmonica Scelta
+42193638 3 -- Vaalmonica Versare
+78598237 3 -- Vaalmonica Intonare
+4582942 3 -- Vaalmonica Followed Rhythm
+31971040 3 -- Vaalmonica Chosen Melody
+21502796 3 -- Ryko, Lightsworn Hunter
+38815069 3 -- Rinyan, Lightsworn Rogue
+95503687 3 -- Lumina, Lightsworn Summoner
+7183277 3 -- Aurkus, Lightsworn Druid
+2420921 3 -- Shire, Lightsworn Spirit
+40164421 3 -- Minerva, Lightsworn Maiden
+96235275 3 -- Jain, Lightsworn Paladin
+22624373 3 -- Lyla, Lightsworn Sorceress
+59019082 3 -- Garoth, Lightsworn Warrior
+58996430 3 -- Wulf, Lightsworn Beast
+83725008 3 -- Jenis, Lightsworn Mender
+44178886 3 -- Ehren, Lightsworn Monk
+77558536 3 -- Raiden, Hand of the Lightsworn
+73176465 3 -- Felis, Lightsworn Archer
+94381039 3 -- Celestia, Lightsworn Angel
+21785144 3 -- Gragonith, Lightsworn Dragon
+57774843 3 -- Judgment Dragon
+4779823 3 -- Michael, the Arch-Lightsworn
+30100551 3 -- Minerva, the Exalted Lightsworn
+98095162 3 -- Curious, the Lightsworn Dominion
+691925 3 -- Solar Recharge
+36099620 3 -- Realm of Light
+30502181 3 -- Lightsworn Sabre
+94886282 3 -- Charge of the Light Brigade
+35577420 3 -- Light Spiral
+61962135 3 -- Glorious Illusion
+22201234 3 -- Lightsworn Barrier
+32233746 3 -- Vanquishing Light
+66194206 3 -- Lightsworn Judgment
+22339232 3 -- Wightmare
+57473560 3 -- Wightprince
+6128460 3 -- Wightbaking
+40991587 3 -- The Lady in Wight
+90243945 3 -- Wightprincess
+13258285 3 -- Ukiyoe-P.U.N.K. Sharakusai
+50642380 3 -- Gagaku-P.U.N.K. Wa Gon
+82041999 3 -- Joruri-P.U.N.K. Madame Spider
+19535693 3 -- Noh-P.U.N.K. Ze Amin
+6609736 3 -- Noh-P.U.N.K. Deer Note
+55920742 3 -- Noh-P.U.N.K. Foxy Tune
+81914447 3 -- Noh-P.U.N.K. Ogre Dance
+18313046 3 -- Ukiyoe-P.U.N.K. Rising Carp
+28403802 3 -- P.U.N.K. JAM Dragon Drive
+44708154 3 -- Ukiyoe-P.U.N.K. Amazing Dragon
+81192859 3 -- Gagaku-P.U.N.K. Wild Picking
+17691568 3 -- Gagaku-P.U.N.K. Crash Beat
+49370016 3 -- P.U.N.K. JAM Extreme Session
+43685562 3 -- Joruri-P.U.N.K. Dangerous Gabu
+70070211 3 -- Joruri-P.U.N.K. Nashiwari Surprise
+17266660 3 -- Herald of Orange Light
+92919429 3 -- Diviner of the Herald
+44665365 3 -- Herald of Perfection
+48546368 3 -- Herald of Ultimateness
+1249315 3 -- Herald of Pure Light
+46935289 3 -- Herald of Mirage Lights
+27383110 3 -- Dawn of the Herald
+79306385 3 -- Oracle of the Herald
+60473572 3 -- Metalfoes Steelen
+7868571 3 -- Metalfoes Silverd
+33256280 3 -- Metalfoes Goldriver
+69351984 3 -- Metalfoes Volflame
+18716735 3 -- Raremetalfoes Bismugear
+10024317 3 -- Parametalfoes Melcaster
+56518311 3 -- Metalfoes Vanisher
+77693536 3 -- Fullmetalfoes Alkahest
+81612598 3 -- Metalfoes Adamante
+4688231 3 -- Metalfoes Mithrilium
+37491810 3 -- Parametalfoes Azortless
+28016193 3 -- Metalfoes Orichalc
+54401832 3 -- Metalfoes Crimsonite
+24094258 3 -- Heavymetalfoes Electrumite
+61728808 3 -- Heavymetalfoes Amalgam
+46500985 3 -- Metamorformation
+73594093 3 -- Metalfoes Fusion
+39564736 3 -- Fullmetalfoes Fusion
+58549532 3 -- Parametalfoes Fusion
+33327029 3 -- Metalfoes Counter
+69711728 3 -- Metalfoes Combination
+68819554 3 -- Performage Damage Juggler
+4807253 3 -- Performage Flame Eater
+31292357 3 -- Performage Hat Tricker
+67696066 3 -- Performage Trick Clown
+71578874 3 -- Performage Mirror Conductor
+4081665 3 -- Performage Stilts Launcher
+17016362 3 -- Performage Trapeze Magician
+79777187 3 -- Bubble Barrier
+93983867 3 -- Trick Box
+90681088 3 -- Legendary Fire King Ponix
+96594609 3 -- Fire King Avatar Kirin
+54149433 3 -- Fire King Avatar Garunix
+69000994 3 -- Fire King Avatar Barong
+66413481 3 -- Fire King Avatar Yaksha
+18621798 3 -- Fire King Avatar Arvata
+38910263 3 -- Fire King Avatar Rangbali
+23015896 3 -- Fire King High Avatar Garunix
+66431519 3 -- Sacred Fire King Garunix
+2526224 3 -- Fire King High Avatar Kirin
+64182380 3 -- Garunix Eternity, Hyang of the Fire Kings
+22993208 3 -- Onslaught of the Fire Kings
+59388357 3 -- Circle of the Fire Kings
+57554544 3 -- Fire King Island
+65305978 3 -- Fire King Sanctuary
+91703676 3 -- Fire King Sky Burn
+38798785 3 -- Echelon of the Fire Kings
+#SDSS-AE
+11962031 3 -- Salamangreat of Fire
+53490455 3 -- Salamangreat Raccoon
+89484053 3 -- Salamangreat Mole
+67225377 3 -- Salamangreat Meer
+94620082 3 -- Salamangreat Foxy
+26889158 3 -- Salamangreat Gazelle
+52277807 3 -- Salamangreat Spinny
+49094491 3 -- Salamangreat Fennec
+71861848 3 -- Salamangreat Coyote
+57357130 3 -- Salamangreat Weasel
+20618081 3 -- Salamangreat Falco
+56003780 3 -- Salamangreat Jack Jaguar
+13173832 3 -- Salamangreat Wolvie
+89662401 3 -- Salamangreat Fowl
+59577547 3 -- Salamangreat Parro
+84755744 3 -- Salamangreat Tiger
+25166510 3 -- Salamangreat Beat Bison
+47961808 3 -- Barrier Statue of the Inferno
+50366775 3 -- Formud Skipper
+80794697 3 -- Flame Bufferlo
+16188701 3 -- Lady Debug
+1295111 3 -- Salamangreat Sanctuary
+64178424 3 -- Will of the Salamangreat
+25800447 3 -- Fusion of Fire
+52155219 3 -- Salamangreat Circle
+88540324 3 -- Salamangreat Claw
+83554231 3 -- Salamangreat Recureance
+66947913 3 -- Rising Fire
+92345028 3 -- Fury of Fire
+28534130 3 -- Salamangreat Burning Shell
+54529134 3 -- Salamangreat Transcendence
+46898368 3 -- Burning Draw
+83533296 3 -- Salamangreat Charge
+65681983 1 -- Crossout Designator
+57160136 3 -- Cynet Mining
+20788863 3 -- Salamangreat Gift
+14934922 3 -- Salamangreat Rage
+51339637 3 -- Salamangreat Roar
+19027895 3 -- Salamangreat Revive
+37261776 3 -- Salamangreat Violet Chimera
+10140443 3 -- Salamangreat Burst Gryphon
+87327776 3 -- Salamangreat Miragestallio
+41463181 3 -- Salamangreat Heatleo
+87871125 3 -- Salamangreat Sunlight Wolf
+14812471 3 -- Salamangreat Balelynx
+31313405 3 -- Salamangreat Pyro Phoenix
+57134592 3 -- Salamangreat Raging Phoenix
+#SDSS-AEP
+93332803 3 -- Dogoran, the Mad Flame Kaiju
+60303245 3 -- Salamangreat Almiraj
+2857636 3 -- Knightmare Phoenix
+35269904 3 -- Triple Tactics Thrust
+23002292 2 -- Red Reboot
+#LEDE-AE
+2333466 3 -- Gandora-G the Dragon of Destruction
+39321065 3 -- Silent Swordsman Zero
+65726770 3 -- Silent Magician Zero
+92110878 3 -- Gadget Trio
+38505587 3 -- Moremarshmallon
+64603182 3 -- Ancient Gear Dark Golem
+91098230 3 -- Ancient Gear Tanker
+27483935 3 -- Ancient Gear Commander
+64881644 3 -- Refrain the Melodious Songstress
+90276649 3 -- Couplet the Melodious Songstress
+27260347 3 -- Snake-Eyes Diabellstar
+53765052 3 -- Diabellze the Original Sinkeeper
+99153051 3 -- Ragnaraika the Evil Seed
+26548709 3 -- Ragnaraika Samurai Beetle
+52543404 3 -- Ragnaraika Armored Lizard
+39931513 3 -- Tenpai Dragon Paidra
+65326118 3 -- Tenpai Dragon Fadra
+91810826 1 -- Tenpai Dragon Chundra
+24215921 3 -- Gruesome Grave Squirmer
+60203670 3 -- Gold Pride - Eliminator
+97698279 3 -- Centur-Ion Gargoyle II
+23093373 3 -- Selettrice Vaalmonica
+59481082 3 -- Lightsworn Dragonling
+96576187 3 -- Weiss, Lightsworn Archfiend
+22970795 3 -- Wightlord
+59369430 3 -- Golgoil the Steel Seismic Smasher
+85753549 3 -- Mikazukinoyaiba, the Moon Fang Dragon
+74150658 3 -- Talons of Shurilane
+58143852 3 -- Nightmare Apprentice
+84631951 3 -- Dinovatus Docus
+21036656 3 -- Cyclos the Circular Sprite
+57420265 3 -- Fishborg Harpooner
+83819309 3 -- Cooling Embers
+10804018 3 -- Saffira, Divine Dragon of the Voiceless Voice
+56208713 3 -- Bacha the Melodious Maestra
+83793721 3 -- Flowering Etoile the Melodious Magnificat
+19181420 3 -- Mementotlan Twin Dragon
+46186135 3 -- Enlightenment Dragon
+82570174 3 -- Sangenpai Bident Dragion
+18969888 3 -- Sangenpai Transcendent Dragion
+45464587 3 -- Gold Pride - Eradicator
+71858682 3 -- Centur-Ion Auxila
+18843291 3 -- Minerva, the Athenian Lightsworn
+44241999 3 -- Goblin Biker Troika Griare
+70636044 3 -- Varudras, the Final Bringer of the End Times
+7020743 3 -- Tantrum Toddler
+43129357 3 -- Ragnaraika Skeletal Soldier
+70514456 3 -- Ragnaraika Mantis Monk
+6908161 3 -- Ragnaraika Chain Coils
+42307760 3 -- Ragnaraika Stag Sovereign
+79791878 3 -- Shining Sarcophagus
+5786513 3 -- Turn Silence
+32270212 3 -- Ties That Bind
+78679226 3 -- Future Silence
+4064925 3 -- Ancient Gear Advance
+31458630 3 -- Melodious Concerto
+67457739 3 -- Sinful Spoils Struggle
+4841383 3 -- Ragnaraika Bloom
+30336082 1 -- Sangen Summoning
+66730191 3 -- Sangen Kaimen
+93729896 3 -- Nightmare Throne
+39114494 3 -- Blessing of the Voiceless Voice
+66518509 3 -- Mementotlan Fusion
+92907248 3 -- Wake Up Centur-Ion!
+38491852 3 -- Vaalmonica Invitare
+65496951 3 -- Vaalmonica Disarmonia
+91880660 3 -- Way Where There's a Will
+28279365 3 -- Blink Out
+64664373 3 -- Metaltronus
+91668078 3 -- In Papa's Footsteps
+27157727 3 -- Stronghold the Hidden Fortress
+53541822 3 -- Ancient Gear Duel
+90946420 3 -- Goblin Biker Grand Pileup
+26334139 3 -- Sinful Spoils Subdual
+53329234 3 -- Sinful Spoils of Slumber - Morrian
+89824842 3 -- Ragnaraika Hunting Dance
+25218587 3 -- Lightsworn Aegis
+52607696 3 -- Mirage Mirror Force
+88001391 3 -- Zoma the Earthbound Spirit
+25096909 3 -- Simultaneous Equation Cannons
+64681432 3 -- Gandora the Dragon of Destruction
+1278431 3 -- Ancient Gear Frame
+42878636 3 -- Ancient Gear Hunting Hound
+95735217 3 -- Ancient Gear Golem - Ultimate Pound
+84673417 3 -- Jain, Twilightsworn General
+10071151 3 -- Lyla, Twilightsworn Enchantress
+56166150 3 -- Lumina, Twilightsworn Shaman
+83550869 3 -- Ryko, Twilightsworn Fighter
+19959563 3 -- Punishment Dragon
+66853752 3 -- Fishborg Launcher
+51282878 3 -- Fishborg Planter
+62023839 3 -- Fishborg Archer
+10560119 3 -- Fishborg Doctor
+49959355 3 -- Uni-Zombie
+84366728 3 -- Vanguard of the Underground Emperor
+53416326 3 -- Fairyant the Circular Sorcerer
+51788412 3 -- Chaos Ancient Gear Giant
+87182127 3 -- Ancient Gear Howitzer
+37663536 3 -- Ancient Gear Megaton Golem
+12954226 3 -- Circle of the Fairies
+93125329 3 -- Golden Cloud Beast - Malong
+90590303 3 -- Number 41: Bagooska the Terribly Tired Tapir
+73082255 3 -- The Zombie Vampire
+20665527 3 -- Amphibious Swarmship Amblowhale
+70709488 3 -- Shinobi Insect Hagakuremino
+91140491 3 -- Seraphim Papillion
+10547580 3 -- Ancient Gear Ballista
+64061284 3 -- Ancient Gear Fusion
+24037702 3 -- March of the Dark Brigade
+60431417 3 -- Twilight Twin Dragons
+47482043 3 -- Ancient Gear Reborn
+56889 3 -- Cross-Dimensional Duel
+57348141 3 -- Twilight Eraser
+83747250 3 -- Twilight Cloth
+78474168 3 -- Breakthrough Skill
+#24AT-AE3
+11398059 3 -- King of the Feral Imps
+73898890 3 -- Dyna Mondo
+53334471 1 -- Gozen Match
+92826944 3 -- Mezuki
+29726552 3 -- Kumongous, the Sticky String Kaiju
+63941210 3 -- Jizukiru, the Star Destroying Kaiju
+78661338 3 -- Fantastical Dragon Phantazmay
+95679145 3 -- Dogmatika Maximus
+28912357 3 -- Gear Gigant X
+1855932 3 -- Bujintei Kagutsuchi
+6983839 3 -- Tornado Dragon
+9349094 3 -- Sacred Tree Beast, Hyperyton
+77058170 3 -- Underclock Taker
+22423493 3 -- Qliphort Genius
+73345237 3 -- Benghalancer the Resurgent
+48976825 3 -- Burial from a Different Dimension
+45141013 3 -- Heat Wave
+17626381 3 -- Supply Squad
+7811875 3 -- Gravity Collapse
+#ES01-AE
+71564252 3 -- Thunder King Rai-Oh
+42009836 3 -- Fossil Dyna Pachycephalo
+89312388 3 -- Elemental HERO Prisma
+67750322 3 -- Skull Meister
+97940434 3 -- Chaos Hunter
+46565218 3 -- Santa Claws
+14920218 3 -- Oafdragon Magician
+55063751 3 -- Gameciel, the Sea Turtle Kaiju
+71525232 3 -- Gandora-X the Dragon of Demolition
+71703785 3 -- Palladium Oracle Mahad
+55623480 3 -- Fairy Tail - Snow
+82385847 3 -- Dinowrestler Pankratops
+71197066 3 -- Gizmek Orochi, the Serpentron Sky Slasher
+35405755 3 -- Kurikara Divincarnate
+77202120 3 -- Assault Synchron
+74652966 3 -- Code of Soul
+55410871 3 -- Blue-Eyes Chaos MAX Dragon
+23995346 3 -- Blue-Eyes Ultimate Dragon
+2129638 3 -- Blue-Eyes Twin Burst Dragon
+50237654 3 -- The Dark Magicians
+85059922 3 -- Master of Chaos
+11443677 3 -- Blue-Eyes Tyrant Dragon
+11765832 3 -- Garura, Wings of Resonant Life
+65815684 3 -- Vicious Astraloud
+74586817 3 -- PSY-Framelord Omega
+64880894 3 -- Stardust Charge Warrior
+42566602 3 -- Coral Dragon
+81846453 3 -- Martial Metal Marcher
+68431965 3 -- Shooting Riser Dragon
+60465049 3 -- Psychic End Punisher
+22850702 3 -- Chaos Angel
+95992081 3 -- Leviair the Sea Dragon
+21044178 0 -- Abyss Dweller
+63767246 3 -- Number 38: Hope Harbinger Dragon Titanic Galaxy
+8165596 3 -- Number 90: Galaxy-Eyes Photon Lord
+66011101 3 -- Number 60: Dugares the Timeless
+98452268 3 -- Odd-Eyes Rebellion Dragon Overlord
+90448279 3 -- Divine Arsenal AA-ZEUS - Sky Thunder
+9940036 3 -- Mereologic Aggregator
+30095833 3 -- Odd-Eyes Rebellion Xyz Dragon
+41999284 3 -- Linkuriboh
+74997493 3 -- Saryuja Skull Dread
+24361622 3 -- Hieratic Seal of the Heavenly Spheres
+59934749 3 -- Isolde, Two Tales of the Noble Knights
+49202162 3 -- Black Luster Soldier - Soldier of Chaos
+4280258 0 -- Apollousa, Bow of the Goddess
+65741786 3 -- I:P Masquerena
+13117073 3 -- Barricadeborg Blocker
+50277355 3 -- Cross-Sheep
+86066372 3 -- Accesscode Talker
+98127546 3 -- Underworld Goddess of the Closed World
+45112597 3 -- Worldsea Dragon Zealantis
+59750328 3 -- Card of Demise
+75500286 1 -- Gold Sarcophagus
+40450317 3 -- Ties of the Brethren
+1845204 3 -- Instant Fusion
+46052429 3 -- Advanced Ritual Art
+67723438 3 -- Emergency Teleport
+35480699 3 -- Book of Eclipse
+98645731 3 -- Pot of Duality
+57103969 3 -- Fire Formation - Tenki
+78610936 3 -- Xyz Encore
+99330325 3 -- Interrupted Kaiju Slumber
+8267140 3 -- Cosmic Cyclone
+71143015 3 -- Ultimate Fusion
+19403423 3 -- Time-Tearing Morganite
+84749824 3 -- Solemn Warning
+58921041 3 -- Anti-Spell Fragrance
+14883228 3 -- Typhoon
+40605147 3 -- Solemn Strike
+6351147 3 -- Transaction Rollback
+#CR05-AE
+13893596 3 -- Exodius the Ultimate Forbidden Lord
+64043465 3 -- Obliterate!!!
+56427559 3 -- Gimmick Puppet Gear Changer
+20032555 3 -- Gimmick Puppet Egg Head
+29216967 3 -- Gimmick Puppet Scissor Arms
+76543119 3 -- Gimmick Puppet Des Troy
+8226374 3 -- Gimmick Puppet Humpty Dumpty
+43598843 3 -- Gimmick Puppet Terror Baby
+92418590 3 -- Gimmick Puppet Dreary Doll
+39806198 3 -- Gimmick Puppet Magnet Doll
+92821268 3 -- Gimmick Puppet Twilight Joker
+55204071 3 -- Gimmick Puppet Nightmare
+34620088 3 -- Gimmick Puppet Shadow Feeler
+79086452 3 -- Gimmick Puppet Bisque Doll
+7593748 3 -- Gimmick Puppet Gigantes Doll
+88120966 3 -- Number 15: Gimmick Puppet Giant Grinder
+75433814 3 -- Number 40: Gimmick Puppet of Strings
+48995978 3 -- Number 88: Gimmick Puppet of Leo
+33776843 3 -- Number C15: Gimmick Puppet Giant Hunter
+69170557 3 -- Number C40: Gimmick Puppet of Dark Strings
+6165656 3 -- Number C88: Gimmick Puppet Disaster Leo
+97520532 3 -- Gimmick Puppet Chimera Doll
+67968069 3 -- Junk Puppet
+1969506 3 -- Puppet Ritual
+94220427 3 -- Rank-Up-Magic Argent Chaos Force
+57093995 3 -- Condolence Puppet
+6471156 3 -- Perform Puppet
+63881033 3 -- Marshalling Field
+32875265 3 -- Puppet Parade
+33750025 3 -- Samsara Dragon
+47297616 3 -- Light and Darkness Dragon
+88643579 3 -- Dark End Dragon
+25132288 3 -- Light End Dragon
+12980373 3 -- Madolche Mewfeuille
+49374988 3 -- Madolche Baaple
+89521713 3 -- Madolche Cruffssant
+91350799 3 -- Madolche Hootcake
+26570480 3 -- Madolche Chickolates
+75363626 3 -- Madolche Chouxvalier
+11868731 3 -- Madolche Magileine
+48252330 3 -- Madolche Butlerusk
+34680482 3 -- Madolche Anjelly
+26016357 3 -- Madolche Marmalmaide
+52404456 3 -- Madolche Messengelato
+77848740 3 -- Madolche Petingcessoeur
+74641045 3 -- Madolche Puddingcess
+37164373 3 -- Madolche Queen Tiaramisu
+20343502 3 -- Madolche Teacher Glassouffle
+44311445 3 -- Madolche Puddingcess Chocolat-a-la-Mode
+96150936 3 -- Madolche Fresh Sistart
+14001430 3 -- Madolche Chateau
+60470713 3 -- Madolche Ticket
+71348837 3 -- Madolche Salon
+12940613 3 -- Madolche Lesson
+48439321 3 -- Madolche Waltz
+75833426 3 -- Madolche Tea Break
+23681456 3 -- Madolchepalooza
+79759367 3 -- Madolche Nights
+68159562 3 -- Madolche Promenade
+97148796 3 -- Drytron Alpha Thuban
+33543890 3 -- Drytron Beta Rastaban
+60037599 3 -- Drytron Gamma Eltanin
+96026108 3 -- Drytron Zeta Aldhibah
+22420202 3 -- Drytron Delta Altais
+69815951 3 -- Drytron Meteonis Draconids
+95209656 3 -- Drytron Meteonis Quadrantids
+1174075 3 -- Drytron Mu Beta Fafnir
+22398665 3 -- Meteonis Drytron
+58793369 3 -- Drytron Fafnir
+94187078 3 -- Drytron Nova
+21576077 3 -- Drytron Eclipse
+57970721 3 -- Drytron Asterism
+84965420 3 -- Drytron Meteor Shower
+87047161 3 -- Mermaid Shark
+20838380 3 -- Shark Stickers
+47840168 3 -- Left-Hand Shark
+43138260 3 -- Xyz Remora
+90303176 3 -- Silent Angler
+64319467 3 -- Double Fin Shark
+11845050 3 -- Right-Hand Shark
+70156946 3 -- Lantern Shark
+7150545 3 -- Buzzsaw Shark
+70101178 3 -- Panther Shark
+7500772 3 -- Eagle Shark
+23536866 3 -- Gazer Shark
+61496006 3 -- Abyss Shark
+98881700 3 -- Crystal Shark
+71923655 3 -- Sharkraken
+31320433 3 -- Number 47: Nightmare Shark
+14306092 3 -- Shark Caesar
+59479050 3 -- Number 71: Rebarian Shark
+440556 3 -- Bahamut Shark
+48739166 3 -- Number 101: Silent Honor ARK
+37279508 3 -- Number 37: Hope Woven Dragon Spider Shark
+50449881 3 -- Shark Fortress
+12744567 3 -- Number C101: Silent Honor DARK
+23672629 3 -- Valiant Shark Lancer
+26976414 3 -- Atlantean Pikeman
+21565445 3 -- Neptabyss, the Atlantean Prince
+37104630 3 -- Atlantean Heavy Infantry
+8078366 3 -- Atlantean Attack Squad
+706925 3 -- Atlantean Marksman
+28754338 3 -- Legendary Atlantean Tridon
+74311226 3 -- Atlantean Dragoons
+47826112 3 -- Poseidra, the Atlantean Dragon
+73199638 3 -- Call of the Atlanteans
+23899727 3 -- Mermail Abysslinde
+69293721 3 -- Mermail Abyssgunde
+96682430 3 -- Mermail Abysshilde
+74298287 3 -- Mermail Abyssdine
+28577986 3 -- Mermail Abyssocea
+71133680 3 -- Mermail Abyssnerei
+22076135 3 -- Mermail Abyssturge
+58471134 3 -- Mermail Abysspike
+95466842 3 -- Mermail Abysslung
+21767650 3 -- Mermail Abyssmander
+282886 3 -- Mermail Abyssnose
+21954587 3 -- Mermail Abyssmegalo
+37781520 3 -- Mermail Abyssleed
+22446869 3 -- Mermail Abyssteus
+75180828 3 -- Mermail Abyssbalaen
+59170782 3 -- Mermail Abysstrite
+74371660 3 -- Mermail Abyssgaios
+23545031 3 -- Mermail Abyssalacia
+8719957 3 -- Abyss-scale of the Kraken
+19596712 3 -- Abyss-scale of Cetus
+72932673 3 -- Abyss-scale of the Mizuchi
+34707034 3 -- Abyss-squall
+60202749 3 -- Abyss-sphere
+79206750 3 -- Abyss-scorn
+33883834 3 -- Shien's Squire
+1498130 3 -- Kagemusha of the Six Samurai
+61737116 3 -- Elder of the Six Samurai
+2511717 3 -- Legendary Six Samurai - Kageki
+48505422 3 -- Legendary Six Samurai - Shinai
+74094021 3 -- Legendary Six Samurai - Mizuho
+49721904 3 -- Legendary Six Samurai - Kizan
+75116619 3 -- Legendary Six Samurai - Enishi
+83039729 3 -- Grandmaster of the Six Samurai
+29981921 3 -- Legendary Six Samurai - Shi En
+72345736 3 -- Six Samurai United
+27970830 3 -- Gateway of the Six
+54031490 3 -- Shien's Smoke Signal
+81426505 3 -- Six Strike - Triple Impact
+27821104 3 -- Asceticism of the Six Samurai
+47436247 3 -- Shien's Dojo
+41458579 3 -- Musakani Magatama
+23212990 3 -- Six Strike - Thunder Blast
+75525309 3 -- Six Style - Dual Wield
+53212882 3 -- Floowandereeze & Snowl
+18940725 3 -- Floowandereeze & Robina
+54334420 3 -- Floowandereeze & Eglen
+80433039 3 -- Floowandereeze & Stri
+17827173 3 -- Floowandereeze & Toccan
+80611581 3 -- Floowandereeze & Empen
+28126717 3 -- Floowandereeze and the Magnificent Map
+55521751 3 -- Floowandereeze and the Unexplored Winds
+69087397 3 -- Floowandereeze and the Advent of Adventure
+41215808 3 -- Floowandereeze and the Dreaming Town
+77610503 3 -- Floowandereeze and the Scary Sea
+62133026 3 -- Vernusylph of the Flowering Fields
+9238125 3 -- Vernusylph of the Thawing Mountains
+81519836 3 -- Vernusylph of the Misting Seedlings
+9350312 3 -- Vernusylph of the Flourishing Hills
+36745317 3 -- Vernusylph of the Awakening Forests
+55125728 3 -- Vera the Vernusylph Goddess
+14108995 3 -- Vernusylph Corolla
+7206349 3 -- Vernusylph in Full Bloom
+37313338 3 -- Vernusylph and the Changing Season
+63708033 3 -- Vernusylph and the Flower Buds
+2656842 3 -- Beetrooper Scout Buggy
+39041550 3 -- Beetrooper Scale Bomber
+65430555 3 -- Beetrooper Sting Lancer
+51578214 3 -- Beetrooper Assault Roller
+88962829 3 -- Beetrooper Light Flapper
+14357527 3 -- Heavy Beetrooper Mighty Neptune
+50855622 3 -- Ultra Beetrooper Absolute Hercules
+91300233 3 -- Beetrooper Cruel Saturnas
+2834264 3 -- Beetrooper Armor Horn
+38229962 3 -- Giant Beetrooper Invincible Atlas
+64213017 3 -- Beetrooper Formation
+87240371 3 -- Beetrooper Descent
+13234975 3 -- Beetrooper Landing
+1712616 3 -- Beetrooper Fly & Sting
+40633084 3 -- Beetrooper Squad
+26400609 3 -- Tidal, Dragon Ruler of Waterfalls
+27415516 3 -- Stream, Dragon Ruler of Droplets
+53804307 3 -- Blaster, Dragon Ruler of Infernos
+53797637 3 -- Burner, Dragon Ruler of Sparks
+29587993 3 -- Mist Valley Apex Avian
+69327790 3 -- Raiza the Mega Monarch
+3629090 3 -- Cyber Angel Idaten
+99427357 3 -- Cyber Angel Natasha
+46772449 3 -- Evilswarm Exciton Knight
+80117527 3 -- Number 11: Big Eye
+10389142 3 -- Number 42: Galaxy Tomahawk
+48130397 3 -- Super Polymerization
+60600126 3 -- Cyber Emergency
+45725480 3 -- Sacred Sword of Seven Stars
+#INFO-AE
+96823189 3 -- Dragon of Pride and Soul
+38775407 3 -- Sengenjin Wakes from a Millennium
+74169516 3 -- Golem that Guards the Millennium Treasures
+1164211 3 -- Shield of the Millennium Dynasty
+37552929 3 -- Maiden of the Millennium Moon
+63947968 3 -- Fiend Reflection of the Millennium
+342673 3 -- Dark Magician the Magician of Black Magic
+36436372 3 -- Gimmick Puppet Little Soldiers
+63825486 3 -- Gimmick Puppet Rouge Doll
+99229085 3 -- Gimmick Puppet Cattle Scream
+35614780 3 -- Light End Sublimation Dragon
+62002838 3 -- Dark End Evaporation Dragon
+98007437 3 -- Knight Armed Dragon, the Armored Knight Dragon
+25592142 3 -- Astellar of the White Forest
+61980241 3 -- Elzette of the White Forest
+98385955 3 -- Silvy of the White Forest
+24779554 3 -- Rucia of the White Forest
+60764609 2 -- Fiendsmith Engraver
+97262307 3 -- Ragnaraika Wicked Butterfly
+23657016 3 -- Tenpai Dragon Genroku
+50042011 3 -- Mementotlan Shleepy
+96030710 3 -- Centur-Ion Atrii
+22435424 3 -- Drytron Nu II
+59829423 3 -- Lord of the Missing Barrows
+85314178 3 -- Cosmo Queen the Queen of Prayers
+22712877 3 -- Paralyzing Mushroom
+58707981 3 -- Disablaster the Negation Fortress
+84192580 3 -- Mulcharmy Purulia
+11590299 3 -- Dora Dora
+57985393 3 -- Broomy
+84079032 3 -- Bettan Bat
+10474647 3 -- Depresspard
+56863746 3 -- Drytron Meteonis DA Draconids
+83257450 3 -- The Unstoppable Exodia Incarnate
+19652159 3 -- Light and Darkness Dragonlord
+46640168 3 -- Fiendsmith's Lacrima
+82135803 3 -- Fiendsmith's Desirae
+14529511 3 -- Mementomictlan Tecuhtlica - Creation King
+41924516 3 -- Silvera, Wolf Tamer of the White Forest
+77313225 3 -- Rciela, Sinister Soul of the White Forest
+14307929 3 -- Diabell, Queen of the White Forest
+40702028 3 -- DPH Gendamoore
+76290637 3 -- Gimmick Puppet Fantasix Machinix
+3685372 3 -- CXyz Gimmick Puppet Fanatix Machinix
+49689480 3 -- Madolche Queen Tiarafraise
+76078185 3 -- Heretical Phobos Covos
+2463794 3 -- Fiendsmith's Requiem
+49867899 3 -- Fiendsmith's Sequence
+75352507 3 -- Ragnaraika Selene Snapper
+1340142 3 -- Varar, Vaalmonican Concord
+38745241 3 -- Madolche Mini Meowcaroons
+74139959 3 -- Cosmic Tree Irmistil
+1528054 3 -- Silhouhatte Rabbit
+37613663 3 -- Millennium Ankh
+63017368 3 -- Wedju Temple
+402416 3 -- Obliterate!!! Blaze
+36890111 3 -- Mansion of the Dreadful Dolls
+63295720 3 -- Dragon's Light and Darkness
+99289828 3 -- Tales of the White Forest
+35778533 3 -- Beware the White Forest
+62173132 3 -- Susurrus of the Sinful Spoils
+98567237 2 -- Fiendsmith's Tract
+35552985 3 -- Fiendsmith's Sanct
+61950680 3 -- Emblema Salvation
+97345699 3 -- Vesper Girsu
+24839398 3 -- Trap Gatherer
+60238002 3 -- Interdimensional Matter Forwarder
+97223101 3 -- That's 10!
+23617756 3 -- Exxod Fires of Rage
+59016454 3 -- Dark Magic Mirror Force
+36400569 3 -- Service Puppet Play
+62995268 3 -- Woes of the White Forest
+99989863 3 -- Fiendsmith in Paradise
+25388971 3 -- Sangen Kaiho
+61773610 3 -- Guardian of the Voiceless Voice
+98167225 3 -- Vaalmonica Creation
+24166324 3 -- Meteoroa Drytron
+51650038 3 -- Madolche Dessert
+97045737 3 -- Dominus Purge
+24440742 3 -- Silhouhatte Trick
+50838440 3 -- Three in One
+58604027 3 -- The Legendary Exodia Incarnate
+32841045 3 -- Magical Musketeer Caspar
+68246154 3 -- Magical Musketeer Doc
+5230799 3 -- Magical Musketeer Kidbrave
+31629407 3 -- Magical Musketeer Starfire
+68024506 3 -- Magical Musketeer Calamity
+94418111 3 -- Magical Musketeer Wild
+30907810 3 -- Magical Musket Mastermind Zakiel
+33347467 3 -- Ghost Ship
+45458027 3 -- Gearspring Spirit
+40177746 3 -- Eva
+43502497 3 -- Pendulum Witch
+53008933 3 -- Archfiend's Advent
+75892194 3 -- Ancient Gear Dragon
+33250142 3 -- Ultimate Flagship Ursatron
+80453041 3 -- Phantom of Yubel
+21915012 3 -- Cupid Pitch
+48654267 3 -- Supreme King Z-ARC - Synchro Universe
+30741334 3 -- Coach King Giantrainer
+93713837 3 -- Number 24: Dragulas the Vampiric Dragon
+27240101 3 -- Kikinagashi Fucho
+10666000 3 -- Number 1: Infection Buzzking
+47132793 3 -- Blaze, Supreme Ruler of all Dragons
+71791814 3 -- Magical Musketeer Max
+9839945 3 -- Lyna the Light Charmer, Lustrous
+8264361 3 -- Dharc the Dark Charmer, Gloomy
+89771220 3 -- Ursarctic Drytron
+67901914 3 -- Magical Musket - Steady Hands
+93356623 3 -- Magical Musket - Cross-Domination
+61322713 3 -- Shadow's Light
+39973386 3 -- Duality
+20745268 3 -- Magical Musket - Desperado
+66149377 3 -- Magical Musket - Dancing Needle
+29628180 3 -- Magical Musket - Last Stand
+92534075 3 -- Magical Musket - Fiendish Deal
+47810543 3 -- Magical Musket - Crooked Crown
+44822037 3 -- Angel Statue - Azurune
+3129635 3 -- Tiki Curse
+49514333 3 -- Tiki Soul
+#24AT-AE4
+64335804 3 -- Red-Eyes Black Metal Dragon
+79559912 3 -- D/D/D Wave High King Caesar
+13959634 3 -- Moulinglacia the Elemental Lord
+36956512 3 -- Gadarla, the Mystery Dust Kaiju
+40509732 3 -- Samurai Destroyer
+54493213 3 -- Helios - The Primordial Sun
+63176202 3 -- Great Shogun Shien
+97651498 3 -- Fabled Lurrie
+35112613 3 -- Kuriphoton
+55969226 3 -- Blue Dragon Summoner
+69610924 3 -- Number 17: Leviathan Dragon
+5014629 3 -- Submersible Carrier Aero Shark
+48608796 3 -- Lyrilusc - Assembled Nightingale
+79130389 3 -- Marincess Coral Anemone
+12247206 3 -- Inferno Reckless Summon
+80921533 3 -- Mausoleum of the Emperor
+27178262 3 -- Cunning of the Six Samurai
+52665542 3 -- Lightsworn Sanctuary
+68540058 3 -- Metalmorph
+23626223 3 -- Statue of Anguish Pattern
+#BN01-AE
+14181608 3 -- Mushroom Man
+13069066 3 -- Sword Arm of Dragon
+27324313 3 -- Wattkid
+52584282 3 -- Hercules Beetle
+15367030 3 -- Gokibore
+49417509 3 -- Wolf
+49791927 3 -- Tiger Axe
+14977074 3 -- Garoozis
+76634149 3 -- Kairyu-Shin
+2906250 3 -- Grappler
+75390004 3 -- Megazowler
+38289717 3 -- Crawling Dragon 2
+68339286 3 -- Metal Guardian
+92667214 3 -- Clown Zombie
+55550921 3 -- Battle Warrior
+92944626 3 -- Wings of Wicked Flame
+22026707 3 -- Curtain of the Dark Ones
+80600490 3 -- Kageningen
+40200834 3 -- Sleeping Lion
+49587396 3 -- Ancient Tool
+61454890 3 -- Necrolancer the Time-lord
+732302 3 -- Temple of Skulls
+62403074 3 -- Rhaimundos of the Red Sword
+53581214 3 -- Fire Reaper
+89558090 3 -- Dark Prisoner
+1929294 3 -- Key Mace
+99030164 3 -- Happy Lover
+75889523 3 -- Archfiend Marmot of Nefariousness
+97973387 3 -- Droll Bird
+39175982 3 -- Winged Cleaver
+15510988 3 -- Thunder Kid
+54844990 3 -- Skull Stalker
+8783685 3 -- Hourglass of Life
+84285623 3 -- Haniwa
+63432835 3 -- Stone Armadiller
+15507080 3 -- Sectarian of Secrets
+96643568 3 -- Wetha
+18914778 3 -- Change Slime
+45909477 3 -- Moon Envoy
+38942059 3 -- Sonic Maid
+44073668 3 -- Takriminos
+70345785 3 -- Yamadron
+33734439 3 -- Three-Legged Zombies
+5628232 3 -- Flying Penguin
+32012841 3 -- Millennium Shield
+68401546 3 -- Fairy's Gift
+59383041 3 -- Toon Alligator
+62762898 3 -- Parrot Dragon
+99261403 3 -- Dark Rabbit
+24433920 3 -- Pendulum Machine
+24311372 3 -- Zoa
+59983499 3 -- Dancing Elf
+48649353 3 -- Ushi Oni
+72299832 3 -- Giant Mech-Soldier
+71950093 3 -- Shovel Crusher
+7359741 3 -- Mechanicalchaser
+34743446 3 -- Blocker
+7526150 3 -- Golgoil
+33621868 3 -- Giganto
+95288024 3 -- Sky Dragon
+68171737 3 -- Stone Dragon
+59053232 3 -- Turu-Purun
+58831685 3 -- Giant Red Seasnake
+47986555 3 -- Millennium Golem
+48531733 3 -- Bolt Penguin
+70924884 3 -- Alinsection
+80234301 3 -- Prisman
+53713014 3 -- Crazy Fish
+10262698 3 -- The Statue of Easter Island
+72929454 3 -- Turtle Bird
+70084224 3 -- Neck Hunter
+96967123 3 -- Dharma Cannon
+69750536 3 -- Wow Warrior
+68638985 3 -- Slime Toad
+17238333 3 -- Wretched Ghost of the Attic
+89904598 3 -- Anthrosaurus
+42348802 3 -- Trakodon
+20315854 3 -- Fairy Dragon
+56713552 3 -- Obese Marmot of Nefariousness
+82085619 3 -- Shining Friendship
+29802344 3 -- Snakeyashi
+43352213 3 -- Nekogal 2
+79629370 3 -- Maiden of the Moonlight
+4179849 3 -- Queen of Autumn Leaves
+2830619 3 -- Flame Viper
+65623423 3 -- Gruesome Goo
+38999506 3 -- Cosmo Queen
+38277918 3 -- Mikazukinoyaiba
+64271667 3 -- Meteor Dragon
+64428736 3 -- Alligator's Sword
+12493482 3 -- Dunames Dark Witch
+48766543 3 -- Cyber-Tech Alligator
+14898066 3 -- Vorse Raider
+38445524 3 -- Gil Garth
+37265642 3 -- Sabersaurus
+69247929 3 -- Gene-Warped Warwolf
+32626733 3 -- Spiral Serpent
+33112041 3 -- Volcanic Rat
+60606759 3 -- Renge, Gatekeeper of Dark World
+22499463 3 -- Venom Cobra
+89386122 3 -- Ally of Justice Clausolas
+74093656 3 -- Tune Warrior
+487395 3 -- Water Spirit
+29054481 3 -- Mist Valley Watcher
+23115241 3 -- X-Saber Anu Piranha
+40155554 3 -- Ally Mind
+57308711 3 -- Unicycular
+91731841 3 -- Gem-Knight Garnet
+27126980 3 -- Gem-Knight Sapphire
+69380702 3 -- Bunilla
+95788410 3 -- Rabidragon
+77542832 3 -- Evilswarm Heliotrope
+87151205 3 -- Wattaildragon
+14214060 3 -- Trance the Magic Swordsman
+3557275 3 -- White Duston
+17390179 3 -- Flash Knight
+43785278 3 -- Foucault's Cannon
+89189982 3 -- Metaphys Armed Dragon
+21970285 3 -- Dragon Horn Hunter
+48940337 3 -- Lancephorhynchus
+73779005 3 -- Dragoons of Draconia
+83980492 3 -- Dragong
+19474136 3 -- Mandragon
+74852097 3 -- Phantom Gryphon
+82114013 3 -- Sea Dragoons of Draconia
+18108166 3 -- Mystery Shell Dragon
+45103815 3 -- Risebell the Summoner
+15146890 3 -- Dragonpulse Magician
+51531505 3 -- Dragonpit Magician
+68182934 3 -- Sky Dragoons of Draconia
+87979586 3 -- Angel Trumpeter
+47558785 3 -- Mild Turkey
+84046493 3 -- Ghost Beef
+38955728 3 -- Dragon Core Hexer
+36211150 3 -- Bitron
+95511642 3 -- Crowned by the World Chalice
+32295838 3 -- Digitron
+77994337 3 -- Hallohallo
+14575467 3 -- Zombino
+28363749 3 -- Fire Opal Head
+24154052 3 -- Protron
+47226949 3 -- Leotron
+4148264 3 -- Shiny Black "C" Squadder
+43857222 3 -- Magicalibra
+92176681 3 -- Suppression Collider
+#ROTA-AE
+3149401 3 -- Ultimate Dragon of Pride and Soul
+55697723 3 -- Surfacing Big Jaws
+81096431 3 -- Drake Shark
+27480536 3 -- Armored Shark
+54475145 3 -- Heart of the Blue-Eyes
+80870883 3 -- Red-Eyes Black Fullmetal Dragon
+27268998 3 -- Metalzoa X
+53753697 3 -- Zoa the Fiendish Beast
+29157292 3 -- Metal Illusionist
+56146300 3 -- Battlewasp - Rapier the Onslaught
+92530005 3 -- Performage Ball Balancer
+29925614 3 -- Chaos Allure Queen
+55320758 3 -- Goblin Bikers Gone Wild
+81418467 3 -- Primite Imperial Dragon
+28803166 3 -- Lacrima the Crimson Tears
+54207171 3 -- Mementotlan Akihiron
+81696879 3 -- Centur-Ion Chimerea
+17080584 3 -- Abyssrhine, the Atlantean Spirit
+53085623 3 -- Mermail Shadow Squad
+80570228 3 -- Anarchist Monk of the Six Samurai
+16968936 3 -- Tactical Trainer of the Six Samurai
+43363035 3 -- Wandering Titan of Tartarus
+89357740 3 -- Union Pilot
+15746348 3 -- Eria the Water Channeler
+42141493 3 -- Mulcharmy Fuwalos
+84635192 3 -- Tsuru-Puru-Purun
+11024707 3 -- Flipping Feline
+47028805 3 -- L Magi Mergy
+73413514 3 -- Neverending Nightmare Absorber
+10807219 3 -- Newbee!
+46396218 3 -- Azamina Ilia Silvia
+73391962 3 -- Azamina Mu Rcielago
+9785661 3 -- Azamina Sol Erysichthon
+46174776 3 -- Azamina Moa Regina
+72578374 3 -- Khaos Starsource Dragon
+8963089 3 -- Heosvarog the Mechanical Dawn
+35057188 3 -- Battlewasp - Grand Partisan the Revolution
+71456737 3 -- Battlewasp - Sachi the Ceremonial Bow
+8841431 3 -- Centur-Ion Primera Primus
+34235530 3 -- Legendary Lord Six Samurai - Shi En
+70634245 3 -- Legendary Lord Six Samurai - Enishi
+7628844 3 -- Number C32: Shark Drake LeVeiss
+33113958 3 -- LeVirtue Dragon
+60517697 3 -- Poseidra Abyss, the Atlantean Dragon Lord
+6906306 3 -- Rubysapphirus, the Adamant Jewel
+32991300 3 -- Fiendsmith's Agnumday
+69385019 3 -- Mermail King - Neptabyss
+95784714 3 -- Flying Mary, the Wandering Ghost Ship
+32278723 3 -- Aqua Jet Surface
+68663427 3 -- Reincarnation Unveiling Mail
+94661166 3 -- Incoming Machine!
+21056275 3 -- Armed Rebeellion
+67441879 3 -- Battlewasp Wind
+94845588 3 -- The Hallowed Azamina
+20934683 3 -- Azamina Debtors
+66328392 3 -- Deception of the Sinful Spoils
+93723936 3 -- Scourge of the White Forest
+29111045 3 -- Goblin Biker Grand Breakout
+56506740 3 -- Primite Lordly Lode
+92501449 3 -- Primite Roar
+29095457 3 -- Primite Drillbeam
+55484152 3 -- Sangen Furo
+81878201 3 -- Abyss-sting Triaina
+28273805 3 -- Six Strike - Double Assault
+54261514 3 -- Final Bringer of the End Times
+81756619 3 -- Succumbing-Song Morganite
+17151328 3 -- Firestorms Over Atlantis
+53545926 3 -- Token Support
+80534031 3 -- Virtue Stream
+16938770 3 -- Xyz Poseidon Splash
+53323475 3 -- Puppet Shark
+89812483 3 -- Max Metalmorph
+15216188 3 -- Time Engine
+42201897 3 -- Azamina Determination
+88695895 3 -- Guilt of the Sinful Spoils
+15094540 3 -- Goblin Biker Grand Crisis
+41488249 3 -- Primite Howl
+77573354 3 -- Ragnaraika Wisteria of Woe
+14972952 3 -- Vaalmonica Ereditare
+40366667 3 -- Dominus Impulse
+77751766 3 -- Summer Schoolwork Successful!
+6180710 3 -- Dream Shark
+65899613 3 -- Battlewasp - Pin the Bullseye
+91283212 3 -- Battlewasp - Dart the Hunter
+28388927 3 -- Battlewasp - Sting the Poison
+54772065 3 -- Battlewasp - Twinbow the Attacker
+90161770 3 -- Battlewasp - Arbalest the Rapidfire
+7563579 3 -- Performage Plushfire
+71207871 3 -- Secret Six Samurai - Fuma
+7291576 3 -- Secret Six Samurai - Genba
+44686185 3 -- Secret Six Samurai - Hatsume
+70180284 3 -- Secret Six Samurai - Doji
+6579928 3 -- Secret Six Samurai - Kizaru
+15327215 3 -- Legendary Secret of the Six Samurai
+8495780 3 -- Deep Sea Artisan
+45483489 3 -- Deep Sea Sentry
+71978434 3 -- Deep Sea Minstrel
+26866984 3 -- Trias Hierarchia
+33964637 3 -- Secret Six Samurai - Rihan
+27565379 3 -- Battlewasp - Azusa the Ghost Bow
+53950487 3 -- Battlewasp - Halberd the Charge
+80949182 3 -- Battlewasp - Hama the Conquering Bow
+26443791 3 -- Battlewasp - Ballista the Armageddon
+50793215 3 -- Deep Sea Prima Donna
+33467872 3 -- Deep Sea Repetiteur
+65676461 3 -- Number 32: Shark Drake
+49221191 3 -- Number C32: Shark Drake Veiss
+34876719 3 -- N.As.H. Knight
+61374414 3 -- CXyz N.As.Ch. Knight
+1828513 3 -- Shadow of the Six Samurai - Shien
+74752631 3 -- Battle Shogun of the Six Samurai
+73309655 3 -- Eria the Water Charmer, Gentle
+48815792 3 -- Hiita the Fire Charmer, Ablaze
+52838896 3 -- Summoning Swarm
+89226534 3 -- Revival Swarm
+79968632 3 -- Secret Skills of the Six Samurai
+72060415 3 -- Deep Sea Aria
+26534688 3 -- Magellanica, the Deep Sea City
+25221249 3 -- Battlewasp - Nest
+6357341 3 -- The Six Shinobi
+#DI01-AE
+89943723 3 -- Elemental HERO Neos
+40044918 3 -- Elemental HERO Stratos
+50720316 3 -- Elemental HERO Shadow Mist
+14124483 3 -- Elemental HERO Honest Neos
+13256226 3 -- Elemental HERO Spirit of Neos
+59392529 3 -- Elemental HERO Liquid Soldier
+9411399 3 -- Destiny HERO - Malicious
+26964762 3 -- Destiny HERO - Dark Angel
+16605586 3 -- Destiny HERO - Denier
+22865492 3 -- Vision HERO Increase
+27780618 3 -- Vision HERO Vyon
+8949584 3 -- A Hero Lives
+21143940 3 -- Mask Change
+52947044 3 -- Fusion Destiny
+11881272 3 -- Favorite Hero
+75047173 3 -- Favorite Contact
+22908820 3 -- Elemental HERO Sunrise
+32828466 3 -- Wake Up Your Elemental HERO
+56733747 3 -- Elemental HERO Shining Neos Wingman
+93347961 3 -- Elemental HERO Flame Wingman - Infernal Rage
+60461804 3 -- Destiny HERO - Destroyer Phoenix Enforcer
+29095552 3 -- Masked HERO Acid
+89870349 3 -- Masked HERO Blast
+1948619 3 -- Xtra HERO Wonder Driver
+58004362 3 -- Xtra HERO Cross Crusader
+19324993 3 -- Xtra HERO Infernal Devicer
+#DI02-AE
+20001443 3 -- Swordsoul of Mo Ye
+56495147 3 -- Swordsoul of Taia
+93490856 3 -- Swordsoul Strategist Longyuan
+55273560 3 -- Incredible Ecclesia, the Virtuous
+98159737 3 -- Tenyi Spirit - Adhara
+23431858 3 -- Tenyi Spirit - Vishuda
+87052196 3 -- Tenyi Spirit - Ashuna
+24557335 3 -- Tenyi Spirit - Shthana
+56465981 3 -- Swordsoul Emergence
+93850690 3 -- Swordsoul Sacred Summit
+39730727 3 -- Flawless Perfection of the Tenyi
+51684157 3 -- Heavenly Dragon Circle
+65124425 3 -- Vessel for the Dragon Cycle
+14821890 3 -- Swordsoul Blackout
+69248256 3 -- Swordsoul Grandmaster - Chixiao
+96633955 3 -- Swordsoul Supreme Sovereign - Chengying
+47710198 3 -- Swordsoul Sinister Sovereign - Qixing Longyuan
+5041348 3 -- Draco Berserker of the Tenyi
+83755611 3 -- Baxia, Brightness of the Yang Zing
+43202238 3 -- Yazi, Evil of the Yang Zing
+19048328 3 -- Chaofeng, Phantom of the Yang Zing
+9464441 3 -- Adamancipator Risen - Dragite
+32519092 3 -- Monk of the Tenyi
+78917791 3 -- Shaman of the Tenyi
+#SLF1-AE
+79850798 3 -- Rocket Arrow Express
+51126152 3 -- Night Express Knight
+52481437 3 -- Super Express Bullet Train
+13647631 3 -- Heavy Freight Train Derricrane
+24731453 3 -- Snow Plow Hustle Rustle
+61692648 3 -- Lionhearted Locomotive
+24919805 3 -- Ruffian Railcar
+7080743 3 -- Express Train Trolley Olley
+88875132 3 -- Flying Pegasus Railroad Stampede
+34475451 3 -- Construction Train Signal Red
+56910167 3 -- Superdreadnought Rail Cannon Gustav Max
+49032236 3 -- Number 81: Superdreadnought Rail Cannon Super Dora
+26096328 3 -- Superdreadnought Rail Cannon Juggernaut Liebe
+49121795 3 -- Heavy Armored Train Ironwolf
+146746 3 -- Double Headed Anger Knuckle
+97520701 3 -- Special Schedule
+60879050 3 -- Train Connection
+76136345 3 -- Revolving Switchyard
+25274141 3 -- Urgent Schedule
+51369889 3 -- Barrage Blast
+86120751 3 -- Aleister the Invoker
+13529466 3 -- Invoked Caliga
+49513164 3 -- Invoked Raidjin
+85908279 3 -- Invoked Cocytus
+12307878 3 -- Invoked Purgatrio
+48791583 3 -- Invoked Magellanica
+75286621 3 -- Invoked Mechaba
+11270236 3 -- Invoked Elysium
+97300502 3 -- Invoked Augoeides
+97973962 3 -- Aleister the Invoker of Madness
+47679935 3 -- Magical Meltdown
+74063034 3 -- Invocation
+458748 3 -- The Book of the Law
+47457347 3 -- Omega Summon
+26077387 3 -- Sky Striker Ace - Raye
+37351133 3 -- Sky Striker Ace - Roze
+33331231 3 -- Surgical Striker - H.A.M.P.
+96084564 3 -- Aileron
+96795312 3 -- Sage of Strength - Akash
+22790910 3 -- Sage of Wisdom - Himmel
+34456146 3 -- Sage of Benevolence - Ciela
+20357457 3 -- Pillar of the Future - Cyanos
+63288573 3 -- Sky Striker Ace - Kagari
+90673288 3 -- Sky Striker Ace - Shizuku
+8491308 3 -- Sky Striker Ace - Hayate
+12421694 3 -- Sky Striker Ace - Kaina
+75147529 3 -- Sky Striker Ace - Zeke
+98462037 3 -- Sky Striker Ace - Azalea
+56741506 3 -- Sky Striker Ace - Azalea Temperance
+63166095 3 -- Sky Striker Mobilize - Engage!
+99550630 3 -- Sky Striker Maneuver - Afterburners!
+25955749 3 -- Sky Striker Maneuver - Jamming Waves!
+52340444 3 -- Sky Striker Mecha - Hornet Drones
+98338152 3 -- Sky Striker Mecha - Widow Anchor
+25733157 3 -- Sky Striker Mecha - Eagle Booster
+51227866 3 -- Sky Striker Mecha - Shark Cannon
+97616504 3 -- Sky Striker Mecharmory - Hercules Base
+24010609 3 -- Sky Striker Mecha Modules - Multirole
+50005218 3 -- Sky Striker Airspace - Area Zero
+21623008 3 -- Sky Striker Maneuver - Vector Blast
+46271408 3 -- Sky Striker Maneuver - Scissors Cross
+9726840 3 -- Sky Striker Mobilize - Linkage!
+40398073 3 -- Nurse Dragonmaid
+76782778 3 -- Dragonmaid Ernus
+13171876 3 -- Laundry Dragonmaid
+49575521 3 -- Dragonmaid Nudyarl
+16960120 3 -- Kitchen Dragonmaid
+42055234 3 -- Dragonmaid Tinkhec
+88453933 3 -- Parlor Dragonmaid
+15848542 3 -- Dragonmaid Lorpar
+32600024 3 -- Chamber Dragonmaid
+41232647 3 -- House Dragonmaid
+24799107 3 -- Dragonmaid Sheou
+78231355 3 -- Dragonmaid Hospitality
+14625090 3 -- Dragonmaid Welcome
+40110009 3 -- Dragonmaid Changeover
+15754711 3 -- Dragonmaid Send-Off
+57416183 3 -- Dragonmaid Tidying
+77515704 3 -- Dragonmaid Downtime
+79371769 3 -- Laundry Trap
+36326160 3 -- Live☆Twin Ki-sikil
+73810864 3 -- Live☆Twin Lil-la
+54257392 3 -- Live☆Twin Ki-sikil Frost
+81078880 3 -- Live☆Twin Lil-la Treat
+62098216 3 -- Evil★Twins Ki-sikil & Lil-la
+9205573 3 -- Evil★Twin Ki-sikil
+36609518 3 -- Evil★Twin Lil-la
+93672138 3 -- Evil★Twin's Trouble Sunny
+8083925 3 -- Live☆Twin Home
+35487920 3 -- Live☆Twin Channel
+61976639 3 -- Secret Password
+37582948 3 -- Live☆Twin Sunny's Snitch
+98360333 3 -- Evil★Twin Challenge
+34365442 3 -- Evil★Twin GG EZ
+60759087 3 -- Evil★Twin Present
+27923575 3 -- Boo-Boo Game
+3814632 3 -- Skypalace Gangaridai
+36776089 3 -- Sky Cavalry Centaurea
+72336818 3 -- Pentestag
+65330383 3 -- Knightmare Gryphon
+71607202 3 -- Muckraker From the Underworld
+47961342 3 -- Switch Point
+73355951 3 -- Alpha Summon
+844056 3 -- Red Arrows
+36848764 3 -- Sweet Roommaid
+72233469 3 -- Lil-la Rap
+#24AT-AE5
+10604644 3 -- Therion "King" Regulus
+72634965 3 -- Vanity's Ruler
+28674152 3 -- Radian, the Multidimensional Kaiju
+99426834 3 -- Beastking of the Swamps
+57662975 3 -- Darkstorm Dragon
+84769941 3 -- Super Anti-Kaiju War Machine Mecha-Dogoran
+45221020 3 -- Treasure Panda
+29884951 3 -- Swordsoul Auspice Chunjun
+46759931 3 -- Vision HERO Trinity
+92892239 3 -- Borreload Furious Dragon
+36898537 3 -- Metaphys Horus
+33158448 3 -- F.A. Dawn Dragster
+73079836 3 -- Adamancipator Risen - Raptite
+92519087 3 -- Virtual World Kyubi - Shenshen
+30163008 3 -- Ra'ten, the Heavenly General
+93600443 3 -- Mask Change II
+4227096 3 -- Mistaken Arrest
+67616300 3 -- Chicken Game
+78836195 3 -- Swordsoul Assessment
+#CR06-AE
+50304345 3 -- Evil HERO Infernal Prodigy
+95943058 3 -- Evil HERO Infernal Gainer
+13650422 3 -- Evil HERO Adusted Gold
+45659520 3 -- Evil HERO Sinister Necrom
+58554959 3 -- Evil HERO Malicious Edge
+22160245 3 -- Evil HERO Inferno Wing
+21947653 3 -- Evil HERO Lightning Golem
+50282757 3 -- Evil HERO Infernal Sniper
+58332301 3 -- Evil HERO Dark Gaia
+13293158 3 -- Evil HERO Wild Cyclone
+86676862 3 -- Evil HERO Malicious Fiend
+86165817 3 -- Evil HERO Malicious Bane
+12071500 3 -- Dark Calling
+72043279 3 -- Supreme King's Castle
+18438874 3 -- Evil Mind
+16725505 3 -- Speedroid Red-Eyed Dice
+28151978 3 -- Speedroid Dominobutterfly
+96708940 3 -- Speedroid Marble Machine
+81275020 3 -- Speedroid Terrortop
+53932291 3 -- Speedroid Taketomborg
+59640711 3 -- Speedroid Den-Den Daiko Duke
+96945958 3 -- Speedroid CarTurbo
+86976918 3 -- Speedroid Ultra Hound
+53054833 3 -- Speedroid Double Yoyo
+17328157 3 -- Speedroid Horse Stilts
+50482813 3 -- Speedroid Fuki-Modoshi Piper
+26420373 3 -- Speedroid Passinglider
+82044279 3 -- Clear Wing Synchro Dragon
+90036274 3 -- Clear Wing Fast Dragon
+50954680 3 -- Crystal Wing Synchro Dragon
+59765225 3 -- Crystal Clear Wing Synchro Dragon
+23361526 3 -- Hi-Speedroid Cork Shooter
+86943389 3 -- Hi-Speedroid Puzzle
+42110604 3 -- Hi-Speedroid Chanbara
+21516908 3 -- Hi-Speedroid Hagoita
+97007933 3 -- Hi-Speedroid Kendama
+5772618 3 -- Hi-Speedroid Kitedrake
+86154370 3 -- Hi-Speedroid Clear Wing Rider
+72813401 3 -- Hi-Speedroid Rubber Band Shooter
+88204302 3 -- Speed Recovery
+12148078 3 -- Speedroid Wheel
+29114773 3 -- Speedroid Scratch
+58543073 3 -- Speedroid Dupligate
+90582719 3 -- Gladiator Beast Andal
+5975022 3 -- Gladiator Beast Murmillo
+612115 3 -- Gladiator Beast Retiari
+16003979 3 -- Gladiator Beast Sagittarii
+41470137 3 -- Gladiator Beast Bestiari
+78868776 3 -- Gladiator Beast Laquari
+77642288 3 -- Gladiator Beast Secutor
+25924653 3 -- Gladiator Beast Darius
+57731460 3 -- Gladiator Beast Equeste
+52502677 3 -- Gladiator Beast Attorix
+67385964 3 -- Gladiator Beast Noxious
+88996322 3 -- Gladiator Beast Vespasius
+7573135 3 -- Gladiator Beast Augustus
+92373006 3 -- Test Tiger
+48156348 3 -- Gladiator Beast Gyzarus
+27346636 3 -- Gladiator Beast Heraklinos
+29357956 3 -- Gladiator Beast Nerokius
+3779662 3 -- Gladiator Beast Andabata
+30864377 3 -- Gladiator Beast Tamer Editor
+33652635 3 -- Gladiator Beast Domitianus
+62000467 3 -- Gladiator Beast Dragases
+66863374 3 -- Test Panther
+35224440 3 -- Gladiator Proving Ground
+20201255 3 -- Gladiator Beast's Comeback
+66290900 3 -- Gladiator Beast United
+93684009 3 -- Gladiator Rejection
+96216229 3 -- Gladiator Beast War Chariot
+16990348 3 -- Gladiator Beast Charge
+52394047 3 -- Gladiator Naumachia
+93665266 3 -- Crystron Quan
+20050865 3 -- Crystron Citree
+66938505 3 -- Crystron Rion
+56049970 3 -- Crystron Prasiortle
+83443619 3 -- Crystron Smiger
+29838323 3 -- Crystron Thystvern
+55326322 3 -- Crystron Rosenix
+3422200 3 -- Crystron Sulfefnir
+39964797 3 -- Crystron Quandax
+76359406 3 -- Crystron Ametrix
+2743001 3 -- Crystron Phoenix
+13455674 3 -- Crystron Quariongandrax
+50588353 3 -- Crystron Halqifibrax
+3576031 3 -- Crystolic Potential
+52176579 3 -- Crystron Entry
+99274184 3 -- Crystron Impact
+72291078 3 -- Mecha Phantom Beast O-Lion
+94973028 3 -- Mecha Phantom Beast Coltwing
+22110647 3 -- Mecha Phantom Beast Dracossack
+44097050 3 -- Mecha Phantom Beast Auroradon
+49036338 3 -- PSY-Frame Driver
+38814750 2 -- PSY-Framegear Gamma
+74203495 3 -- PSY-Framegear Delta
+1697104 3 -- PSY-Framegear Epsilon
+85138716 3 -- Rescue Rabbit
+18494511 3 -- Icejade Ran Aegirine
+40854197 3 -- Elemental HERO Absolute Zero
+61665245 3 -- Summon Sorceress
+#SUDA-AE
+99217226 3 -- Paladins of Bonds and Unity
+3598351 3 -- Evil HERO Toxic Bubble
+30583090 3 -- Evil HERO Dead-End Prison
+76978105 3 -- Evil HERO Infernal Rider
+3376703 3 -- Arcana Force V - The Hierophant
+39761418 3 -- Arcana Force XIX - The Sun
+65155517 3 -- Speedroid Colonel Clackers
+2254222 3 -- Speedroid Wing Synchron
+38648860 3 -- Elzette, Azamina of the White Forest
+65033975 3 -- Queen Azamina
+91438674 3 -- Argostars - Glorious Adra
+37426272 3 -- Materiactor Exareptor
+64911387 3 -- Materiactor Zeptwing
+90315086 3 -- Hydrojet Shark
+27704731 3 -- Metalflame Swordsman
+63198739 3 -- Primite Dragon Ether Beryl
+99193444 3 -- Poseidra, the Storming Atlantean
+26582143 3 -- Gladiator Beast Gistel
+62076252 3 -- Test Bear
+99471856 3 -- Crystron Tristaros
+25865565 3 -- Crystron Sulfador
+52854600 3 -- Tenyi Spirit - Suruya
+98248208 3 -- Driangle, Dragon of the Dark Deep
+24643913 3 -- Liberator Eto
+51132012 3 -- Grand Knight of the Red Lotus
+87126721 3 -- Mulcharmy Meowls
+54611591 3 -- Hallo, the Spirit of Tricks
+81005500 3 -- Ween, the Spirit of Treats
+24521325 3 -- Template Skipper
+50915474 3 -- Goddess of the Two Sides
+86304179 3 -- Tempura of Fortune - EBI
+13708888 3 -- Evil HERO Neos Lord
+59893882 3 -- Evil HERO Inferno Wing - Backfire
+86282581 3 -- Evil HERO Darkest Knight
+12686296 3 -- Arcana Force EX - The Chaos Ruler
+58071334 3 -- Snake-Eyes Doomed Dragon
+85065943 3 -- Saint Azamina
+11464648 3 -- Fiendsmith's Rextremende
+48958757 3 -- Gladiator Beast Claudius
+84343351 3 -- Crystal Clear Wing Over Synchro Dragon
+10732060 3 -- Hi-Speedroid Glider 2
+47736165 3 -- Crystron Eleskeletus
+73121813 3 -- Tenyi Spirit - Mula Adhara
+10515412 3 -- Lightstorm Dragon
+46014517 3 -- Goblin Bikers Gone Bonkers
+72409226 3 -- Materiactor Exagard
+9453320 3 -- Abysstrite, the Atlantean Spirit
+45852939 3 -- Eclipse Twins
+72246674 3 -- Gladiator Beast Dareios
+4731783 3 -- A Bao A Qu, the Lightless Shadow
+41739381 3 -- Clockwork Knight
+77124096 3 -- Dark Contact
+3519195 3 -- Evil Assault
+30913809 3 -- Light Force
+76302448 3 -- Arcana Spread
+3496543 3 -- Sinful Spoils of the White Forest
+39881252 3 -- Play the Diabell
+65289956 3 -- Like the Diabell
+2674965 3 -- Argostars - Home Stadium
+38669664 3 -- Materiactor Meltdown
+5063379 3 -- Flavian - Colosseum of the Gladiator Beasts
+31552317 3 -- Crystron Inclusion
+77946022 3 -- Tenyinfinity
+4341721 3 -- Hallo-Ween!
+30339825 3 -- Hydor, the Base of All Things
+67724434 3 -- Double Wild
+3129133 3 -- Delta of Invitation
+39613288 3 -- Dark Supremacy
+66002986 3 -- Speedroid Clear Wing Wonder
+2006591 3 -- Sinful Spoils Awakening
+39491690 3 -- Azamina Aphes
+65889305 3 -- Argostars - Lightning Tydeu
+91284003 3 -- Argostars - Swift Capane
+38379052 3 -- Argostars - Slayer Eteo
+64767757 3 -- Materiactor Critical
+91152455 3 -- Flame Coating Metalmorph
+27556460 3 -- Primite Scream
+63941169 3 -- Abyss-steam
+90939874 3 -- Six Strike - Sextuple Barrage
+26434972 3 -- Fiendsmith Kyrie
+53829527 3 -- Crystron Cluster
+5861892 3 -- Arcana Force EX - The Light Ruler
+62892347 3 -- Arcana Force 0 - The Fool
+8396952 3 -- Arcana Force I - The Magician
+35781051 3 -- Arcana Force III - The Empress
+61175706 3 -- Arcana Force IV - The Emperor
+97574404 3 -- Arcana Force VI - The Lovers
+34568403 3 -- Arcana Force VII - The Chariot
+60953118 3 -- Arcana Force XIV - Temperance
+59712426 3 -- Arcana Force XV - The Fiend
+97452817 3 -- Arcana Force XVIII - The Moon
+23846921 3 -- Arcana Force XXI - The World
+69831560 3 -- Arcana Force EX - The Dark Ruler
+33008376 3 -- Materiactor Gigadra
+60942444 3 -- Tenyi Spirit - Mapura
+97036149 3 -- Tenyi Spirit - Nahata
+4991081 3 -- Harpie's Pet Dragon - Fearsome Fire Blast
+98875863 3 -- G Golem Rock Hammer
+25273572 3 -- G Golem Pebble Dog
+9348522 3 -- Cloudcastle
+70913714 3 -- Old Entity Hastorr
+70597485 3 -- Materiactor Gigaboros
+63813056 3 -- Xtra HERO Dread Decimator
+5402805 3 -- Berserker of the Tenyi
+23935886 3 -- Draco Masters of the Tenyi
+38030232 3 -- Tenyi Spirit - Sahasrara
+61668670 3 -- G Golem Crystal Heart
+97053215 3 -- G Golem Stubborn Menhir
+24151924 3 -- G Golem Invalid Dolmen
+50546029 3 -- G Golem Dignified Trilithon
+97661969 3 -- Aussa the Earth Charmer, Immovable
+30674956 3 -- Wynn the Wind Charmer, Verdant
+71818935 3 -- Moon of the Closed Heaven
+94820406 3 -- Dark Fusion
+73206827 3 -- Light Barrier
+11819473 3 -- Arcana Reading
+17008760 3 -- Materiactor Annulus
+84797028 3 -- Clockwork Night
+36690018 3 -- Reversal of Fate
+99189322 3 -- Arcana Call
+21834870 3 -- Fists of the Unrivaled Tenyi
+#DBCB-AE
+35844557 1 -- Sword Ryzeal
+72238166 3 -- Node Ryzeal
+8633261 2 -- Ice Ryzeal
+34022970 1 -- Ext Ryzeal
+61116514 3 -- Palm Ryzeal
+7511613 3 -- Ryzeal Duo Drive
+34909328 3 -- Ryzeal Detonator
+60394026 3 -- Ryzeal Plugin
+6798031 3 -- Ryzeal Cross
+33787730 3 -- Ryzeal Plasma Hole
+94380860 3 -- Number 103: Ragnazero
+63746411 3 -- Number 106: Giant Hand
+6511113 3 -- Traptrix Rafflesia
+62967433 3 -- Baromet the Sacred Sheep Shrub
+69272449 1 -- Maliss <P> White Rabbit
+96676583 3 -- Maliss <P> Chessy Cat
+32061192 1 -- Maliss <P> Dormouse
+68059897 3 -- Maliss <Q> Red Ransom
+95454996 3 -- Maliss <Q> White Binder
+21848500 3 -- Maliss <Q> Hearts Crypter
+68337209 1 -- Maliss in Underground
+94722358 3 -- Maliss <C> MTP-07
+20726052 3 -- Maliss <C> GWC-06
+57111661 3 -- Maliss <C> TB-11
+18789533 3 -- Dotscaper
+92998610 3 -- Aloof Lupine
+66403530 3 -- Topologic Zeroboros
+5821478 3 -- Topologic Bomber Dragon
+72529749 3 -- Topologic Trisbaena
+43839002 3 -- Cynet Backdoor
+93509766 3 -- Kyoro Ryu-Ge Kaiva
+20904475 3 -- Kairo Ryu-Ge Emva
+56499179 3 -- Genro Ryu-Ge Hakva
+92487128 3 -- Sosei Ryu-Ge Mistva
+29882827 3 -- Ryu-Ge Rising
+55276522 3 -- Ryu-Ge War Zone
+82661630 3 -- Ryu-Ge Realm - Dino Domains
+28669235 3 -- Ryu-Ge Realm - Sea Spires
+55154344 3 -- Ryu-Ge Realm - Wyrm Winds
+81549048 3 -- Ryu-Ge Rivalry
+97526666 3 -- Planet Pathfinder
+6728559 3 -- Archnemeses Protos
+66523544 3 -- Superdimensional Robot Galaxy Destroyer
+57282724 3 -- World Gears of Theurlogical Demiurgy
+65367484 3 -- Photon Thrasher
+34143852 3 -- Heroic Challenger - Extra Sword
+24610207 3 -- Star Drawing
+16889337 3 -- Aratama
+67972302 3 -- Sakitama
+21770839 3 -- Odd-Eyes Phantasma Dragon
+13090893 3 -- Grid Sweeper
+29374928 3 -- Armored Bitron
+56161953 3 -- Scrypton
+16684346 3 -- Proxy Horse
+70950698 3 -- Boot Staggered
+39317553 3 -- Drill Driver Vespenato
+9763474 3 -- Haggard Lizardose
+72355441 3 -- Xyz Gift
+26708437 3 -- Xyz Reborn
+#25AT-AE1
+46947713 3 -- Transcode Talker
+20292186 3 -- Artifact Scythe
+30765615 3 -- Ringowurm, the Dragon Guarding the Hundred Apples
+67234805 3 -- Powersink Stone
+47432275 3 -- Kuribon
+20210570 3 -- Regulus
+34022290 3 -- Guardian Eatos
+66736715 3 -- Moissa Knight, the Comet General
+25958491 3 -- Ancient Sacred Wyvern
+68836428 3 -- Tri-Edge Levia
+80796456 3 -- Number 70: Malevolent Sin
+88581108 3 -- True King of All Calamities
+92015800 3 -- Number 76: Harmonizer Gradielle
+5043010 3 -- Firewall Dragon
+37129797 3 -- Vampire Sucker
+60292055 3 -- Elphase
+75524092 3 -- Vicious Claw
+37812118 3 -- Cup of Ace
+64014615 3 -- Pot of Acquisitiveness
+16278116 3 -- Dragon's Bind
+49082032 3 -- Resurgam Xyz
+#CR07-AE
+16020923 3 -- Pikari @Ignister
+42429678 3 -- Bururu @Ignister
+88413677 3 -- Doyon @Ignister
+15808381 3 -- Achichi @Ignister
+41306080 3 -- Hiyari @Ignister
+78751195 3 -- Doshin @Ignister
+14146794 3 -- Donyoribo @Ignister
+55762976 3 -- Gussari @Ignister
+82257671 3 -- Gatchiri @Ignister
+66192538 3 -- Danmari @Ignister
+37061511 3 -- Water Leviathan @Ignister
+62111090 3 -- Earth Golem @Ignister
+98506199 3 -- Wind Pegasus @Ignister
+61399402 3 -- Light Dragon @Ignister
+24842059 3 -- Linguriboh
+11738489 3 -- The Arrival Cyberse @Ignister
+24882256 3 -- Fire Phoenix @Ignister
+97383507 3 -- Dark Templar @Ignister
+59054773 3 -- Ignister A.I.Land
+28270534 3 -- FA.I.ghting Spirit
+32056070 3 -- You and A.I.
+6552971 3 -- A.I. Meet You
+10493654 3 -- A.I. Contact
+85327820 3 -- A.I.'s Ritual
+59332125 3 -- A.I. Love Fusion
+22933016 3 -- A.I.dle Reborn
+86449372 3 -- TA.I. Strike
+69381150 3 -- A.I.Q
+54374642 3 -- A.I.'s Show
+28645123 3 -- A.I. Challenge You
+77421977 3 -- A.I. Shadow
+2347477 3 -- Micro Coder
+63528891 3 -- Backup Secretary
+30114823 3 -- Code Generator
+71278040 3 -- Parallel eXceed
+20455229 3 -- Firewall Defenser
+57940938 3 -- Firewall Phantom
+65037172 3 -- Cyberse Sage
+92422871 3 -- Cyberse Desavewurm
+52698008 3 -- Cyberse Wicckid
+59859086 3 -- Splash Mage
+30342076 3 -- Link Decoder
+34767865 3 -- Cynet Ritual
+60018643 3 -- Cynet Codec
+57900671 3 -- Cynet Rollback
+70366448 3 -- Drastic Draw
+7403341 3 -- Cynet Conflict
+82886276 3 -- Cynet Circuit
+60316373 3 -- Heraldic Beast Aberconway
+96704018 3 -- Heraldic Beast Berners Falcon
+56921677 3 -- Heraldic Beast Basilisk
+82315772 3 -- Heraldic Beast Eale
+19310321 3 -- Heraldic Beast Twin-Headed Eagle
+45705025 3 -- Heraldic Beast Unicorn
+82293134 3 -- Heraldic Beast Leo
+87255382 3 -- Heraldic Beast Amphisbaena
+47387961 3 -- Number 8: Heraldic King Genom-Heritage
+23649496 3 -- Number 18: Heraldry Patriarch
+2407234 3 -- Number 69: Heraldry Crest
+11522979 3 -- Number C69: Heraldry Crest of Horror
+61314842 3 -- Advanced Heraldry Art
+84220251 3 -- Heraldry Reborn
+59048135 3 -- Augmented Heraldry
+84482694 3 -- Charged-Up Heraldry
+17536995 3 -- Heraldry Change
+90411554 3 -- Redox, Dragon Ruler of Boulders
+89399912 3 -- Tempest, Dragon Ruler of Storms
+91020571 3 -- Reactan, Dragon Ruler of Pebbles
+89185742 3 -- Lightning, Dragon Ruler of Drafts
+17947697 3 -- Maiden of White
+54332792 3 -- Neo Kaiser Sea Horse
+89604813 3 -- Blue-Eyes Ultimate Spirit Dragon
+16699558 3 -- Indigo-Eyes Silver Dragon
+42097666 3 -- Spirit with Eyes of Blue
+80326401 3 -- Wishes for Eyes of Blue
+17725109 3 -- Roar of the Blue-Eyed Dragons
+43219114 3 -- Majesty of the White Dragons
+96746083 3 -- True King Agnimazud, the Vanisher
+82321037 3 -- True King Bahrastos, the Fathomer
+30539496 3 -- True King Lithosagym, the Disaster
+95004025 3 -- Majesty Maiden, the True Dracocaster
+22499034 3 -- Ignis Heat, the True Dracowarrior
+58984738 3 -- Dinomight Knight, the True Dracofighter
+94982447 3 -- Dreiath III, the True Dracocavalry General
+21377582 3 -- Master Peace, the True Dracoslaying King
+57761191 3 -- Metaltron XII, the True Dracombatant
+94160895 3 -- Mariamne, the True Dracophoenix
+13035077 3 -- Dragonic Diagram
+49430782 3 -- True Draco Heritage
+75425320 3 -- Disciples of the True Dracophoenix
+35125879 3 -- True King's Return
+61529473 3 -- True Draco Apocalypse
+2061963 3 -- Number 104: Masquerade
+49678559 3 -- Number 102: Star Seraph Sentry
+59627393 3 -- Number 105: Battlin' Boxer Star Cestus
+57734012 3 -- Rank-Up-Magic - The Seventh One
+23153227 3 -- Seventh Ascension
+7477101 3 -- Seventh Tachyon
+21501505 3 -- Cairngorgon, Antiluminescent Knight
+1269512 3 -- Full Armored Utopic Ray Lancer
+#25YC-AE
+10949074 3 -- Anotherverse Stratios
+#ALIN-AE
+58931850 3 -- Dragon Master Lords
+3723262 3 -- Wizard @Ignister
+30118811 3 -- Backup @Ignister
+66102515 3 -- Kurikurinku @Ignister
+2501624 3 -- Dark Magician Girl the Magician's Apprentice
+35095329 3 -- Evil HERO Vicious Claws
+61480937 3 -- Regulus the Fairy Beast
+98888032 3 -- Spore the Fairy Seed
+34873741 3 -- Kuribon the Fairy Spirit
+60268386 3 -- Heraldic Beast Gryphon
+97662494 3 -- Heraldic Beast Stad Whale
+23151193 3 -- Diabellstar Vengeance
+60145298 3 -- Diabellze the White Witch
+96540807 3 -- Regenesis Warrior
+22938501 3 -- Regenesis Sage
+59323650 3 -- Regenesis Dragon
+95718355 3 -- Regenesis Archfiend
+22812963 3 -- Regenesis Lord
+58201062 3 -- Spectral, Dragon Ruler of Flickers
+94655777 3 -- Nebulus, Dragon Ruler of Mishaps
+21050476 3 -- Argostars - Fierce Parthe
+57448410 3 -- Prima Materiactor
+84433129 3 -- Star Ryzeal
+20938824 1 -- Maliss <P> March Hare
+56322832 3 -- Tensei Ryu-Ge Anva
+83711531 3 -- Red-Eyes Metal Claws Dragon
+19715246 3 -- Cyber Jormungardr
+56100345 3 -- Cyberdark Wurm
+82699999 3 -- Live☆Twin Lil-la Sweet
+19093698 3 -- Moissa Wight
+45488703 3 -- NT8000 - SIRIUS
+81476402 3 -- Wicked Serpent Night Dragon
+18861006 3 -- Crimson Firewing Pegasus
+44265115 3 -- Brain Controller
+71750854 3 -- Bomber Place
+17749468 3 -- Azamina
+43143567 3 -- Fallen Angel of the Golden Land
+70538272 3 -- Filia Regis
+16926971 3 -- Firewall Saber Dragon
+43321985 3 -- Ancient Fairy Life Dragon
+79415624 3 -- Snake-Eyes Vengeance Dragon
+5800323 3 -- Poplar of the White Forest
+42209438 3 -- Legendary Lord Six Samurai - Kizan
+78693036 3 -- Juraishin, the Cursed Thunder God
+5088741 3 -- Code Igniter
+31086840 3 -- Number 69: Heraldry Crest - Shatter Stream
+77571454 3 -- Number 69: Heraldry Crest - Dark Matter Demolition
+4965193 3 -- Chasma, Dragon Ruler of Auroras
+30350202 3 -- Eclipse, Dragon Ruler of Catastrophes
+67359907 3 -- Disaster, Dragon Ruler of All Apocalypses
+3743515 3 -- Steamed Sabersaurus
+39138610 3 -- Allied Code Talker @Ignister
+6636319 3 -- Evil★Twin Ki-sikil Deal
+42021064 3 -- Dogurad, the Stonetrooper
+79015062 3 -- A.I. Connect
+5414777 3 -- World of Spirits
+31809476 3 -- Flash of Heraldry
+78293584 3 -- Filia Diabell
+4398189 3 -- Witch of the White Forest
+31786838 3 -- Regenesis
+67171933 3 -- Regenesis Code
+4575541 3 -- Here There Be Dragons
+30964246 3 -- Argostars - Giantslaying
+66059345 3 -- Materiactor Meltthrough
+93453053 3 -- Maliss in the Mirror
+39848658 3 -- Wight Reanimator
+66236707 3 -- Gordian Slicer
+92221402 3 -- Chaotic Elements
+38625110 3 -- Let's Go Together
+65114115 3 -- Seven Stars Slash - Army Annihilator Hagun
+91509824 3 -- SA.I.dekick
+28903523 3 -- Eternal Sunshine
+64998567 3 -- Curse of Diabell
+90386276 3 -- Sinful Spoils Sanctification
+27781371 3 -- Regenesis Birth
+53276089 3 -- Ryzeal Mass Driver
+90664684 3 -- Ryu-Ge End
+22669793 3 -- Eldlixir of the Glorious Golden Land
+58053438 3 -- Songs of the Dominators
+85442146 3 -- Dragon's Mind
+21846145 3 -- Abduction
+23893227 3 -- Cyber Dragon Core
+56364287 3 -- Cyber Dragon Herz
+1142880 3 -- Cyber Dragon Nachster
+82562802 3 -- Cyberdark Claw
+5370235 3 -- Cyberdark Chimera
+27182739 3 -- Mathmech Sigma
+53577438 3 -- Mathmech Nabla
+80965043 3 -- Mathmech Addition
+16360142 3 -- Mathmech Subtraction
+52354896 3 -- Mathmech Multiplication
+89743495 3 -- Mathmech Division
+17946349 3 -- Mathmech Diameter
+36521307 3 -- Mathmech Circular
+24731391 3 -- Cyberse Magician
+64599569 3 -- Chimeratech Overdragon
+79229522 3 -- Chimeratech Fortress Dragon
+84058253 3 -- Chimeratech Rampage Dragon
+87116928 3 -- Chimeratech Megafleet Dragon
+15248594 3 -- Geomathmech Magma
+42632209 3 -- Geomathmech Final Sigma
+58069384 3 -- Cyber Dragon Nova
+10443957 3 -- Cyber Dragon Infinity
+88021907 3 -- Primathmech Laplacian
+85692042 3 -- Primathmech Alembertian
+11674673 3 -- Cyberse Witch
+74567889 3 -- Dark Infant @Ignister
+88093706 3 -- Update Jammer
+46724542 3 -- Cyber Dragon Sieger
+3659803 3 -- Overload Fusion
+86686671 3 -- Cyber Repair Plant
+64753988 3 -- Cyberdark Realm
+78217065 3 -- Evolution End Burst
+14025912 3 -- Mathmech Equation
+41410651 3 -- Mathmech Billionblade Nayuta
+87804365 3 -- Mathmech Superfactorial
+14393464 3 -- Mathmech Induction
+#TT02-AEB
+37343995 3 -- Exosister Martha
+16474916 3 -- Exosister Elis
+43863925 3 -- Exosister Stella
+79858629 3 -- Exosister Irene
+5352328 3 -- Exosister Sophia
+77913594 3 -- Exosister Pax
+4408198 3 -- Exosister Arment
+30802207 3 -- Exosister Carpedivem
+77891946 3 -- Exosister Vadis
+197042 3 -- Exosister Returnia
+59242457 3 -- Exosisters Magnifica
+42741437 3 -- Exosister Mikailis
+78135071 3 -- Exosister Kaspitell
+5530780 3 -- Exosister Gibrine
+41524885 3 -- Exosister Asophiel
+#TT02-AEA
+94259633 3 -- Relinquished Anima
+#CR08-AE
+8512558 3 -- Utopic Onomatopoeia
+69852487 3 -- Astraltopia
+23720856 3 -- Zubababancho Gagagacoat
+59724555 3 -- Dodododwarf Gogogoglove
+68258355 3 -- ZS - Armed Sage
+4647954 3 -- ZS - Ascended Sage
+51865604 3 -- ZS - Vanish Sage
+32164201 3 -- ZW - Pegasus Twin Saber
+81471108 3 -- ZW - Tornado Bringer
+84013237 3 -- Number 39: Utopia
+62517849 3 -- Number 39: Utopia Double
+93777634 3 -- Number 39: Utopia Rising
+21521304 3 -- Number 39: Utopia Beyond
+95134948 3 -- Number 99: Utopia Dragonar
+56840427 3 -- Number C39: Utopia Ray
+65305468 3 -- Number F0: Utopic Future
+26973555 3 -- Number F0: Utopic Draco Future
+75402014 3 -- Ultimate Dragonic Utopia Ray
+68679595 3 -- Ultimate Leo Utopia Ray
+94770493 3 -- Double or Nothing!
+11705261 3 -- Xyz Change Tactics
+62623659 3 -- Zexal Construction
+6595475 3 -- Onomatopaira
+85119159 3 -- Onomatopickup
+67517351 3 -- Hyper Rank-Up-Magic Utopiforce
+68630939 3 -- Numbers Protection
+84812868 3 -- Lunalight White Rabbit
+11317977 3 -- Lunalight Black Sheep
+48427163 3 -- Lunalight Purple Butterfly
+83190280 3 -- Lunalight Tiger
+11439455 3 -- Lunalight Blue Cat
+35618217 3 -- Lunalight Kaleido Chick
+94919024 3 -- Lunalight Crimson Fox
+14152693 3 -- Lunalight Emerald Bird
+50546208 3 -- Lunalight Yellow Marten
+47705572 3 -- Lunalight Wolf
+51777272 3 -- Lunalight Cat Dancer
+97165977 3 -- Lunalight Panther Dancer
+88753594 3 -- Lunalight Sabre Dancer
+24550676 3 -- Lunalight Leo Dancer
+48444114 3 -- Luna Light Perfume
+87931906 3 -- Lunalight Fusion
+11193246 3 -- Lunalight Reincarnation Dance
+13935001 3 -- Lunalight Serenade Dance
+73625877 3 -- Time Escaper
+98358303 3 -- Serene Psychic Witch
+25343017 3 -- Hushed Psychic Cleric
+62950604 3 -- Silent Psychic Wizard
+1834753 3 -- Overdrive Teleporter
+40101111 3 -- Ultimate Axon Kicker
+11047543 3 -- Psychic Feel Zone
+55673611 3 -- Psychic Trigger
+96570609 3 -- Ehther the Heavenly Monarch
+23064604 3 -- Erebus the Underworld Monarch
+73125233 3 -- Raiza the Storm Monarch
+9748752 3 -- Caius the Shadow Monarch
+95457011 3 -- Edea the Heavenly Squire
+59463312 3 -- Eidos the Underworld Squire
+19870120 3 -- March of the Monarchs
+61466310 3 -- Return of the Monarchs
+79844764 3 -- The Monarchs Stormforth
+5795980 3 -- Strike of the Monarchs
+33609262 3 -- Tenacity of the Monarchs
+84171830 3 -- Domain of the True Monarchs
+22842126 3 -- Pantheism of the Monarchs
+99940363 3 -- Frost Blast of the Monarchs
+98552723 3 -- Restoration of the Monarchs
+26822796 3 -- The Monarchs Awaken
+8522996 3 -- The First Monarch
+48716527 3 -- The Monarchs Erupt
+18235309 3 -- Escalation of the Monarchs
+54241725 3 -- The Prime Monarch
+1047075 3 -- Fighting Flame Swordsman
+37531679 3 -- Salamandra, the Flying Flame Dragon
+73936388 3 -- Mirage Swordsman
+324483 3 -- Ultimate Flame Swordsman
+36319131 3 -- Fighting Flame Dragon
+73714736 3 -- Flame Swordsrealm
+9102835 3 -- Salamandra Fusion
+35697544 3 -- Fighting Flame Sword
+62091148 3 -- Salamandra with Chain
+8080257 3 -- Flame Swordsdance
+58753372 3 -- Super Quantal Fairy Alphan
+12369277 3 -- Super Quantum Blue Layer
+85374678 3 -- Super Quantum Green Layer
+59975920 3 -- Super Quantum Red Layer
+73422829 3 -- Super Quantum White Layer
+85252081 3 -- Super Quantal Mech Beast Grampulse
+11646785 3 -- Super Quantal Mech Beast Aeroboros
+57031794 3 -- Super Quantal Mech Beast Magnaliger
+57450198 3 -- Super Quantal Mech Beast Lusterrex
+84025439 3 -- Super Quantal Mech King Great Magnus
+95493471 3 -- Neo Super Quantal Mech King Blaster Magna
+10424147 3 -- Super Quantal Mech Ship Magnacarrier
+72332074 3 -- Super Quantal Alphan Spike
+15721392 3 -- Super Quantal Alphancall Appeal
+47819246 3 -- Super Quantal Mech Sword - Magnaslayer
+68934651 3 -- Firewall Dragon Darkfluid
+64211118 3 -- Firewall Dragon Darkfluid - Neo Tempest Terahertz
+21637210 3 -- Firewall Dragon Singularity
+#25AT-AE2
+96381979 3 -- Brotherhood of the Fire Fist - Tiger King
+45379225 3 -- Psychic Lifetrancer
+91499077 3 -- Gagaga Samurai
+98642179 3 -- Ferocious Flame Swordsman
+85060248 3 -- Mind Protector
+21454943 3 -- Psychic Commander
+58786132 3 -- Lucius the Shadow Vassal
+22404675 3 -- Mithra the Thunder Vassal
+95993388 3 -- Landrobe the Rock Vassal
+24326617 3 -- Escher the Frost Vassal
+59808784 3 -- Berlineth the Firestorm Vassal
+22382087 3 -- Garum the Storm Vassal
+43385557 3 -- Magical Android
+70780151 3 -- Thought Ruler Archfiend
+7582066 3 -- Psychic Nightmare
+24221808 3 -- Overmind Archfiend
+15028680 3 -- HTS Psyhemuth
+25472513 3 -- Celestial Double Star Shaman
+70491413 3 -- Surprise Chain
+67378935 3 -- Overlay Network
+50277973 3 -- Swamp Mirrorer
+1825445 3 -- Super Quantal Union - Magnaformation
+#DUAD-AE
+62006866 3 -- Zubababa Knight
+9491461 3 -- Gagaga Ganbara Knight
+35886170 3 -- Gogogo Goblindbergh
+62880279 3 -- Dodododo Warrior
+8379983 3 -- Lunalight Gold Leo
+35763582 3 -- Lunalight Silver Hound
+61168637 3 -- Linkslayer @Ignister
+97556336 3 -- Medius the Pure
+34541940 3 -- Artmage Finmel
+60946049 3 -- Artmage Graflare
+97434754 3 -- Artmage Litera
+23829452 3 -- Artmage Power Patron
+9213491 3 -- Serene Psychic Girl
+36218106 3 -- Hushed Psychic Minister
+62606805 3 -- Mind Procedure
+95091919 3 -- Prototype Psychic Blaster
+31596518 3 -- Eidos the Underworld Monarch
+67584223 3 -- Tessera the Primal Squire
+94979322 3 -- Dark Flare Swordsman
+30373970 3 -- Miasma Dragon Tistina
+67768675 3 -- Kaibaman the Legend
+93156774 3 -- Vanquish Soul Hollie Sue
+29251488 3 -- Chef de Nouvelles
+66646087 3 -- Super Quantal Fairy Zetan
+92034192 3 -- Super Quantum Black Layer
+29439831 3 -- Morgana the Witch of Eyes
+55423549 3 -- Leo Wizard the Dark Fiend
+91818544 3 -- WAKE CUP! Mocha
+28306253 3 -- Angry Burger
+54701958 3 -- Lunalight Liger Dancer
+81196066 3 -- Lunalight Perfume Dancer
+27184601 3 -- Artmage Diactorus
+53589300 3 -- Nerva the Power Patron of Creation
+80073414 3 -- Absolute Axon Kicker
+26462013 3 -- Primite Dragon Nether Berzelius
+53466722 3 -- First of the Dragonlords
+89851827 3 -- Secreterion Dragon
+16246535 3 -- Silent Psychic Magician
+52644170 3 -- Crossmind Archfiend
+88139289 3 -- Psychic Blaster Mk-II
+15123983 3 -- THE Star Ham
+41522092 3 -- Number F0: Utopic Future Zexal
+88917691 3 -- Gagagaga Girl
+14301396 3 -- Heroic Champion - Magnum Excalibur
+40706444 3 -- Argostars - Adventurous Arion
+77894049 3 -- Vanquish Soul Rocks
+13289758 3 -- Gaia Stream, the Graceful Force
+40673853 3 -- Vallon, the Super Psy Skyblaster
+76072561 3 -- Sky Striker Ace = Zero
+12067160 3 -- Gorgon of Zilofthonia
+49451215 3 -- Ukanomitsune-no-Onari
+75956913 3 -- Gagaga Utopic Tactics
+2344618 3 -- Lunalight Masquerade
+74733322 3 -- Artmage Academic Arcane Arts Acropolis
+48739627 3 -- Theorealize
+37517035 3 -- Artmage Masterwork -Succession-
+1122030 3 -- Artmage Vandalism -Assault-
+74011784 3 -- Artmage Varnish -Alteration-
+483 3 -- Parallel Teleport
+36494597 3 -- Teleport Fusion
+63899196 3 -- The Monarchs Masterplan
+9283801 3 -- The Monarchs Revolt
+36672909 3 -- Regenesis Cycle
+62767644 3 -- Inferno of the Ashened
+99161253 3 -- Primite Fusion
+35550352 3 -- Vanquish Soul, Start!
+61944066 3 -- Nouvelles Recipe Book "Recettes de Nouvellez"
+98349765 3 -- Layer 19 "Sudden Incursion! Super Quantum Black!!"
+34433770 3 -- Sky Striker Special Maneuver - Lemnisgate!
+61822419 3 -- Guilt-Gripping Morganite
+97227123 3 -- Return of the Duelist
+23611122 3 -- Sudden Thunder Swamp
+60600821 3 -- Spring
+96004535 3 -- Unbreakable Xyz Barrier
+23599634 3 -- Artmage Pact -Awakening-
+59983249 3 -- Monarchic Perfection
+95382988 3 -- Regenesis Commands
+22377092 3 -- Trap Holic
+58761791 3 -- Shipping Error
+85150300 3 -- Spirit Poacher
+50903514 3 -- Blue Flame Swordsman
+86999951 3 -- Crystal God Tistina
+59504256 3 -- Demigod of the Tistina
+86111442 3 -- Sentinel of the Tistina
+13510157 3 -- Hound of the Tistina
+87498729 3 -- Fallen of the Tistina
+24892828 3 -- Returned of the Tistina
+50281477 3 -- Tainted of the Tistina
+78783557 3 -- Veidos the Eruption Dragon of Extinction
+4271596 3 -- King of the Ashened City
+30676200 3 -- Hero of the Ashened City
+67660909 3 -- Priestess of the Ashened City
+35151572 3 -- Shaman of the Ashened City
+62156277 3 -- Spearhead of the Ashened City
+3233859 3 -- Psychic Wheeleder
+30227494 3 -- Psychic Tracker
+70843274 3 -- Psychic Processor
+8540986 3 -- Veidos the Dragon of Endless Darkness
+35035985 3 -- Embers of the Ashened
+99115354 3 -- Hyper Psychic Riser
+12172567 3 -- Mind Castlin
+86532744 3 -- Number S39: Utopia Prime
+86331741 3 -- Gagagaga Magician
+31123642 3 -- ZS - Utopic Sage
+87676171 3 -- Tistina, the Divinity that Defies Darkness
+12397569 3 -- Divine Domain Baatistina
+13070280 3 -- Play of the Tistina
+58882608 3 -- Breath of the Tistina
+3055018 3 -- Obsidim, the Ashened City
+30453613 3 -- Awakening of Veidos
+61434639 3 -- Rekindling the Ashened
+98828338 3 -- Extinguishing the Ashened
+16238373 3 -- Psychic Arsenal
+85277313 3 -- Signs of the Tistina
+59069885 3 -- Embrace of the Tistina
+86553594 3 -- Discordance of the Tistina
+66848311 3 -- Ashened for Eternity
+34813443 3 -- Ashened to Endlessness
+43633088 3 -- Emergency Apport
+#DUAD-AES
+3606728 3 -- Gagaga Girl
+#DBJH-AE
+75003700 3 -- Dracotail Lukias
+1498449 3 -- Dracotail Faimena
+44482554 3 -- Dracotail Pan
+70871153 3 -- Dracotail Urgula
+7375867 3 -- Dracotail Mululu
+33760966 3 -- Dracotail Arthalion
+79755671 3 -- Dracotail Gulamel
+6153210 1 -- Ketu Dracotail
+32548318 3 -- Rahu Dracotail
+69932023 3 -- Dracotail Horn
+5431722 3 -- Dracotail Flame
+61173621 3 -- Edge Imp Chain
+13735899 3 -- Mysterion the Dragon Crown
+34773082 3 -- Frightfur Patchwork
+31425736 1 -- Cupsy☆Yummy
+68810435 3 -- Cooky☆Yummy
+4215180 3 -- Lollipo☆Yummy
+31603289 3 -- Cupsy★Yummy Way
+67098897 3 -- Cooky★Yummy Way
+93192592 3 -- Lollipo★Yummy Way
+30581601 2 -- Yummy★Snatchy
+66975205 3 -- Yummyusment☆Mignon
+93360904 3 -- Yummyusment★Acroquey
+29369059 3 -- Yummy☆Surprise
+65853758 3 -- Yummy★Redemption
+23656668 3 -- Gravity Controller
+72537897 1 -- Obedience Schooled
+33907039 3 -- Piri Reis Map
+92248362 2 -- K9-17 Izuna
+28642461 1 -- K9-66a Jokul
+55031170 3 -- K9-66b Lantern
+91025875 3 -- K9-ØØ Lupis
+27420823 3 -- K9-17 "Ripper"
+54919528 3 -- K9-ØØ "Hound"
+90303227 3 -- K9-X "Werewolf"
+27308231 3 -- K9-LC Release Restraint
+53792930 3 -- K9-X Forced Release
+80181649 3 -- "A Case for K9"
+26585784 3 -- K9-EW Special Release Experiment
+75214390 3 -- Overlay Booster
+29669359 3 -- Number 61: Volcasaurus
+2609443 3 -- Chronomaly Vimana
+29510428 3 -- Imperial Princess Quinquery
+14198496 3 -- Mystic Piper
+69865139 3 -- Guiding Light
+19636995 3 -- Red Hared Hasty Horse
+55067058 3 -- Number 19: Freezadon
+77334267 3 -- Wind-Up Arsenal Zenmaioh
+49456901 3 -- Number C104: Umbral Horror Masquerade
+55888045 3 -- Number C106: Giant Red Hand
+39139935 3 -- Number 33: Chronomaly Machu Mech
+69840739 3 -- Artifact Durendal
+57707471 3 -- Number 21: Frozen Lady Justice
+90126061 3 -- Number 5: Doom Chimera Dragon
+35772782 0 -- Number 67: Pair-a-Dice Smasher
+22829942 3 -- Fusion Recycling Plant
+51697825 3 -- Jack-In-The-Hand
+58570206 3 -- Heavy Polymerization
+#CR09-AE
+11609969 3 -- D/D Savant Kepler
+46796664 3 -- D/D Savant Copernicus
+45206713 3 -- D/D Swirl Slime
+72291412 3 -- D/D Necro Slime
+48210156 3 -- D/D Nighthowl
+72181263 3 -- D/D Orthros
+19580308 3 -- D/D Lamia
+28406301 3 -- D/D Gryphon
+5997110 3 -- D/D Count Surveyor
+42382265 3 -- D/D Scale Surveyor
+74387963 3 -- D/D Extra Surveyor
+74069667 3 -- D/D/D Oblivion King Abyss Ragnarok
+83303851 3 -- D/D/D Chaos King Apocalypse
+25857977 3 -- D/D/D Vice King Requiem
+74583607 3 -- D/D/D Flame King Genghis
+82956492 3 -- D/D/D Oracle King d'Arc
+16006416 3 -- D/D/D Flame High King Genghis
+987311 3 -- D/D/D Gust King Alexander
+6766208 3 -- D/D/D Gust High King Alexander
+3758046 3 -- D/D/D Wave King Caesar
+71612253 3 -- D/D/D Marksman King Tell
+15939229 3 -- D/D/D Duo-Dawn King Kali Yuga
+46593546 3 -- D/D/D Deviser King Deus Machinex
+9024198 3 -- D/D/D Abyss King Gilgamesh
+46372010 3 -- Dark Contract with the Gate
+73360025 3 -- Dark Contract with the Swamp King
+33814281 3 -- Dark Contract with Patent License
+9765723 3 -- Dark Contract with the Witch
+91781484 3 -- D/D/D Headhunt
+17720747 3 -- Witch of the Black Rose
+44125452 3 -- Rose Fairy
+90724272 3 -- Dark Rose Fairy
+29107423 3 -- Ruddy Rose Witch
+98884569 3 -- Blue Rose Dragon
+26118970 3 -- Red Rose Dragon
+12213463 3 -- White Rose Dragon
+93708824 3 -- Roxrose Dragon
+73580471 3 -- Black Rose Dragon
+40139997 3 -- Ruddy Rose Dragon
+76524506 3 -- Garden Rose Flora
+72218246 3 -- Crossrose Dragon
+71645242 3 -- Black Garden
+45247637 3 -- Mark of the Rose
+53503015 3 -- Frozen Rose
+84335863 3 -- White Rose Cloister
+69167267 3 -- Basal Rose Shoot
+99092624 3 -- Blooming of the Darkest Rose
+97688360 3 -- Gouki Twistcobra
+24073068 3 -- Gouki Suprex
+60461077 3 -- Gouki Riscorpio
+54088068 3 -- Gouki Headbatt
+85008676 3 -- Gouki Octostretch
+20191720 3 -- Gouki Moonsault
+71555408 3 -- Gouki Iron Claw
+7540107 3 -- Gouki Guts
+78437364 3 -- Gouki The Great Ogre
+11516241 3 -- Gouki The Powerload Ogre
+62376646 3 -- Gouki Re-Match
+55226153 3 -- DoSolfachord Cutia
+92610868 3 -- ReSolfachord Dreamia
+28115467 3 -- MiSolfachord Eliteia
+54100561 3 -- FaSolfachord Fancia
+91598270 3 -- SolSolfachord Gracia
+27993919 3 -- LaSolfachord Angelia
+54387923 3 -- TiSolfachord Beautia
+80776622 3 -- DoSolfachord Coolia
+37972500 3 -- GranSolfachord Musecia
+84521924 3 -- GranSolfachord Coolia
+27870337 3 -- Solfachord Elegance
+53265336 3 -- Solfachord Scale
+29650040 3 -- Solfachord Harmonia
+56510115 3 -- Solfachord Symphony
+56058749 3 -- Solfachord Musica
+92043888 3 -- Solfachord Formal
+82782870 3 -- Mitsurugi no Mikoto, Kusanagi
+18176525 3 -- Mitsurugi no Mikoto, Saji
+40543231 3 -- Mitsurugi no Mikoto, Aramasa
+76948970 3 -- Mitsurugi no Miko, Wousu
+19899073 3 -- Ame no Murakumo no Mitsurugi
+55397172 3 -- Futsu no Mitama no Mitsurugi
+13332685 3 -- Ame no Habakiri no Mitsurugi
+45171524 3 -- Mitsurugi Prayers
+81560239 3 -- Mitsurugi Ritual
+49721684 3 -- Mitsurugi Mirror
+76725398 3 -- Mitsurugi Magatama
+12210097 3 -- Mitsurugi Sacred Boundary
+17954937 3 -- Mitsurugi Great Purification
+49604192 3 -- Mitsurugi Tempest
+12163590 3 -- Dragonmaid Cehrmba
+48658295 3 -- Lady's Dragonmaid
+75046994 3 -- Noh-P.U.N.K. Rising Scale
+11441009 3 -- P.U.N.K. JAM FEVER!
+48835607 3 -- Galatea-I, the Orcust Automaton
+74820316 3 -- Enlilgirsu, the Orcust Mekk-Knight
+20295753 3 -- Night Sword Serpent
+84900597 3 -- Lamia
+72924435 3 -- Periallis, Empress of Blossoms
+#25AT-AE3
+54191698 3 -- Number 29: Mannequin Cat
+68353324 3 -- Nimble Beaver
+24348804 3 -- Lose 1 Turn
+55705473 3 -- Baobaboon
+90027012 3 -- Choju of the Trillion Hands
+32762201 3 -- Ancient Gear Statue
+4145915 3 -- Gimmick Puppet Fiendish Knight
+88686573 3 -- Nimble Angler
+22900219 3 -- Dinowrestler Chimera T Wrextle
+58672736 3 -- Dinowrestler Giga Spinosavate
+77967790 3 -- Dinowrestler King T Wrextle
+65711558 3 -- Ancient Warriors Oath - Double Dragon Lords
+32453837 3 -- Number 2: Ninja Shadow Mosquito
+61650133 3 -- Summoning Curse
+68441986 3 -- Ninjitsu Art of Mosquito Marching
+37930737 3 -- Gravity Balance
+18046862 3 -- Grief Tablet
+91078716 3 -- Pollinosis
+22888900 3 -- Grisaille Prison
+46259438 3 -- Contract Laundering
+23068051 3 -- Waterfall of Dragon Souls
+69873498 3 -- Break the Seal
+#CH01-AE
+62962630 3 -- Aluber the Jester of Despia
+95515789 3 -- Blazing Cartesia, the Virtuous
+25451383 3 -- Albion the Shrouded Dragon
+45883110 3 -- Guiding Quem, the Virtuous
+45484331 3 -- Springans Kitt
+19096726 3 -- Tri-Brigade Mercourier
+36577931 3 -- Despian Tragedy
+32731036 3 -- The Bystial Lubellion
+33854624 3 -- Bystial Magnamhut
+60242223 3 -- Bystial Saronir
+6637331 3 -- Bystial Druiswurm
+69680031 3 -- Dogmatika Fleurdelis, the Knighted
+30271097 3 -- The Fallen & The Virtuous
+44362883 3 -- Branded Fusion
+34995106 3 -- Branded in White
+82738008 3 -- Branded in Red
+36637374 3 -- Branded Opening
+29948294 3 -- Branded in High Spirits
+18973184 3 -- Branded Lost
+34090915 3 -- Branded Regained
+62022479 3 -- Branded Bond
+17751597 3 -- Branded Retribution
+6763530 3 -- Branded Banishment
+81767888 3 -- Branded Sword
+32756828 3 -- Branded Beast
+43331750 3 -- Fusion Duplication
+76666602 3 -- The Dragon that Devours the Dogma
+44146295 3 -- Mirrorjade the Iceblade Dragon
+87746184 3 -- Albion the Branded Dragon
+70534340 3 -- Lubellion the Searing Dragon
+3410461 3 -- Alba-Lenatus the Abyss Dragon
+41373230 3 -- Titaniklad the Ash Dragon
+34848821 3 -- Brigrand the Glory Dragon
+1906812 3 -- Sprind the Irondash Dragon
+51409648 3 -- Rindbrumm the Striking Dragon
+24915933 3 -- Granguignol the Dusk Dragon
+#TFTV-AE
+93053159 3 -- Alba System Dogmatikalamity
+65589010 3 -- Dogmatika Nation
+22073844 3 -- Dogmatika Nexus
+96891787 3 -- Dogmatika Theo, the Iron Punch
+33296432 3 -- Dogmatika Adin, the Enlightened
+29354228 3 -- Dogmatika Encounter
+52331012 3 -- Tri-Brigade Rugal the Silver Sheller
+99726621 3 -- Tri-Brigade Shuraig the Ominous Omen
+26847978 3 -- Tri-Brigade Ferrijit the Barren Blossom
+14816857 3 -- Tri-Brigade Nervall
+50810455 3 -- Tri-Brigade Kerass
+87209160 3 -- Tri-Brigade Fraktall
+51097887 3 -- Tri-Brigade Airborne Assault
+13694209 3 -- Dogmatika Ashiyan
+25908748 3 -- Tri-Brigade Stand-Off
+87481592 3 -- Dogmatikacism
+86379342 3 -- Tri-Brigade Oath
+23499963 3 -- Springans Watch
+60884672 3 -- Great Sand Sea - Gold Golgonda
+29601381 3 -- Springans Captain Sargas
+62941499 3 -- Springans Ship - Exblowrer
+20424878 3 -- Springans Rockey
+56818977 3 -- Springans Pedor
+83203672 3 -- Springans Branga
+56196385 3 -- Tri-Brigade Kitt
+96378317 3 -- Tri-Brigade Rendezvous
+83199011 3 -- Springans Call!
+67436768 3 -- Springans Brothers
+10584050 3 -- Springans Blast!
+48285768 3 -- Springans Merrymaker
+7496001 3 -- Springans Booty
+56588755 3 -- Dogmatika Genesis
+31002402 3 -- Dogmatikalamity
+99543666 3 -- Despia, Theater of the Branded
+40352445 3 -- White Knight of Dogmatika
+90179822 3 -- Despian Comedy
+81555617 3 -- Ad Libitum of Despia
+99456344 3 -- Dramaturge of Despia
+18666161 3 -- Despian Proskenion
+72272462 3 -- Despian Quaeritis
+6855503 3 -- Masquerade the Blazing Dragon
+31042659 3 -- Supreme Sovereign Serpent of Golgonda
+67100549 3 -- Screams of the Branded
+93595154 3 -- Judgment of the Branded
+25415161 3 -- Springans Interluder
+82489470 3 -- The Golden Swordsoul
+47163170 3 -- Tri-Brigade Bearbrumm the Rampant Rampager
+82777208 3 -- Icejade Acti
+28762303 3 -- Icejade Tinola
+55151012 3 -- Icejade Tremora
+39354437 3 -- Icejade Aegirine
+3355732 3 -- Icejade Kosmochlor
+66749546 3 -- Icejade Creation Kingfisher
+55343303 3 -- Icejade Cradle
+7142724 3 -- Icejade Cenote Enion Cradle
+53742162 3 -- Icejade Erosion
+48654323 3 -- White Relic of Dogmatika
+99137266 3 -- Swordsoul Strife
+34536828 3 -- Branded Disciple
+60921537 3 -- Dogmatikamacabre
+83670388 3 -- Icejade Curse
+10065487 3 -- Branded Loss
+42158279 3 -- Dogmatikaturgy
+1041278 3 -- Branded Expulsion
+37683547 3 -- Albaz the Ashen
+84332527 3 -- Therion "Bull" Ain
+21727231 3 -- Therion "Reaper" Fum
+57111330 3 -- Therion "Duke" Yul
+83610035 3 -- Therion "Lily" Borea
+90969892 3 -- Tribe Drive
+84792926 3 -- Therion Discolosseum
+57285770 3 -- Therion Charge
+43270827 3 -- Therion Cross
+79775821 3 -- Therion Stand Up!
+21887075 3 -- Endless Engine Argyro System
+15443125 3 -- Spright Starter
+76145933 3 -- Spright Blue
+13533678 3 -- Spright Jet
+49928686 3 -- Spright Pixies
+75922381 3 -- Spright Red
+2311090 3 -- Spright Carrot
+42431833 3 -- Spright Gamma Burst
+48806195 3 -- Therion "Empress" Alasia
+75290703 3 -- Therion Irregular
+27381364 3 -- Spright Elf
+54498517 3 -- Gigantic Spright
+88836438 3 -- Spright Smashers
+68250822 3 -- Spright Double Cross
+72329844 3 -- Spright Sprind
+14220547 3 -- Branded in Central Dogmatika
+72656408 3 -- Bystial Baldrake
+70485614 3 -- Decisive Battle of Golgonda
+5141117 3 -- The Abyss Dragon Swordsoul
+69120785 3 -- The Bystial Alba Los
+35569555 3 -- Dogmatikamatrix
+7889323 3 -- Tri-Brigade Showdown
+51522296 3 -- Dogmatika Alba Zoa
+1295442 3 -- Icejade Creation Aegirocassis
+86682165 3 -- Icejade Gymir Aegirine
+72776252 3 -- Icejade Manifestation
+9175957 3 -- Tally-ho! Springans
+34047456 3 -- Gigantic Thundercross
+11132674 3 -- Gigantic "Champion" Sargas
+10019086 3 -- Tri-Brigade Arms Bucephalus II
+60442460 3 -- Branded Befallen
+72554664 3 -- Light of the Branded
+19271881 3 -- Brightest, Blazing, Branded King
+27572350 3 -- Bystial Dis Pater
+38811586 3 -- Albion the Sanctifire Dragon
+53971455 3 -- Despian Luluwalilith
+83308376 3 -- Swordsoul Punishment
+10793085 3 -- Tri-Brigade Roar
+45675980 3 -- Etude of the Branded
+82090807 3 -- Fallen of Argyros
+45005708 3 -- The Bystial Aluber
+56787189 3 -- New Frontier
+#DOOD-AE
+67322708 3 -- D/D Lance Soldier
+93317313 3 -- D/D Defense Soldier
+20715411 3 -- D/D/D Zero Doom Queen Machinex
+66100116 3 -- Vengeful Witch
+92595825 3 -- Twilight Rose Black Knight
+29099860 3 -- Gouki Machine Suprex
+55088578 3 -- Onomatokage
+92472273 3 -- DoomZ XII Zero - Drastea
+28877382 3 -- DoomZ V Five - Amalthe
+54265980 3 -- DoomZ VII Seven - Elara
+81650695 3 -- Power Patron DoomZ
+27755794 3 -- Radiant Typhoon Meghala
+54143349 3 -- Radiant Typhoon Eldam
+80538047 3 -- Radiant Typhoon Swen
+16922142 3 -- Radiant Typhoon Krosea
+53927851 3 -- Radiant Typhoon Varuroon, the Vibrant Vortex
+85315450 3 -- Radiant Typhoon Fonix, the Great Flame
+12800564 3 -- Master Peace, the True Dracoverlord
+58205203 3 -- Mariamne Paradox, the True Dracophoenix Knight
+84693918 3 -- Solfachord Solfegia
+11688916 3 -- Solfachord Primoa
+47082621 3 -- Regenesis Overlord
+84477320 3 -- Dracotail Phryxul
+10966439 3 -- Marshmao☆Yummy
+47960073 3 -- K9-04 Noroi
+73355772 3 -- Dogmatika Fleurdelis, the Thunderbolt
+19743887 3 -- VARefar, the Judge of Ball
+46148485 3 -- Sphinx of the Cycle
+72632190 3 -- Triple-Headed Behemoth
+9627299 3 -- Ichiki Sayori-Hime
+45016904 3 -- Tao Tao the Chanter
+71410542 3 -- WAKE CUP! Macchia
+8805651 3 -- Megalith Phuloch
+44293356 3 -- Megalith Notrah Plura
+71398055 3 -- D/D/D/D Dimensional King Arc Crisis
+7782069 3 -- Gouki The Tyrant Ogre
+33171768 3 -- Axon Kicker Oracle
+70576413 3 -- D/D/D First King Clovis
+6560411 3 -- Bramble Rose Dragon
+33955120 3 -- Rage Rose Witch
+69453825 3 -- Gouki Dragon Ogre
+5848934 3 -- Serene Psychic Sorceress
+32232538 3 -- D/D/D Wise King Solomon
+68231287 3 -- Jupiter the Power Patron of Destruction
+95626382 3 -- DoomZ XII End - Drastrius
+31010081 3 -- DoomZ Break - Diactorus
+67515699 3 -- K9-66X "Jacks"
+94503794 3 -- Kerzebs, the Gaoled Glutton
+30998403 3 -- D/D/D Sky King Zeus Ragnarok
+7382007 3 -- Gouki Sheik Ogre
+33781156 3 -- Tri-Brigade Arms Mouser
+69176851 3 -- Miasma Necromancer
+6260560 3 -- Laevateinn the Burning Blade
+32665564 3 -- Dark Contract with the Zero King
+69053263 3 -- Black Rose Garden
+95448372 3 -- Gouki Gameface
+32442017 3 -- DoomZ Raiders
+68831625 3 -- DoomZ Command "D.O.O.M.D.U.R.G."
+94326720 3 -- Theorealize Overdrive
+21720439 3 -- Artmage Movement -Pedigree-
+67115133 3 -- Radiant Typhoon Chant
+94103142 3 -- Radiant Typhoon Manifestation
+20508881 3 -- Radiant Typhoon Vision
+66092596 3 -- Draco Awakening
+93481594 3 -- Solfachord Happiness
+29876299 3 -- Megalith Anastasis
+56870908 3 -- Yum☆Yum☆Yummys
+92269002 3 -- Tri-Brigade Hammer
+28653611 3 -- Infernal Punisher
+55158350 3 -- Fusion Draft
+81143465 3 -- Tragic Twin Twined Jewels
+28531163 3 -- Apocavities
+54936778 3 -- Dark Contract with the Different Dimension
+80320877 3 -- DoomZ Destruction
+17719582 3 -- Artmage Peripeteia -Turmoil-
+53813120 3 -- Radiant Typhoon Mandate
+80208225 3 -- Dracotail Sting
+16693934 3 -- Quadogmatika Beast
+42091632 3 -- Dominus Spiral
+89086647 3 -- Okiku's Dish Count
+32349062 3 -- D/D Dog
+33334269 3 -- D/D Ghost
+21686473 3 -- D/D/D Destiny King Zero Laplace
+76029419 3 -- D/D/D Supersight King Zero Maxwell
+97417863 3 -- D/D/D/D Super-Dimensional Sovereign Emperor Zero Paradox
+94689206 3 -- Block Dragon
+15545291 3 -- Granmarg the Mega Monarch
+23689697 3 -- Mobius the Mega Monarch
+69230391 3 -- Thestalos the Mega Monarch
+87602890 3 -- Zaborg the Mega Monarch
+87288189 3 -- Caius the Mega Monarch
+87750925 3 -- Disguise, the Copycat Hero
+18300894 3 -- Silk Bomb Moth
+63056220 3 -- Megalith Ophiel
+90444325 3 -- Megalith Hagith
+36849933 3 -- Megalith Och
+63233638 3 -- Megalith Phaleg
+99628747 3 -- Megalith Bethor
+25726386 3 -- Megalith Aratron
+78990927 3 -- Megalith Phul
+18988396 3 -- Miracle Raven
+8463720 3 -- D/D/D Dragonbane King Beowulf
+44852429 3 -- D/D/D Cursed King Siegfried
+70659412 3 -- Psychic Omnibuster
+81916745 3 -- Lycoris Lilyreaper
+51497409 3 -- D/D/D Stone King Darius
+88406570 3 -- Gouki Destroy Ogre
+59644128 3 -- Gouki Jet Ogre
+30286474 3 -- Gouki The Master Ogre
+44376395 3 -- ASHLAN U1000
+85638822 3 -- Gouki Cage Match
+35870016 3 -- Gouki Finishing Move
+84504242 3 -- Megalith Portal
+69003792 3 -- Megalith Unformed
+71771004 3 -- Readying of Rites
+43150717 3 -- Xyz Lay
+23249029 3 -- Cursed Copycat Noble Arms
+40204620 3 -- Megalith Promotion
+76209339 3 -- Megalith Emergence
+#DOOD-AES
+40227329 3 -- Go! - D/D/D Divine Zero King Rage
+47198668 3 -- D/D/D Doom King Armageddon
+27873305 3 -- D/D/D Wave Oblivion King Caesar Ragnarok
+84569886 3 -- D/D/D Super Doom King Purple Armageddon
+72402069 3 -- D/D/D Super Doom King Bright Armageddon
+18897163 3 -- D/D/D Super Doom King Dark Armageddon
+45974017 3 -- Dark Contract with the Yamimakai
+10833828 3 -- Forbidden Dark Contract with the Swamp King
+60168186 3 -- Dark Contract with the Entities
+37209439 3 -- Dark Contract with Errors
+9030160 3 -- Dark Contract with the Eternal Darkness
+53325667 3 -- Garden Rose Maiden
+4290468 3 -- Splendid Rose
+30010480 3 -- Gouki Thunder Ogre
+47946130 3 -- Gouki The Giant Ogre
+95515058 3 -- Gouki The Blade Ogre
+22510667 3 -- Gouki The Solid Ogre
+26285557 3 -- Gouki Face Turn
+61269611 3 -- Dinowrestler Iguanodraka
+71068247 3 -- Totem Bird
+#DOOD-AEC
+97896503 3 -- Zubaba Knight
+24291651 3 -- Ganbara Knight
+62476815 3 -- Gogogo Golem
+83274244 3 -- Dododo Warrior
+82052602 3 -- Gagagaback
+17494901 3 -- Gagagabolt
+18446701 3 -- Gagagashield
+76972801 3 -- Gagagaguard
+12423762 3 -- Gagaga Gardna
+9583383 3 -- Gagaga Caesar
+44250812 3 -- Gagaga Clerk
+13166204 3 -- Gagagarush
+21831848 3 -- Gagagadraw
+57782164 3 -- Gagagawind
+917796 3 -- Gagagatag
+21715135 3 -- Gagaga Academy Emergency Network
+56105047 3 -- Gogogo Ghost
+39695323 3 -- Gogogo Giant
+19667590 3 -- Gogogo Gigas
+63583431 3 -- Gogogo Talisman
+19700943 3 -- Dododo Bot
+39432962 3 -- Dododo Witch
+75421661 3 -- Dododo Swordsman
+73866096 3 -- Dodododraw
+28884172 3 -- Gagaga Mancer
+2948263 3 -- Gogogo Golem - Golden Form
+46871387 3 -- Number 55: Gogogo Goliath
+31563350 3 -- Zubaba General
+74605254 3 -- D/D Savant Galilei
+19302550 3 -- D/D Savant Newton
+41546 3 -- D/D Savant Thomas
+46035545 3 -- D/D Savant Nikola
+81571633 3 -- D/D Proud Ogre
+17979378 3 -- D/D Proud Chevalier
+44186624 3 -- D/D/D Supreme King Kaiser
+39153655 3 -- D/D Cerberus
+12822541 3 -- D/D Lilith
+32146097 3 -- D/D Pandora
+19808608 3 -- D/D Berfomet
+59123937 3 -- D/D Vice Typhon
+36614113 3 -- D/D Ark
+55415564 3 -- D/D Evil
+92536468 3 -- D/D/D Rebel King Leonidas
+56619314 3 -- D/D/D Dragon King Pendragon
+72648577 3 -- D/D/D Human Resources
+8643186 3 -- D/D Recruits
+811734 3 -- D/D/D Contract Change
+71069715 3 -- D/D Reroll
+12097275 3 -- Gouki Bearhug
+67586735 3 -- Gouki Tagpartner
+93581434 3 -- Gouki Ringtrainer
+10552026 3 -- Gouki Heel Ogre
+93507434 3 -- Dinowrestler Capaptera
+29996433 3 -- Dinowrestler Capoeiraptor
+56980148 3 -- Dinowrestler Systegosaur
+90173539 3 -- World Dino Wrestling
+48372950 3 -- Dinowrestler Eskrimamenchi
+75366958 3 -- Dinowrestler Coelasilat
+11755663 3 -- Dinowrestler Martial Anga
+69121954 3 -- Dinowrestler Terra Parkourio
+35770983 3 -- Dinowrestler Martial Ankylo
+61764082 3 -- Dinowrestler Rambrachio
+54446813 3 -- Dinowrestler Martial Ampelo
+80831552 3 -- Dinowrestler Valeonyx
+#25AT-AE4
+4334811 3 -- Scrap Recycler
+32530043 3 -- Gallant Granite
+16259549 3 -- Number 49: Fortune Tune
+72330894 3 -- Simorgh, Bird of Sovereignty
+67316075 3 -- Darklord Nurse Reficule
+33420078 3 -- Plaguespreader Zombie
+66457407 3 -- Copy Plant
+62379337 3 -- Violet Witch
+68018709 3 -- Condemned Maiden
+44656450 3 -- Condemned Witch
+7987191 3 -- Borreload Riot Dragon
+71166481 3 -- Number 75: Bamboozling Gossip Shadow
+39622156 3 -- Number 26: Spaceway Octobypass
+49725936 3 -- Triple Burst Dragon
+739444 3 -- Vorticular Drumgon
+13143275 3 -- Guardragon Pisty
+44887817 3 -- Miracle Fertilizer
+96864811 3 -- Forbidden Dress
+54773234 3 -- Forbidden Scripture
+87571563 3 -- World Legacy Guardragon
+20071842 3 -- Heavy Interlock
+97803170 3 -- Call of the Archfiend
+29649320 3 -- Mirror Force Launcher
+15943341 3 -- Magical Cylinders
+#CR10-AE
+
+#CH02-AE
+
+#DBPR-AE
+
+#BPRO-AE
+
+#CR11-AE

--- a/OCG-AE.lflist.conf
+++ b/OCG-AE.lflist.conf
@@ -322,7 +322,7 @@ $whitelist
 20436034 3 -- Ring of Magnetism
 56830749 3 -- Share the Pain
 83225447 3 -- Stim-Pack
-19613556 0 -- Heavy Storm
+19613556 1 -- Heavy Storm
 41462083 3 -- Thousand Dragon
 #MRL
 53183600 3 -- Blue-Eyes Toon Dragon
@@ -836,7 +836,7 @@ $whitelist
 47233801 3 -- Dark Snake Syndrome
 73628505 1 -- Terraforming
 10012614 3 -- Banner of Courage
-46411259 0 -- Metamorphosis
+46411259 3 -- Metamorphosis
 72405967 3 -- Royal Tribute
 5990062 3 -- Reversal Quiz
 65830223 3 -- Coffin Seller
@@ -2026,7 +2026,7 @@ $whitelist
 41721210 3 -- Dark Magician the Dragon Knight
 #SDID-AEP
 24508238 3 -- D.D. Crow
-94145021 3 -- Droll & Lock Bird
+94145021 2 -- Droll & Lock Bird
 59438930 3 -- Ghost Ogre & Snow Rabbit
 12266229 3 -- Illusion of Chaos
 11321089 3 -- Guardian Chimera
@@ -2714,8 +2714,8 @@ $whitelist
 77392987 3 -- T.G. Rocket Salamander
 14391625 3 -- Visas Samsara
 40785230 3 -- Veda Kalarcanum
-72270339 1 -- Diabellstar the Black Witch
-9674034 1 -- Snake-Eye Ash
+72270339 2 -- Diabellstar the Black Witch
+9674034 2 -- Snake-Eye Ash
 45663742 3 -- Snake-Eye Oak
 12058741 3 -- Snake-Eye Birch
 48452496 3 -- Snake-Eyes Flamberge Dragon
@@ -3033,7 +3033,7 @@ $whitelist
 51473858 3 -- Goblin Biker Clatter Sploder
 27868563 3 -- Goblin Biker Boom Mach
 64257161 3 -- Goblin Biker Mean Merciless
-90241276 1 -- Snake-Eyes Poplar
+90241276 2 -- Snake-Eyes Poplar
 26746975 3 -- Dark Guardian
 53134520 3 -- Phantasmal Summoning Beast
 99529628 3 -- Keaf, Murk of the Ghoti
@@ -5089,7 +5089,7 @@ $whitelist
 94979322 3 -- Dark Flare Swordsman
 30373970 3 -- Miasma Dragon Tistina
 67768675 3 -- Kaibaman the Legend
-93156774 3 -- Vanquish Soul Hollie Sue
+93156774 2 -- Vanquish Soul Hollie Sue
 29251488 3 -- Chef de Nouvelles
 66646087 3 -- Super Quantal Fairy Zetan
 92034192 3 -- Super Quantum Black Layer
@@ -5210,13 +5210,13 @@ $whitelist
 31603289 3 -- Cupsy★Yummy Way
 67098897 3 -- Cooky★Yummy Way
 93192592 3 -- Lollipo★Yummy Way
-30581601 2 -- Yummy★Snatchy
+30581601 1 -- Yummy★Snatchy
 66975205 3 -- Yummyusment☆Mignon
 93360904 3 -- Yummyusment★Acroquey
 29369059 3 -- Yummy☆Surprise
 65853758 3 -- Yummy★Redemption
 23656668 3 -- Gravity Controller
-72537897 1 -- Obedience Schooled
+72537897 0 -- Obedience Schooled
 33907039 3 -- Piri Reis Map
 92248362 2 -- K9-17 Izuna
 28642461 1 -- K9-66a Jokul
@@ -5330,7 +5330,7 @@ $whitelist
 19899073 3 -- Ame no Murakumo no Mitsurugi
 55397172 3 -- Futsu no Mitama no Mitsurugi
 13332685 3 -- Ame no Habakiri no Mitsurugi
-45171524 3 -- Mitsurugi Prayers
+45171524 1 -- Mitsurugi Prayers
 81560239 3 -- Mitsurugi Ritual
 49721684 3 -- Mitsurugi Mirror
 76725398 3 -- Mitsurugi Magatama
@@ -5470,7 +5470,7 @@ $whitelist
 83670388 3 -- Icejade Curse
 10065487 3 -- Branded Loss
 42158279 3 -- Dogmatikaturgy
-1041278 3 -- Branded Expulsion
+1041278 0 -- Branded Expulsion
 37683547 3 -- Albaz the Ashen
 84332527 3 -- Therion "Bull" Ain
 21727231 3 -- Therion "Reaper" Fum

--- a/OCG-AE.lflist.conf
+++ b/OCG-AE.lflist.conf
@@ -5755,11 +5755,300 @@ $whitelist
 29649320 3 -- Mirror Force Launcher
 15943341 3 -- Magical Cylinders
 #CR10-AE
-
+48355999 3 -- Rokket Synchron
+26655293 3 -- Magnarokket Dragon
+32476603 3 -- Silverrokket Dragon
+68464358 3 -- Rokket Tracer
+5969957 3 -- Rokket Recharger
+67127799 3 -- Rokket Caliber
+67748760 3 -- Absorouter Dragon
+70333910 3 -- Noctovision Dragon
+12023931 3 -- Booster Dragon
+23732205 3 -- Dillingerous Dragon
+29296344 3 -- Quadborrel Dragon
+85289965 3 -- Borrelsword Dragon
+31833038 3 -- Borreload Dragon
+98630720 3 -- Borrelend Dragon
+31443476 3 -- Quick Launch
+36668118 3 -- Boot Sector Launch
+6556178 3 -- Borrel Regenerator
+55289183 3 -- Capricious Darklord
+82773292 3 -- Indulged Darklord
+92807548 3 -- Darklord Ukoback
+47664723 3 -- Darklord Edeh Arae
+51728779 3 -- Darklord Amdusc
+25339070 3 -- Darklord Nasten
+40921744 3 -- Darklord Zerato
+85771019 3 -- Darklord Asmodeus
+11260714 3 -- Darklord Superbia
+18168997 3 -- Darklord Nergal
+88234365 3 -- Darklord Tezcatlipoca
+55690251 3 -- Darklord Desire
+52840267 3 -- Darklord Ixchel
+25451652 3 -- Darklord Morningstar
+4167084 3 -- The First Darklord
+35306215 3 -- Condemned Darklord
+87112784 3 -- Banishment of the Darklords
+14517422 3 -- Darklord Contact
+58787301 3 -- Darklord Descent
+50501121 3 -- Darklord Rebellion
+87990236 3 -- Darklord Enchantment
+48152161 3 -- The Sanctified Darklord
+54527349 3 -- Darklord Uprising
+36205132 3 -- Filo, Messenger Fur Hire
+94073244 3 -- Donpa, Marksman Fur Hire
+31467949 3 -- Recon, Scout Fur Hire
+28004531 3 -- Rex, Freight Fur Hire
+67466547 3 -- Helmer, Helmsman Fur Hire
+93850652 3 -- Beat, Bladesman Fur Hire
+20345391 3 -- Seal, Strategist Fur Hire
+66740005 3 -- Bravo, Fighter Fur Hire
+93738004 3 -- Sagitta, Maverick Fur Hire
+25123713 3 -- Dyna, Hero Fur Hire
+1527418 3 -- Wiz, Sage Fur Hire
+38916526 3 -- Rafale, Champion Fur Hire
+8728498 3 -- Donner, Dagger Fur Hire
+66023650 3 -- Folgo, Justice Fur Hire
+91405870 3 -- Mayhem Fur Hire
+48214588 3 -- Rookie Fur Hire
+64400161 3 -- Fandora, the Flying Furtress
+37890974 3 -- Training Fur Hire, Fur All Your Training Needs
+97522863 3 -- The Man with the Mark
+34926568 3 -- Merciless Scorpion of Serket
+60411677 3 -- Anubis the Last Judge
+89194033 3 -- Mystical Beast of Serket
+97800311 3 -- Divine Serpent Apophis
+23804920 3 -- Divine Scorpion Beast of Serket
+69299029 3 -- Treasures of the Kings
+96687733 3 -- Defense of the Temple
+29762407 3 -- Temple of the Kings
+59576447 3 -- Verdict of Anubis
+95561146 3 -- Apophis the Serpent
+28649820 3 -- Embodiment of Apophis
+85888377 3 -- Apophis the Swamp Deity
+6043161 3 -- R.B. Ga10 Driller
+33438265 3 -- R.B. Ga10 Cutter
+79436874 3 -- R.B. VALCan Rocket
+81794107 3 -- R.B. Lambda Cannon
+17188206 3 -- R.B. Lambda Blade
+44573911 3 -- R.B. Ga10 Pile Bunker
+6821579 3 -- R.B. VALCan Booster
+32216688 3 -- R.B. The Brute Blues
+80071619 3 -- R.B. Shepherd's Crook
+78710386 3 -- R.B. Funk Dock
+5109321 3 -- R.B. Stage Landing
+16066654 3 -- R.B. Operation Test
+43450363 3 -- R.B. Last Stand
+79859067 3 -- R.B. Next Phase
+15381421 3 -- Starliege Seyfert
+72705654 3 -- Tachyon Cloudragon
+51786039 3 -- Nebula Dragon
+88774734 3 -- Galactic Spiral Dragon
+45710945 3 -- Galaxy-Eyes Tachyon Primal
+18294799 3 -- Schwarzschild Infinity Dragon
+88177324 3 -- Number 107: Galaxy-Eyes Tachyon Dragon
+68396121 3 -- Number C107: Neo Galaxy-Eyes Tachyon Dragon
+28400508 3 -- Number 97: Draglubion
+44698398 3 -- Divine Golden Shadow Dragon Dragluxion
+92362073 3 -- Galaxy Satellite Dragon
+71083002 3 -- Tachyon Spiral of Destruction
+44466810 3 -- Lord of the Tachyon Galaxy
+8038143 3 -- Tachyon Transmigration
+89789152 3 -- Tachyon Spiral Galaxy
 #CH02-AE
-
+11911336 3 -- Spellbook of the Grand Circle
+48016074 3 -- Charmers of the Grand Circle
 #DBPR-AE
-
+95365081 3 -- Hecahands Ibtel
+32759190 3 -- Hecahands Yadel
+68144894 3 -- Hecahands Godos
+95132593 3 -- Hecahands Gaigas
+21637502 3 -- Hecahands Breus
+67021206 3 -- Hecahands Jauzah
+94410955 3 -- Hecahands Xeno
+20415050 3 -- The Hidden Hecahands
+57809669 3 -- Hecahands Tartaros
+93294363 3 -- Ib'al-Hecahands
+29792472 3 -- Yad'al-Hecahands
+56187077 3 -- Proto Enneacraft - "orgIA"
+92171126 3 -- Deftero Enneacraft - "alazoneIA"
+29570824 3 -- Ekto Enneacraft - "tromarIA"
+55965529 3 -- Enato Enneacraft - "oknirIA"
+82359538 3 -- Enneacraft - Aiza.LEON
+28454232 3 -- Enneacraft - Asta.PIXEA
+54842941 3 -- Enneacraft - Atori.MAR
+81237046 3 -- Enneacraft - Archa.TAIL
+17621695 3 -- Enneapolis
+54020393 3 -- Enneacraft Release
+80015408 3 -- Enneacraft Reverth
+16509007 3 -- Kewl Tune Mix
+43904702 3 -- Kewl Tune Clip
+89392810 3 -- Kewl Tune Reco
+16387555 3 -- Kewl Tune Cue
+42781164 3 -- Kewl Tune Track Maker
+88170262 3 -- Kewl Tune Remix
+15665977 3 -- Kewl Tune RS
+41069676 3 -- Kewl Tune Loudness War
+78058681 3 -- Kewl Tune Synchro
+14442329 3 -- JJ "Kewl Tune"
+40847034 3 -- Kewl Tune Playlist
 #BPRO-AE
-
+25554552 3 -- Rokket Loader
+51548207 3 -- Hollowrokket Dragon
+98937206 3 -- Rokket Detonator
+24431911 3 -- Tellusion the Magna Warrior
+51826619 3 -- Magnet Warrior Sigma Plus
+87814728 3 -- Magnet Warrior Sigma Minus
+23219323 3 -- Junk Warrior/Assault Mode
+50604072 3 -- Crimson Blader/Assault Mode
+86098176 3 -- Assault Lich
+13597785 3 -- Elfnote Lucina
+59581480 3 -- Elfnote Tinia
+85976588 3 -- Elfnote Fortuna
+12375297 3 -- Elfnote Power Patron
+58769832 3 -- Royal Archfiend
+85154941 3 -- Duke Archfiend
+11248645 3 -- Highness Archfiend
+47647354 3 -- Rex, Ride Fur Hire
+84031359 3 -- Darklord Gulgolet
+10426067 3 -- Darklord Djehuty
+78910832 3 -- Vic Viper Type-L
+5121528 3 -- B.E.S. Derringer Core
+41516133 3 -- Super B.E.S. Metal Slave
+47425162 3 -- Rescue-ACE Quick Attacker
+73819701 3 -- Fallen of the White Dragon
+19304410 3 -- Tri-Brigade Springans Kitt
+46708514 3 -- Derk, Longing for the Blue Skies
+12197223 3 -- Shiina, Twin Tempests of Celestial Thunder
+49181828 3 -- Fist Armed Dragon
+85586937 3 -- WAKE CUP! Earl
+12975671 3 -- First Penguin
+48469380 3 -- Archfiend Emperor
+84464389 3 -- Borreload Fatalflare Dragon
+11852093 3 -- D/D/D Alfred the Divine Sage King
+47247792 3 -- Conduction Warrior Plasma Magnum
+74631897 3 -- Artmage Non-Finito
+10136446 3 -- Darklord Eveningstar
+42125140 3 -- Dracotail Shaulas
+79519259 3 -- Nightwinged Cleric
+5914858 3 -- Junora the Power Patron of Tuning
+42302563 3 -- Elfnote Seraphim Strelitzia
+78397661 3 -- Ecclesia and the Dark Dragon
+4891376 3 -- Zalen the Shackled Dragon
+31286915 3 -- K9-X "Ripper/M"
+77675029 3 -- Exosister Karmael
+4079728 3 -- Gung-Ho! Springans!
+30064423 3 -- Topologic Blaster Dragon
+66452432 3 -- Borrelshroud Dragon
+3957130 3 -- Trisborrel Dragon
+39341885 3 -- Radiant Typhoon Varuroon, the Marine Eidolon
+66736884 3 -- Keel, Shipwright Fur Hire
+2725599 3 -- Rescue-ACE Arbitrator
+38129297 3 -- Double Interlock
+65514302 3 -- Magnet Bonding
+91002901 3 -- Duel Evolution - Assault Zone
+38007649 3 -- DoomZ Change
+64491754 3 -- Elfnotes: Welcome Home
+90880453 3 -- Elfnotes: A Plea for Help
+27285068 3 -- Theorealize Liberation
+63679166 3 -- Throne of the Archfiends
+90764871 3 -- Archfiend Strategy
+26162470 3 -- Fandora, the Flying Fighting Furtress
+53557529 3 -- Whirlwind Fur Hire
+99941223 3 -- Darklord Dance
+4909946 3 -- Boss on Parade
+25940932 3 -- Radiant Typhoon Ascendance
+52335937 3 -- Exosister Betrayal
+98829635 3 -- Forbidden Crown
+25224340 3 -- Nightmare Hands
+51612489 3 -- Riot's Reason
+87607094 3 -- Borrel Reboot
+50590801 3 -- Elfnotes: Aristeia of Trust
+24092792 3 -- Elfnotes: Rhapsodia of Madness
+87985506 3 -- Archfiend Playtime
+13379114 3 -- Archfiend's Fervor
+59374259 3 -- Furtive Techniques Fur Hire, Fur All Your Ultimate Moves
+86762958 3 -- Assist★Yummy!
+12157563 3 -- Forbidden Ritual Art
+49652661 3 -- Arsenal Audit
+85640370 3 -- Tip of the Tinying Tongue
+11035075 3 -- Shichi-Go-San
+22106558 3 -- Mechanical Mechanic
+69191257 3 -- Jade Dragon Mech
+95589901 3 -- Mischief of the Wolves
+22984000 3 -- Mercurium the Living Quicksilver
+68378605 3 -- Vodnika the Fountain Spirit
+94467314 3 -- Rain of Frogs
+21861412 3 -- Flux Ochsenfeld
+57256127 3 -- Shipping Archfiend
+94641726 3 -- Storm-Bane Dragon Destorbim
+20049870 3 -- GMX Researcher Selande
+56034579 3 -- GMX Chairman Kimridge
+83528184 3 -- GMX Associate Noma
+29927283 3 -- Returned Dino Daneen
+56311997 3 -- GMX - ALLOS
+82706696 3 -- GMX - VELOX
+18795635 3 -- GMX Applied Experiment #55
+66429798 3 -- Pesanta the Titan of Troubadours
+42544773 3 -- Spenta, the Magistus Sealer
+44839512 3 -- Conduction Warrior Linear Magnum Plus Minus
+38423248 3 -- Invoked Magistus Omega
+#BPRO-AEC
+53266486 3 -- Anesthrokket Dragon
+80250185 3 -- Autorokket Dragon
+5087128 3 -- Shelrokket Dragon
+32472237 3 -- Metalrokket Dragon
+12950294 3 -- Speedburst Dragon
+31353051 3 -- Exploderokket Dragon
+93612434 3 -- Double Disruptor Dragon
+87263576 3 -- Outburst Dragon
+54458867 3 -- Squib Draw
+30131474 3 -- Borrel Supplier
+67526112 3 -- Rapid Trigger
+36092504 3 -- Bayonet Punisher
+66015185 3 -- Twin Triangle Dragon
+15627227 3 -- Overburst Dragon
+73341839 3 -- Miniborrel Dragon
+95372220 3 -- Flash Charge Dragon
+62753201 3 -- Borrel Cooling
+55034079 3 -- Link Turret
+20419926 3 -- Execute Protocols
+41348446 3 -- Detonation Code
+99785935 3 -- Alpha The Magnet Warrior
+39256679 3 -- Beta The Magnet Warrior
+11549357 3 -- Gamma The Magnet Warrior
+54734082 3 -- Magnet Induction
+4740489 3 -- Magnetic Field
+80352158 3 -- Magnet Reverse
+17841166 3 -- Magnet Force
+77133792 3 -- Magnet Conversion
+6022371 3 -- Water Dragon Cluster
+79402185 3 -- Bonding - D2O
+6890729 3 -- Bonding - DHO
+6021033 3 -- Doomkaiser Dragon
+23693634 3 -- Colossal Fighter
+38898779 3 -- Colossal Fighter/Assault Mode
+88332693 3 -- Assault Mode Zero
+74431740 3 -- Assault Reboot
+44364207 3 -- Jade Knight
+86170989 3 -- Falchionβ
+35514096 3 -- Lord British Space Fighter
+12079734 3 -- Delta Tri
+14506878 3 -- DUCKER Mobile Cannon
+41224658 3 -- Ambitious Gofer
+84257883 3 -- B.E.S. Blaster Cannon Core
+10642488 3 -- Vic Viper T301
+82821760 3 -- B.E.S. Big Core MK-3
+93920745 3 -- Penguin Soldier
+17679043 3 -- Penguin Torpedo
+6836211 3 -- The Great Emperor Penguin
+76442347 3 -- Puny Penguin
+32623004 3 -- Nopenguin
+79169622 3 -- Glacial Beast Polar Penguin
+91397409 3 -- Penguin Brave
+69792699 3 -- Penguin Sword
+14761450 3 -- Penguin Squire
+41255165 3 -- Penguin Ninja
+73640163 3 -- Penguin Cleric
+80893872 3 -- Royal Penguins Garden
 #CR11-AE


### PR DESCRIPTION
Banlist taken from: https://www.yugioh-card.com/hk/event/rules_guides/forbidden_cardlist_aen.php?list=202311&lang=en

Card pool scrape from: https://yugipedia.com/wiki/Asian-English
With some passcodes added manually (e.g. `The Winged Dragon of Ra - Sphere Mode`)
