### PR TITLE
Updated April OCG and Rush Banlists

### DIFF
--- a/0OCG.lflist.conf
+++ b/0OCG.lflist.conf
@@ -1,0 +1,195 @@
+#[2024.04 OCG]
+!2024.04 OCG
+#Forbidden
+62320425 0 --Agido the Ancient Sentry
+91869203 0 --Amazoness Archer
+73356503 0 --Barrier Statue of the Stormwinds
+9929398 0 --Blackwing - Gofu the Vague Shadow
+69243953 0 --Butterfly Dagger - Elma
+11384280 0 --Cannon Soldier
+14702066 0 --Cannon Soldier MK-2
+57953380 0 --Card of the Safe Return
+3040496 0 --Chaos Ruler, the Chaotic Magical Dragon
+60682203 0 --Cold Wave
+17375316 0 --Confiscation
+50588353 0 --Crystron Halqifibrax
+34124316 0 --Cyber Jar
+69015963 0 --Cyber-Stein
+15341821 0 --Dandylion
+44763025 0 --Delinquent Duo
+80845034 0 --WANTED: Seeker of Sinful Spoils
+23557835 0 --Dimension Fusion
+31423101 0 --Divine Sword - Phoenix Blade
+8903700 0 --Djinn Releaser of Rituals
+51858306 0 --Eclipse Wyvern
+17412721 0 --Elder Entity Norden
+78706415 0 --Fiber Jar
+93369354 0 --Fishborg Blaster
+42703248 0 --Giant Trunade
+79571449 0 --Graceful Charity
+75732622 0 --Grinder Golem
+59537380 0 --Guardragon Agarpain
+86148577 0 --Guardragon Elpy
+62242678 0 --Hot Red Dragon Archfiend King Calamity
+61740673 0 --Imperial Order
+32909498 0 --Kashtira Fenrir
+25926710 0 --Kelbek the Ancient Vanguard
+39064822 0 --Knightmare Goblin
+3679218 0 --Knightmare Mermaid
+85602018 0 --Last Will
+28566710 0 --Last turn
+34086406 0 --Lavalval Chain
+57421866 0 --Level Eater
+17178486 0 --Life Equalizer
+85243784 0 --Linkross
+32723153 0 --Magical Explosion
+34206604 0 --Magical Scientist
+31178212 0 --Majespecter Unicorn - Kirin
+34906152 0 --Mass Driver
+21377582 0 --Master Peace, The True Dracoslaying King
+46411259 0 --Methamorphosis
+96782886 0 --Mind Master
+41482598 0 --Mirage of Nightmare
+76375976 0 --Mystic Mine
+54719828 0 --Number 16: Shock Master
+63504681 0 --Number 86: Heroic Champion - Rhongomyniad
+58820923 0 --Number 95: Galaxy-Eyes Dark Matter Dragon
+52653092 0 --Number S0: Utopic ZEXAL
+34945480 0 --Outer Entity Azathot
+74191942 0 --Painful Choice
+7563579 0 --Performage PlushFire
+23558733 0 --Phoenixian Cluster Amaryllis
+55144522 0 --Pot of Greed
+70369116 0 --Predaplant Verte Anaconda
+70828912 0 --Premature Burial
+37818794 0 --Red-Eyes Dark Dragoon
+27174286 0 --Return from the Different Dimension
+93016201 0 --Royal Oppression
+3280747 0 --Sixth Sense
+63789924 0 --Smoke Grenade of the Thief
+45986603 0 --Snatch Steal
+54447022 0 --Soul Charge
+27381364 0 --Spright Elf
+20663556 0 --Substitoad
+77679716 0 --Superheavy Samurai Soulbreaker Armor
+92731385 0 --Tearlaments Kitkallos
+63101919 0 --Tempest Magician
+42829885 0 --The Forceful Sentry
+88071625 0 --The Tyrant Neptune
+90809975 0 --Toadally Awesome
+79875176 0 --Toon Cannon Soldier
+22593417 0 --Topologic Gumblar Dragon
+64697231 0 --Trap Dustshoot
+88581108 0 --True King of All Calamities
+80604091 0 --Ultimate Offering
+83152482 0 --Union Carrier
+5851097 0 --Vanity's Emptiness
+44910027 0 --Victory Dragon
+2563463 0 --Wandering Gryphon Rider
+16923472 0 --Wind-up Hunter
+85115440 0 --Zoodiac Broadbull
+48905153 0 --Zoodiac Drident
+# Limited
+73468603 1 -- Set Rotation
+76794549 1 --Astrograph Sorcerer
+53804307 1 --Blaster, Dragon Ruler of Infernos
+6602300 1 --Blaze Fenix, The Burning Bombardment Bird
+94689206 1 --Block Dragon
+44362883 1 --Branded Fusion
+36637374 1 --Branded Opening
+7394770 1 --Brilliant Fusion
+72656408 1 --Bystial Baldrake
+6637331 1 --Bystial Druiswurm
+33854624 1 --Bystial Magnamhut
+72892473 1 --Card Destruction
+12289247 1 --Chronograph Sorcerer
+65681983 1 --Crossout Designator
+82385847 1 --Dinowrestler Pankratops
+90448279 1 --Divine Arsenal AA-ZEUS - Sky Thunder
+61292243 1 --EMERGENCY!
+40177746 1 --Eva
+26400609 1 --Tidal, Dragon Ruler of Waterfalls
+33396948 1 --Exodia the Forbidden one
+81439173 1 --Foolish Burial
+52947044 1 --Fusion Destiny
+27970830 1 --Gateway of the Six
+67441435 1 --Glow-up Bulb
+75500286 1 --Gold Sarcophagus
+18144506 1 --Harpie's Feather Duster
+19613556 1 --Heavy Storm
+24094258 1 --Heavymetalfoes Electrumite
+17266660 1 --Herald of Orange Light
+1845204 1 --Instant Fusion
+68304193 1 --Kashtira Unicorn
+63542003 1 --Keldo the Possessed Statue
+7902349 1 --Left Arm of the Forbidden one
+44519536 1 --Left Leg  of the Forbidden one
+92746535 1 --Luster Pendulum
+4423206 1 --M-X-Saber Invoker
+93600443 1 --Mask Change 2
+36521307 1 --Mathmech Circular
+83764718 1 --Monster Reborn
+33508719 1 --Morphing Jar
+99937011 1 --Mudora the Sword Oracle
+33782437 1 --One Day of Peace
+24207889 1 --There Can Be Only One
+2295440 1 --One for One
+38814750 1 --PSY-Framegear Gamma
+74586817 1 --PSY-Framelord Omega
+17330916 1 --Performapal Monkeyboard
+84211599 1 --Pot of Prosperity
+35272499 1 --Predaplant Ophrys Scorpio
+23701465 1 --Primal Seed
+71832012 1 --Prime Planet Paraisos
+77103950 1 --Primeval Planet Perlereino
+21347668 1 --Purrely Sleepy Memory
+23002292 1 --Red Reboot
+90411554 1 --Redox, Dragon Ruler of Boulders
+32807846 1 --Reinforcement of the Army
+70903634 1 --Right Arm of the Forbidden one
+8124921 1 --Right Leg of the Forbidden one
+90846359 1 --Rivalry of Warlords
+92107604 1 --Runick Fountain
+78080961 1 --SPYRAL Quik-Fix
+82732705 1 --Skill Drain
+52340444 1 --Sky Striker Mecha - Hornet Drones
+81275020 1 --Speedroid Terrortop
+76145933 1 --Spright Blue
+13533678 1 --Spright Jet
+15443125 1 --Spright Starter
+90361010 1 --Superheavy Samurai Soulpiercer
+90953320 1 --T.G. Hyper Librarian
+37961969 1 --Tearlaments Havnis
+4928565 1 --Tearlaments Kashtira
+74078255 1 --Tearlaments Merrli
+73956664 1 --Tearlaments Reinoheart
+572850 1 --Tearlaments Scheiren
+89399912 1 --Tempest, Dragon Ruler of Storms
+73628505 1 --Terraforming
+32731036 1 --The Bystial Lubellion
+15291624 1 --Thunder Dragon Colossus
+35316708 1 --Time Seal
+21076084 1 --Trickstar Reincarnation
+46060017 1 --Zoodiac Barrage
+78872731 1 --Zoodiac Ratpier
+# Semi-Limited
+29301450 2 --S:P Little Knight
+92714517 2 --Big Welcome Labrynth
+24224830 2 --Called by the Grave
+9411399 2 --Destiny HERO - Malicious
+94677445 2 --Ib the World Chalice Justiciar
+91800273 2 --Dimension Shifter
+2526224 2 --Fire King High Avatar Kirin
+9674034 2 --Snake-Eye Ash
+35059553 2 --Kaiser Colosseum
+49238328 2 --Pot of Extravagance
+67723438 2 --Emergency Teleport
+35726888 2 --Foolish Burial GoodsS
+14532163 2 --Lightning Storm
+56700100 2 --My Friend Purrely
+35261759 2 --Pot of Desires
+55584558 2 --Purrely Delicious Memory
+12580477 2 --Raigeki
+65734501 2 --Rescue-ACE Air Lifter
+48130397 2 --Super Polymerization
+11110587 2 --That Grass Looks Greener

--- a/0Rush-Prerelease.lflist.conf
+++ b/0Rush-Prerelease.lflist.conf
@@ -1,0 +1,2193 @@
+#[2024.04.01 Rush Prereleases]
+!2024.04.01 Rush Prereleases
+$whitelist
+160001001 3 --Lizard Soldier (Rush)
+160001002 3 --Lesser Dragon (Rush)
+160001003 3 --Ancient Turtle Protector
+160001004 3 --Binding Chain (Rush)
+160001005 3 --Tang the Noodle Ninja
+160001006 3 --Little D (Rush)
+160001007 3 --Arma Knight (Rush)
+160001008 3 --Petit Moth (Rush)
+160001009 3 --Skull Servant (Rush)
+160001010 3 --Silver Fang (Rush)
+160001011 3 --Feral Imp (Rush)
+160001012 3 --Faith Bird (Rush)
+160001013 3 --LaMoon (Rush)
+160001014 3 --Machine Attacker (Rush)
+160001015 3 --Crawling Dragon (Rush)
+160001016 3 --Max Raider
+160001017 3 --Kuribot
+160001018 3 --Whispering Fairy
+160001019 3 --Fire Golem
+160001020 3 --Hilt, the Bearer of Noble Arms
+160001022 3 --Raidacross, Hero of the Dawn
+160001024 3 --Sportsdragon Pitcher
+160001025 3 --Sportsdragon Slugger
+160001026 3 --Dragonic Slayer
+160001028 3 --Prima Guitarna the Shining Superstar
+160001029 3 --Yamiruler the Dark Delayer
+160001030 3 --Spice the Elite Noodle Ninja
+160001031 3 --Defender of Dragon Sorcerers
+160001032 3 --Thunder the Thunder
+160001033 3 --Sonic Attacker
+160001034 3 --Mask of Volos
+160001035 3 --Diabolic King Beetle
+160001036 3 --Battle Shark Samegalon
+160001037 3 --Pierce!
+160001038 3 --Recovery Force
+160001039 3 --Road Magic - Tempest
+160001040 3 --Seal of the Ancients (Rush)
+160001041 3 --Hammer Crush
+160001042 3 --Sparks (Rush)
+160001043 3 --Darkness Approaches (Rush)
+160001044 3 --One-Side Reverse
+160001045 3 --Mountain (Rush)
+160001046 3 --Counter Cannonball
+160001047 3 --Call of the Earthbound (Rush)
+160001048 3 --Gust (Rush)
+160001049 3 --Brutal Retribution
+160001050 3 --1-Up
+160002001 3 --Sportsdragon Keeper
+160002002 3 --Wattkiss
+160002003 3 --Watangel
+160002004 3 --Mammoth Graveyard (Rush)
+160002005 3 --Megazowler (Rush)
+160002006 3 --Bubbly Elf
+160002007 3 --LaMoon the Party Princess
+160002008 3 --Kanan the Sword Diva
+160002009 3 --Beast Gear Gyro Jackal
+160002010 3 --Beast Gear Buggy Dog
+160002011 3 --Beast Gear Moto Wolf
+160002012 3 --Jet Barracuda
+160002013 3 --Heat Dartfish
+160002014 3 --Harpie Girl (Rush)
+160002015 3 --Vishwar Randi (Rush)
+160002016 3 --Sevens Road Mage
+160002017 3 --Lightning Voltcondor
+160002018 3 --Full Meteor Impact
+160002019 3 --Sportsdragon Defender
+160002020 3 --Sportsdragon Striker
+160002021 3 --Shock Dragon
+160002022 3 --Piercing Dragon Bunker Strike
+160002023 3 --Romanpick
+160002024 3 --Romic n' Roller
+160002025 3 --Esperade the Smashing Superstar
+160002026 3 --Nandes the Fire Awakener
+160002027 3 --Dian Keto the Boogie Master
+160002028 3 --Beast Gear Emperor Catapult Kong
+160002029 3 --Super King Rex
+160002030 3 --Wicked Shadow Dark Lurker
+160002031 3 --Royal Rebel's Heavy Metal
+160002032 3 --Hydro Cannon Big Bluefin
+160002033 3 --Archfiend's Summoning Flute
+160002034 3 --Shaman Octopus
+160002035 3 --Innocent Lancer
+160002036 3 --Road Magic - Tectonic Shift
+160002037 3 --Lullabind
+160002038 3 --Party Party Party
+160002039 3 --Apocalypse - Beast Gear World
+160002040 3 --Thousand Knives (Rush)
+160002041 3 --Dark Magic Attack (Rush)
+160002042 3 --Blades of Divine Wind
+160002043 3 --Attribute Shift Bomb
+160002044 3 --Blue Medicine (Rush)
+160002045 3 --Party Time - Disco Ball
+160002046 3 --Rage and Conspiracy
+160002047 3 --Siesta Hold
+160002048 3 --Phantom Bind
+160002049 3 --Double Block
+160002050 3 --Driving Snow (Rush)
+160003001 3 --Light Sorcerer
+160003002 3 --Scoop Scooter
+160003003 3 --Stock the Noodle Ninja
+160003004 3 --Mushroom Man (Rush)
+160003005 3 --Niwatori (Rush)
+160003006 3 --Chu-Ske the Mouse Fighter (Rush)
+160003007 3 --Baby Dragon (Rush)
+160003008 3 --Hitotsu-Me Giant (Rush)
+160003009 3 --Doriado (Rush)
+160003010 3 --Water Magician (Rush)
+160003011 3 --Gazelle the King of Mythical Beasts (Rush)
+160003012 3 --Ojisan
+160003013 3 --Echeclus the Star Knight
+160003014 3 --Sparkhearts Girl
+160003015 3 --Silver Wolf
+160003016 3 --Beast Summoner
+160003017 3 --Sieth, the Scabbard of Noble Arms
+160003018 3 --Bendorbreak the Conqueror
+160003019 3 --Savage Claw Tiger
+160003020 3 --Treasure Dragon
+160003021 3 --Dragon Merchant
+160003022 3 --Clear Ice Dragon
+160003023 3 --Burning Blaze Dragon
+160003024 3 --Ancient Arise Dragon
+160003025 3 --Illusion Strike Dragon Miragias
+160003026 3 --Kesshin the Dark Decimator
+160003027 3 --Seahorse Server
+160003028 3 --Seahorse Carrier
+160003029 3 --Vishwar Lambadi
+160003030 3 --Beast Gear Trike Fox
+160003031 3 --Beast Gear King Convoy Liogon
+160003032 3 --Printing Presser
+160003033 3 --Extra Spice the Elite Noodle Ninja
+160003034 3 --Anchor Moray
+160003035 3 --Trick Pigeon
+160003036 3 --Luminous Parrot
+160003037 3 --Long Shield Gardna
+160003038 3 --Eldign Patrol Ship
+160003039 3 --Survival Swordfish
+160003040 3 --Darkness Crested Hawk
+160003041 3 --Sea Dragon King Granganus
+160003042 3 --Rightful Magic
+160003043 3 --Dragon's Return
+160003044 3 --Blazing Chestnut
+160003045 3 --The Noodle Art of Spicery
+160003046 3 --The Noodle Art of Savory
+160003047 3 --Triple Threat Thunder
+160003048 3 --Shining City Nights
+160003049 3 --Aqua Boost
+160003050 3 --Big Umi
+160003051 3 --Thousand Attack Rocket
+160003052 3 --Umi (Rush)
+160003053 3 --Forest (Rush)
+160003054 3 --Soul of a Reporter
+160003055 3 --Bait Bite Ball
+160003056 3 --Counter Shield
+160003057 3 --Counter Pigeons
+160003058 3 --Giant Tortoise of Greed
+160003059 3 --Triple Trio
+160003060 3 --Faulty Fire
+160004001 3 --Constructor Soldier Drillzard
+160004002 3 --Constructor Warrior Shovelon
+160004003 3 --Constructor Battler Big Roller
+160004004 3 --Brassaxophone the Music Princess
+160004005 3 --Flutomahawk the Music Princess
+160004006 3 --Bull Breaker
+160004007 3 --Oppressed Ant
+160004008 3 --United Ants
+160004009 3 --Ants Running About
+160004010 3 --Tsuvolcano
+160004011 3 --Enchanting Mermaid (Rush)
+160004012 3 --Descendant of Titans
+160004013 3 --Grace Princess Kana
+160004014 3 --Silent Assailant
+160004015 3 --Steel Mech Lord Mirror Innovator
+160004016 3 --Insurrection Dragon
+160004017 3 --Chemical Cure Blue
+160004018 3 --Tama the Mancer Cat
+160004019 3 --Modorina the Light Retriever
+160004020 3 --Semeruler the Dark Summoner
+160004021 3 --Wyrm Excavator the Heavy Cavalry Draco [L]
+160004022 3 --Wyrm Excavator the Heavy Cavalry Draco
+160004023 3 --Wyrm Excavator the Heavy Cavalry Draco [R]
+160004024 3 --Constructor Wyrm Buildragon
+160004025 3 --Picklon the Constructor Fairy
+160004026 3 --Nuncharinet the Music Princess
+160004027 3 --Trumpetonfa the Music Princess
+160004028 3 --Ensembullfighter the Music Fiend
+160004029 3 --Digisoon the Music Fiend
+160004030 3 --Gingangel, the Deluxe Sushi Fairy
+160004031 3 --Drilling Mandrill
+160004032 3 --Shield Boring Kong
+160004033 3 --Antrebellion of the Rebellion
+160004034 3 --Anmagmabear
+160004035 3 --Aromagmabear
+160004036 3 --Magmassage
+160004037 3 --Magmax Mantleveda
+160004038 3 --Sakakaze the Talismanic Warrior
+160004039 3 --Type Change Beam
+160004040 3 --Ancient Barrier
+160004041 3 --Evil Star Beacon
+160004042 3 --Peaks of Blisstopia
+160004043 3 --Geological Survey
+160004044 3 --Primal Howling
+160004045 3 --Music Princess's Breath
+160004046 3 --Heavy Cavalry Tactics
+160004047 3 --Apocalypse - Legend of the Warrior
+160004048 3 --Fiery Blaze
+160004049 3 --Grand Extreme
+160004050 3 --Sogen (Rush)
+160004051 3 --Triangle Reborn
+160004052 3 --Sword & Shield
+160004053 3 --Constructor Ambush
+160004054 3 --Constructor Blockade
+160004055 3 --Heavy Cavalry Starter
+160004056 3 --Gi-ant Revolution
+160004057 3 --Antiberty Flag
+160004058 3 --Earth Pressure Explosion
+160004059 3 --Jewelry Trap Hole
+160004060 3 --Beast Gear Secret Art - Primal Fist
+160005001 3 --The Fire Dragon
+160005002 3 --CAN:D
+160005003 3 --Royal Rebel's No Wave
+160005004 3 --Guarding Mermaid
+160005005 3 --Kanan the Security Guard
+160005006 3 --Kurobana the Shadow Flower Wolf
+160005007 3 --Lindo the Shadow Flower Warrior
+160005008 3 --Bombing Bird
+160005009 3 --Grass
+160005010 3 --Surge Bolt Lizard
+160005011 3 --Baked Bean Soldier
+160005012 3 --Metal Armored Ant
+160005013 3 --Ice Age Catapult
+160005014 3 --Hyper Engine Vast Vulcan [L]
+160005015 3 --Hyper Engine Vast Vulcan
+160005016 3 --Hyper Engine Vast Vulcan [R]
+160005017 3 --Fortitude Dragon
+160005018 3 --Endoll
+160005019 3 --CAN - Re:D
+160005020 3 --Takegumi the Ruler's Squad
+160005021 3 --Wondering Warrior
+160005022 3 --Icezark the Unequaled
+160005023 3 --Royal Rebel's Phaser
+160005024 3 --Royal Rebel's Doom Metal
+160005025 3 --Vice Jacker
+160005026 3 --Dian Keto the Security Master
+160005027 3 --Acacia the Shadow Flower Priestess
+160005028 3 --Gekka the Shadow Flower Beauty
+160005029 3 --Etraynze the Shadow Flower Ninja
+160005030 3 --Gajumaru the Shadow Flower Lion
+160005031 3 --Garland the True Shadow Flower Ninja
+160005032 3 --Gatling the Shadow Flower Shinobi
+160005033 3 --Blasting Bird
+160005034 3 --Night Vision the Phantom Pigeon
+160005035 3 --Siesta Torero
+160005036 3 --Maginical Miracle
+160005037 3 --Coiled Dragon of Fertility
+160005038 3 --Cheron the Star Knight
+160005039 3 --JAM:P Up!
+160005040 3 --JAM:P Start!
+160005041 3 --Royal Rebel's Command
+160005042 3 --Royal Rebel's Arena
+160005043 3 --Vicissitude of Providence
+160005044 3 --The Menacing Eyes of the Sky Emperor
+160005045 3 --Prison Island - Cell Block 5 & 6
+160005046 3 --Last Day of the Pretty☆Witch
+160005047 3 --Hydration
+160005048 3 --Shadow Flower Spore
+160005049 3 --Apocalypse - The Unstoppable Beast-Warrior
+160005050 3 --Majinrai, the Striking Storm
+160005051 3 --Invading Nature
+160005052 3 --Judgment of the Rising Light
+160005053 3 --Avian Spell Tactics
+160005054 3 --Wasteland (Rush)
+160005055 3 --Pretty☆Witch Imprisonment
+160005056 3 --All For Naught - Bubble Burst
+160005057 3 --Shadow Flower Stance
+160005058 3 --Shadow Flower Return
+160005059 3 --Brocoohearted Pigeon
+160005060 3 --Clowning Cookoo Clock
+160005061 3 --Music Princess's Recital
+160005062 3 --Archfiend's Revival
+160005063 3 --Maraimei, the Igniting Inferno
+160005064 3 --Cheering Grass
+160005065 3 --Acetic Acid Trap Hole
+160006001 3 --Sunny Fairy Spinangel
+160006002 3 --Worker Warrior - New Recruit
+160006003 3 --Worker Warrior - Bad Boss
+160006004 3 --Barbeque Ox
+160006005 3 --Mystic Roastman
+160006006 3 --Archfiend Marmot of Deliciousness
+160006007 3 --Hampering Hippo
+160006008 3 --Dogulce Jomont Blanc
+160006009 3 --Pangoflame
+160006010 3 --Flying Kamakiri #2 (Rush)
+160006011 3 --Northern Dumplina
+160006012 3 --Fazuzu the King of Mythical Wind Beasts
+160006013 3 --Handy Lady
+160006014 3 --Sevens Road Wiz
+160006015 3 --Thunderbold, the Blazing Thunder
+160006016 3 --Stock Buster Dragon
+160006017 3 --Steel Strike Dragon Metagias
+160006018 3 --Speedy Performer
+160006019 3 --Future Diviner
+160006020 3 --Betrayer of Peace
+160006021 3 --Karchizark the Unequaled
+160006022 3 --Air Formula Eagle
+160006023 3 --Secret Service Shine Guard
+160006024 3 --Worker Warrior - Sinister CEO
+160006025 3 --Shichirin Samurai - Kushiro the Skewer Master
+160006026 3 --Beast Drive Mega Elephant
+160006027 3 --Dogulce Langue de Shakoki
+160006028 3 --Doki Doki Hexenhaus
+160006029 3 --Jasmine the Shadow Flower Festival
+160006030 3 --Crafter Drone
+160006031 3 --Assault Armato
+160006032 3 --Heat Hyena
+160006033 3 --Reset Runner
+160006034 3 --Lindmühle
+160006035 3 --Gate Gargoyle
+160006036 3 --Vietor the Prevailing Wind
+160006037 3 --Bladesaurus
+160006038 3 --Arzareth the Sweeping Wind
+160006039 3 --Road Magic - Uplifter
+160006040 3 --Hypernova
+160006041 3 --JAM:P Set!
+160006042 3 --Ruler's Current
+160006043 3 --Against Buster
+160006044 3 --Storm Sonic
+160006045 3 --Following World
+160006046 3 --Business Card Barrage
+160006047 3 --Nutrient Zero
+160006048 3 --Best Bite
+160006049 3 --B・B・Q
+160006050 3 --Wild Kitchen
+160006051 3 --Beast Battlefield Barrier
+160006052 3 --Dekorelic Dessert
+160006053 3 --Talismanic Seal Array
+160006054 3 --Iron Onslaught
+160006055 3 --Rage of the Beasts
+160006056 3 --Berserker Colosseum
+160006057 3 --Mismatched Rivalry
+160006058 3 --7 Chance
+160006059 3 --Psychicounter
+160006060 3 --Dark Ruler Battle Slash
+160006061 3 --Covering Barrage
+160006062 3 --Salary Slash
+160006063 3 --Battle Demotion
+160006064 3 --Eternal Freeze
+160006065 3 --Scaredy Cats
+160007001 3 --Needlkyrie the Celestial Seamstress
+160007002 3 --Takriminos (Rush)
+160007003 3 --Dolphin King Iruqua
+160007004 3 --Gagaga Outfielder
+160007005 3 --Achacha Catcher
+160007006 3 --Zubaba Batter
+160007007 3 --ExPress Train
+160007008 3 --Flavor Inspector
+160007009 3 --Cross Promotion the Elite Noodle Ninja
+160007010 3 --Unidentified Mysterious Urchin
+160007011 3 --Necroman the Third
+160007012 3 --Daybreak Warrior
+160007013 3 --Porcupine Dragon
+160007014 3 --Psypickupper
+160007015 3 --Mezame the Ringing Alarm
+160007016 3 --Piercing Samurai
+160007017 3 --Kimeluna the Dark Shifter
+160007018 3 --Royal Rebel's Break
+160007019 3 --Viscom Nanotron
+160007020 3 --Constructor Sky Wyrm Gantry Dragon
+160007021 3 --Light Dolphin
+160007022 3 --Sea Star Trooper
+160007023 3 --Kataomoiruka
+160007024 3 --Headbutt Cachalot
+160007025 3 --Dododo Second
+160007026 3 --Gogogo Umpire
+160007027 3 --Player #99: Grand Slam Dragon
+160007028 3 --Player #39: Home Run Hitter
+160007029 3 --Reporter Raccoon
+160007030 3 --Clean Machine Newsweeper
+160007031 3 --Sea Dragon Cranedross
+160007032 3 --Sea Dragon Knight
+160007033 3 --Dosodon
+160007034 3 --Raidacross Ash, Hero of Chaos
+160007035 3 --CAN:D LIVE
+160007036 3 --Yamiterasu the Divine Ruler
+160007037 3 --Newsflash the Journalistic Juggernaut
+160007038 3 --Meat Spice the Special Noodle Ninja
+160007039 3 --Miso Instant the Special Noodle Ninja
+160007040 3 --Hunter of Titans
+160007041 3 --Fenrirewritter Sol
+160007042 3 --Supreme Marine Fortress Magnum Overbase
+160007043 3 --Five Types of Assistance
+160007044 3 --Bizarrmor
+160007045 3 --Shape of Aqua
+160007046 3 --Vanishing Torrent
+160007047 3 --Feverous Spirit Stadium
+160007048 3 --Hot Off the Press
+160007049 3 --Reprinter
+160007050 3 --The Noodle Art of Roastery
+160007051 3 --The Noodle Art of Saucery
+160007052 3 --Ship of Seven Treasures
+160007053 3 --Back Beat
+160007054 3 --Stream
+160007055 3 --Card Devastation
+160007056 3 --Shocking Comeback!!
+160007057 3 --Pair Collision
+160007058 3 --Dolphin Counterattack
+160007059 3 --Seastorm of Iruqua
+160007060 3 --Gagagaguts
+160007061 3 --Requesting 9
+160007062 3 --Reporting from the Scene!
+160007063 3 --Breaking News!
+160007064 3 --Spiral Geyser
+160007065 3 --Hardefense Mission
+160008001 3 --Dark Femtron
+160008002 3 --Snake Clown
+160008003 3 --Ancient Lizard Warrior (Rush)
+160008004 3 --Armored Lizard (Rush)
+160008005 3 --Boosturtle
+160008006 3 --Pluggyfish
+160008007 3 --Anglercoilfish
+160008008 3 --Antsgiving
+160008009 3 --Lauan Adventurers
+160008010 3 --Germalewe
+160008011 3 --Sevens Road Sorcerer
+160008012 3 --Rhythmical Performer
+160008013 3 --Excutie Feena
+160008014 3 --Shearkyrie the Celestial Seamstress
+160008015 3 --Mecha Ambulator
+160008016 3 --Captain #39: Home Plate Pinch Hitter
+160008017 3 --Kamaleon
+160008018 3 --Clawmeleon
+160008019 3 --Fiery Infernleon
+160008020 3 --Metal Megaleon
+160008021 3 --Predator Gunleon
+160008022 3 --Ecdysis Caesarleon
+160008023 3 --Spyturtle
+160008024 3 --Rocketortoise Modularchelon
+160008025 3 --Zap Zap Octospark
+160008026 3 --Spirit of Bolt of Inspiration
+160008027 3 --Sensor Duckbill
+160008028 3 --Emitter Stag
+160008029 3 --Blast Jaws
+160008030 3 --Stormbolt Destroyer
+160008031 3 --Blitzkrieg Cavalry Triggerdrago
+160008032 3 --Master of the Sevens Road
+160008033 3 --Hazy Strike Dragon Miragiastar F
+160008034 3 --Endless Romance Blitz
+160008035 3 --Hero of the Assist
+160008036 3 --Semeterasu the Divine Ruler
+160008037 3 --Meika Etraynze the Shadow Flower Venus
+160008038 3 --Durga the Shadow Flower Submarine
+160008039 3 --Metarion King Cobrastar
+160008040 3 --Poseigyon Advencharger
+160008041 3 --Showering Seaferno
+160008042 3 --Prime Roast Beef Horseman
+160008043 3 --Hormone GunMcQueen, the Magnificent Shichirin
+160008044 3 --Ether Fast Striker
+160008045 3 --Vulcan Ignite Hyperdrive
+160008046 3 --Royal Rebel's Echo
+160008047 3 --Shadow Flower Flurry
+160008048 3 --Shadow Flower Wish
+160008049 3 --Tag-Up-Magic Sacrifice Force
+160008050 3 --Bobble Header
+160008051 3 --Release Wrath
+160008052 3 --Fire Wrath
+160008053 3 --Spy Observation
+160008054 3 --Destructurtle Meteor
+160008055 3 --Clapping Thunder
+160008056 3 --Trailblitzing Thunderbolt
+160008057 3 --Parallel Birth Gate
+160008058 3 --Makiu, the Magical Mist (Rush)
+160008059 3 --Jurassic Oasis
+160008060 3 --Buried Shield
+160008061 3 --Wrath of Light
+160008062 3 --Ultimate Fighting Spirit
+160008063 3 --Sakuretsu Force
+160008064 3 --Electrical Discharge
+160008065 3 --Maid's Baneful Gift
+160009001 3 --Milky Wave Neo
+160009002 3 --Galactica Oblivion
+160009003 3 --Ewekai Grounmouton
+160009004 3 --Ewekai Pyrowool
+160009005 3 --Ewekai Nightmutton
+160009006 3 --Magical Sheep Girl Meeeg-chan
+160009007 3 --One Year Broom
+160009008 3 --Decennium Mystic Sword
+160009009 3 --Centennial Wooden Blade
+160009010 3 --Atlas Combat Beetle
+160009011 3 --Protector of the Throne (Rush)
+160009012 3 --Griffore (Rush)
+160009013 3 --Black Handshaker
+160009014 3 --Astrorescue
+160009015 3 --Ozone Layer
+160009016 3 --Transamu Ephyrai
+160009017 3 --Satellite Pegasus
+160009018 3 --Great Cosmonarch
+160009019 3 --Jointech Rex
+160009020 3 --Ewekai Planeau
+160009021 3 --Poet Fairy
+160009022 3 --Swordfish Vanguard Gaju
+160009023 3 --Princess Ladybug White
+160009024 3 --Pakupakuchu
+160009025 3 --Swapling Silkworm Fibron
+160009026 3 --Therappi
+160009027 3 --Rapid Carriearth
+160009028 3 --Dramoth Caterpillar
+160009029 3 --Shitotsu the Talismanic Warrior
+160009030 3 --Bio Mechamantis
+160009031 3 --Crusher Drone
+160009032 3 --Ravenous Insect Matiless
+160009033 3 --Excutie Fermi
+160009034 3 --Anglered Digra
+160009035 3 --Ground Cerberus
+160009036 3 --Bladearmor King Dynas Dorcus
+160009037 3 --Sevensgias the Magical Dragon Knight
+160009038 3 --Constructor Ridge Wyrm Handtoolon
+160009039 3 --Meika Etraynzeyes the Shadow Flower Lunatic
+160009040 3 --Hero of the Sweep
+160009041 3 --Samurai of the Wooden Sword
+160009042 3 --Surge Vortex Dragoon
+160009043 3 --Meteor Charge
+160009044 3 --Meet and Greed
+160009045 3 --Future Mining
+160009046 3 --Sword Skill - Ruler's Slash
+160009047 3 --Defense Destroying Sword
+160009048 3 --Telegraphed Strike
+160009049 3 --Sunny Forest
+160009050 3 --Insect Rampage
+160009051 3 --Intruding Beetles
+160009052 3 --Excutie Up!
+160009053 3 --Ghost Cyclone
+160009054 3 --Strange Wall
+160009055 3 --Ewekai - Grudges from the Grave
+160009056 3 --Lucky Mask of Omens
+160009057 3 --Card Reprinting
+160009058 3 --Security Hole
+160009059 3 --Demolisher Wyrm Roar
+160009060 3 --Climax Clash
+160009061 3 --Engage and Strike!
+160009062 3 --Anciant Barrier
+160009063 3 --Ignoring Insect
+160009064 3 --Hunting Strawberries
+160009065 3 --Crisis at the Sacred Tower
+160010001 3 --Ewekai Aquasheep
+160010002 3 --Ewekai Thunderlambda
+160010003 3 --Ewekai Airaries
+160010004 3 --Hyosube (Rush)
+160010005 3 --Tutumes Dark Witch
+160010006 3 --Heartless Hound Blaster Gundog
+160010007 3 --Heartless Hound Blade Bulldosu
+160010008 3 --Heartless Hound Striking Kai Ken Knuckle
+160010009 3 --Heartless Hound Blaster Chaka Chow Chow
+160010010 3 --Heartless Hound Apex Katana Danbiramatian
+160010011 3 --Sannomiya Golden G Robo MK-III
+160010012 3 --Alien 33
+160010013 3 --The Three Warp-Granny Sisters
+160010014 3 --Alien Count of the White Dwarf, St. Germain
+160010015 3 --Ichtyosterguard
+160010016 3 --Nekogal #2 (Rush)
+160010018 3 --Cremation Dog Nitro
+160010019 3 --Dynamo Might
+160010020 3 --Chemicalize Salamander
+160010021 3 --Parashroom Colony
+160010022 3 --Burstray Gunman
+160010023 3 --Star Trancer
+160010024 3 --Ultra Violady
+160010025 3 --Voidvelgr Requiem
+160010026 3 --Ewekai Waveschaf
+160010027 3 --Infernal Kappa Diwet
+160010029 3 --Nuvia the Wicked Mischief Maker
+160010030 3 --Dian Keto the Cure Maiden
+160010031 3 --Heartless Hound Thunder Emperor Drainu
+160010032 3 --Heartless Hound Martial Master Shiba
+160010033 3 --Beast Gear Sage Roller Stag
+160010034 3 --Berry Fresh Happiness
+160010035 3 --Delirium Papillon
+160010036 3 --Splitter Slime
+160010037 3 --Miginagi the Talismanic Warrior
+160010038 3 --Rice Terrace Ripple
+160010039 3 --Headhunters' Digmole
+160010040 3 --Thunder Gazelle
+160010041 3 --Man-Thro' Tro' (Rush)
+160010042 3 --Abare Ushioni (Rush)
+160010043 3 --Diabearical Lilith
+160010044 3 --Splendid Floor Master
+160010045 3 --Eclipse
+160010046 3 --Melo Melo Meeeg☆Uuultra Beam
+160010047 3 --Caught in the Rain
+160010048 3 --Rainy Megalopolis
+160010049 3 --Bubble Kingdom
+160010050 3 --Woofderful Heartless Hound
+160010051 3 --300 Light-Year Red Cloak
+160010052 3 --Third Coming of the Reptilian Count
+160010053 3 --Area 33
+160010054 3 --Dolphin's Treasure Chest
+160010055 3 --Strange Seas
+160010056 3 --Yamata no Tsurugi
+160010057 3 --Yokai Tiger Orient Strike
+160010058 3 --Power Shock
+160010059 3 --Paxcyclinder
+160010060 3 --Kappa's River Flow
+160010061 3 --Sunbathing Kappa
+160010062 3 --Kappa's Gas
+160010063 3 --The Three Moonlit Mystery Geckos
+160010064 3 --Trap Lid
+160010065 3 --Boost Rescue
+160010101 3 --Blue Tooth Burst Dragon
+160010102 3 --Kappa Emperor River Slider
+160011001 3 --Police Scoop
+160011002 3 --Arts Angel Guard Dolby
+160011003 3 --Arts Angel Glyco Razer
+160011004 3 --Arts Angel CD Fender
+160011005 3 --Bean Soljersey
+160011006 3 --Black Luster Soljersey
+160011007 3 --Blanc de Blanc the Snow Shadow Flower
+160011008 3 --Robbarim
+160011009 3 --Ampler Glee
+160011010 3 --Astrosoldier
+160011011 3 --Galactica Tabula Rasa
+160011012 3 --Alco the Flame Emperor of the Lamp
+160011013 3 --Arts Angel Dia Needle
+160011014 3 --Arts Angel Metal Position
+160011015 3 --Penguin Soljersey
+160011016 3 --Cannon Soljersey
+160011017 3 --Black Luster Soljersey - Envoy of the Drying
+160011018 3 --Iris the Rare Shadow Flower
+160011019 3 --Alpiris the Sower
+160011020 3 --Radrogue Mael
+160011021 3 --Taiban Bluemai
+160011022 3 --Bluegrass Stealer
+160011023 3 --Heel Healer
+160011024 3 --Prophecy Phrase of the Colors of the Wind
+160011025 3 --Asport Pirate the Wind Crusher
+160011026 3 --Bandijo of the Battle Ballad
+160011027 3 --Beast Gear Side Fennec
+160011028 3 --Shariel, the Novice Sushi Fairy
+160011029 3 --Brain Harvester
+160011030 3 --Seraph of Darkness
+160011031 3 --Philan Dwarf
+160011032 3 --Shadow Buyer
+160011033 3 --Ghost Vicious
+160011034 3 --Watchman of the Apocalypse
+160011035 3 --Neo Plandish
+160011036 3 --Salvage Wolfish
+160011037 3 --Doushin Kaika the Shadow Flower Full Moon
+160011038 3 --Javelin Dux the Shadow Flower Piercer
+160011039 3 --Kuzuha the Talismanic Supreme Sage
+160011040 3 --Galactica Xiphos
+160011041 3 --Jointech Rushhorn
+160011042 3 --QWERTY Keyblade
+160011043 3 --Chemicalizer Red
+160011044 3 --Voidvelgr Tyrfing
+160011045 3 --Auto Reverse
+160011046 3 --Black Luster Jersey Ritual
+160011047 3 --Preparation of Jersey Rites
+160011048 3 --Shadow Flower Sewing
+160011049 3 --Shadow Flower Duplication
+160011050 3 --Road Arms - Sevens Lance
+160011051 3 --Flame Arms - Fretberge
+160011052 3 --Heavy Arms - Double Nexcalibur
+160011053 3 --Sacred Arms - Strabishop
+160011054 3 --JAM:P Check!
+160011055 3 --Music Princess's Prelude
+160011056 3 --Atrium's Wind
+160011057 3 --Descent of the Sweeping Spirit
+160011058 3 --Beast Swords - Tiger Sabre
+160011059 3 --Armaments of Ascension
+160011060 3 --Site Preview
+160011061 3 --Indigo Prison
+160011062 3 --Slash Halo
+160011063 3 --Back Jersey
+160011064 3 --Force of Thief
+160011065 3 --Revenge MAX
+160012001 3 --Chromatographagas
+160012002 3 --Ray Dragon
+160012003 3 --The Dragias
+160012004 3 --Silver-Eyes Star Cat
+160012005 3 --Golden-Eyes Star Cat
+160012006 3 --Jointech Tinplatesaurus
+160012007 3 --Red Riser
+160012008 3 --Voidvelgr Kataphraktos
+160012009 3 --Voidvelgr Black Dwarf
+160012010 3 --Machvio of the Ultimate Aria
+160012011 3 --Double-Doom Dragon
+160012012 3 --The Clone
+160012013 3 --Mirroring Wyvern
+160012014 3 --Purple-Eyes Star Cat
+160012015 3 --Green-Eyes Star Cat
+160012016 3 --Cat Claw Girl
+160012017 3 --Dark-Eyes Breakstar Cat
+160012018 3 --Cyber Coatl
+160012019 3 --Excutie Flame
+160012020 3 --Soleil the Skysavior Angel
+160012021 3 --Lua the Skysavior Angel
+160012022 3 --Ranga the Skysavior Knight
+160012023 3 --Seir the Skysavior Knight
+160012024 3 --Ciela the Skysavior Knight
+160012025 3 --Dunkes the Skysavior Knight
+160012026 3 --Astrobio Drake
+160012027 3 --Engine Reviver
+160012028 3 --Gilford the Rising
+160012029 3 --Gilford the Legend (Rush)
+160012030 3 --Transamuroad Rainac
+160012031 3 --Melel the Beautiful Flame Spirit of the Lamp
+160012032 3 --Alchemicalize Salamandra
+160012033 3 --Voidvelgr Protostar
+160012034 3 --Double Ray Dragons
+160012035 3 --The Dragiastar
+160012036 3 --Star Cat Straynya
+160012037 3 --Star Cat Destronya
+160012038 3 --Solcier the Skysavior Lightflash
+160012039 3 --Altierra the Skysavior Transience
+160012040 3 --Digrace the Skysavior Radiance
+160012041 3 --Drukmoor the Skysavior Phantom
+160012042 3 --Stemagic
+160012043 3 --Cracking Claw
+160012044 3 --Voidvelgr Phalanx
+160012045 3 --Road Arms - Sword Breaker
+160012046 3 --The Copy
+160012047 3 --Back to The Fusion
+160012048 3 --Vice Slasher
+160012049 3 --Meowonderful Rush
+160012050 3 --Rising Luna Radiant Luster
+160012051 3 --Blaze Fiend Assault
+160012052 3 --Skysavior Prayer
+160012053 3 --Skysavior Watch
+160012054 3 --Skysavior Symbol
+160012055 3 --Ring of Storms
+160012056 3 --Transamu Lightning
+160012057 3 --Jointech Great Wall
+160012058 3 --Tribute Block
+160012059 3 --Dark Nebula
+160012060 3 --Dragon Double-Doom
+160012061 3 --Stray Force
+160012062 3 --Ether Escape
+160012063 3 --Traditional Tax
+160012064 3 --Buffered Slime
+160012065 3 --Phantom Roar
+160012066 3 --Multistrike Dragon Dragias
+160013000 3 --Sevens Road Witch
+160013001 3 --Earth Sorcerer
+160013002 3 --Aero Sorcerer
+160013003 3 --Galactica Deja Vu
+160013004 3 --Booster Wyvern
+160013005 3 --DBF Rebuildra
+160013006 3 --Voidvelgr Kyrie
+160013007 3 --Voidvelgr Logistikos
+160013008 3 --Voidvelgr Chrysaor
+160013009 3 --Celeb Rose Mage
+160013010 3 --Celeb Rose Sorcerer
+160013011 3 --Celeb Rose Witch
+160013012 3 --Celeb Rose Magician
+160013013 3 --Magiarms Beast Gearpard
+160013014 3 --Zuse the Wisdom Vassal
+160013015 3 --Hebe the Star Vassal
+160013016 3 --Wilhel the Wisdom Monarch
+160013017 3 --Estrome the Star Monarch
+160013018 3 --Wilhel the Mega Monarch
+160013019 3 --Estrome the Mega Monarch
+160013021 3 --Cyber Processor
+160013022 3 --Star Replacer
+160013023 3 --Don A. Corn of the Verdant Vast
+160013024 3 --Braid Blade Reader
+160013025 3 --Skyporter Max
+160013026 3 --Devil Foolish
+160013027 3 --Splame
+160013028 3 --Elegant Aurum Avian
+160013029 3 --Plaster Scout
+160013030 3 --Mad Rare Aquila
+160013031 3 --EXTRAplorer
+160013032 3 --Manifestation Master Dortheo
+160013033 3 --Pureglass Spears
+160013034 3 --Galactiara Fuse Eve
+160013035 3 --Eternal Galactica Oblivion
+160013036 3 --Tamabot Burst Dragon
+160013037 3 --Blue Tooth Enhanced Burst Dragon
+160013038 3 --Red Boot Enhanced Boost Dragon
+160013039 3 --Voidvelgr Theogonia
+160013040 3 --Voidvelgr Gigantomachia
+160013041 3 --Celeb Rose Fabulous Magician
+160013042 3 --Celeb Rose Luxury Magicians
+160013043 3 --Sevens Chariot the Magical Knight
+160013044 3 --Cyber Tactical Dragon
+160013045 3 --Space Fusion - EXTRAplasmer
+160013046 3 --Advance Impact
+160013047 3 --Galactica Addergatling
+160013048 3 --Dragon's Burst Fusion
+160013049 3 --Dragon's Boost Fusion
+160013050 3 --Voidvelgr Gullinbursti
+160013051 3 --Voidvelgr Shroud
+160013052 3 --Charis Magic - Elegant Change
+160013053 3 --Charis Magic Scepter - Death Wand
+160013054 3 --Sevens Wonder Fusion
+160013055 3 --Magical Lance - Grace Spear
+160013056 3 --Emperor Realm
+160013057 3 --Protection of Arthenée
+160013058 3 --Dead or Arainac
+160013059 3 --Recombination Galactica
+160013060 3 --Nobody Scat Thief
+160013061 3 --Rose Chain Salvage
+160013062 3 --Machinations of the Monarchs
+160013063 3 --Nativity of the Monarchs
+160013064 3 --Shared Sentiments
+160013065 3 --Vortex of Shattered Light
+160013066 3 --Rice Terrace Crisis
+160013122 3 --Star Replacer
+160013130 3 --Mad Rare Aquila
+160013157 3 --Protection of Arthenée
+160013166 3 --Rice Terrace Crisis
+160014000 3 --Gaia The Fierce Knight (Rush)
+160014001 3 --Worm Drake (Rush)
+160014002 3 --Jointech Cobra
+160014003 3 --Mega Jointech Fortrex [L]
+160014004 3 --Mega Jointech Fortrex
+160014005 3 --Mega Jointech Fortrex [R]
+160014006 3 --Jointech Arc Scorpio
+160014007 3 --Jointech Spike Centipede
+160014008 3 --Jointech Hero
+160014009 3 --Chemispet Nyanko
+160014010 3 --Chemispet Wanko
+160014011 3 --Melt the Aqueous Spirit
+160014012 3 --Bolt the Conduction Spirit
+160014013 3 --Hot the Combustion Spirit
+160014014 3 --Hyper Assistant Achi
+160014015 3 --Blazebolt Chemistorm Fenghuang Volcalize Phoenix [L]
+160014016 3 --Blazebolt Chemistorm Fenghuang Volcalize Phoenix
+160014017 3 --Blazebolt Chemistorm Fenghuang Volcalize Phoenix [R]
+160014018 3 --Secret Investigator Miscast
+160014019 3 --Secret Investigator Mistake
+160014020 3 --Secret Investigator Mismatch
+160014021 3 --Secret Investigator Mislead
+160014022 3 --Elite Secret Investigator Mystery
+160014023 3 --Abysslayer Leviaknight
+160014024 3 --Abysskite Ange
+160014025 3 --Abysskite Liem
+160014026 3 --Abysskite Karen
+160014027 3 --Constructor Driver Soldier Trailon
+160014028 3 --Change Slime - Dragon Champion Mode
+160014029 3 --Dragoncurse Magician
+160014030 3 --Launcher Catapult Turtle
+160014031 3 --Veteran Curse of Dragon
+160014032 3 --Veteran Gaia the Fierce Knight
+160014033 3 --Polygon Butterfly
+160014034 3 --Negatwor Dragon
+160014035 3 --The Strange Specter of Celestial Starts
+160014036 3 --Steel Soldier Gale Vinary
+160014037 3 --Rising Light Angel Esser
+160014038 3 --Galacterial Ore
+160014039 3 --Dino Skeleton Pushcera
+160014040 3 --All-Seeing Harvey
+160014041 3 --Landporter MAX
+160014042 3 --Snake Princess of Purity
+160014043 3 --Jointech Fighter
+160014044 3 --Jointech Killer Stinger
+160014045 3 --Jointech Burst Dragon
+160014046 3 --Gaia the Battle Ruler
+160014047 3 --Jointech Dig Up
+160014048 3 --Volcalize Compound
+160014049 3 --Chemicalize Structure Force
+160014050 3 --Dark Hole Device
+160014051 3 --Aura Buster
+160014052 3 --Monster Convocation
+160014053 3 --Dark Battle Grounds
+160014054 3 --Gameboard Ablaze and Alight
+160014055 3 --Cat-trois Choice
+160014056 3 --Psymprinting
+160014057 3 --Legend Strike
+160014058 3 --Jointech Ignition
+160014059 3 --Chemicalize Despise
+160014060 3 --Secret File 33 - Noble Death of Resentment
+160014061 3 --Intercepting Gaia
+160014062 3 --Dragonic Escape
+160014063 3 --Amusi Annoyance
+160014064 3 --Excutie Riding!
+160014066 3 --Automatic Accident Prevention
+160014135 3 --The Strange Specter of Celestial Starts
+160014136 3 --Steel Soldier Gale Vinary
+160014137 3 --Rising Light Angel Esser
+160014163 3 --Amusi Annoyance
+160015000 3 --Esperade the Smashing Superstar
+160015001 3 --Darkness Drake
+160015002 3 --Surging-Wave Swordsman Yoshimitsu Shark
+160015003 3 --Darkness Dwarf
+160015004 3 --Darkness Transamu Craisis
+160015005 3 --Striping Wyvern
+160015006 3 --Flap Dragon
+160015007 3 --Flip Dragon
+160015008 3 --Celeb Rose Wiz
+160015009 3 --Darkness Paparazzi
+160015010 3 --Darkness Phantomite
+160015011 3 --Demolition Soldier Ashiba Bikke
+160015012 3 --Fiddlebadour
+160015013 3 --Vibra Brigand
+160015014 3 --Plandolin
+160015015 3 --Star's Hand Camera Lady
+160015016 3 --Surging-Wave Swordsman Tanegashima Tuna
+160015017 3 --Hydro Gun Mini Bluefin
+160015018 3 --Charge Remora
+160015019 3 --Carrier Manta Ray
+160015020 3 --Cyber Fish
+160015021 3 --Cyber Shark (Rush)
+160015022 3 --Surging-Wave Swordsman Onimaru Kunituna
+160015023 3 --Infernal Kappa River Sprinter
+160015024 3 --Meteorite Dragon's Chick
+160015025 3 --Red-Eyes Moon Dragon
+160015026 3 --Alligator's Black Knight
+160015027 3 --Rocket Satellite Medic
+160015028 3 --Meteor Drake
+160015029 3 --Planting Pixie
+160015030 3 --Pure Love Angel
+160015031 3 --Owlchannel
+160015032 3 --Dark Effigy (Rush)
+160015033 3 --Dead End the Mad Fiend of Despair
+160015034 3 --Glacies the Snowmeister of Sacred Splendor
+160015035 3 --Darkness Doom Giant
+160015036 3 --Darkness Galactica Oblivion
+160015037 3 --Red Reboot Enhanced Boost Dragon
+160015038 3 --Celeb Rose Gossip Witch
+160015039 3 --Celeb Rose Gossip Magician
+160015040 3 --Demolition Meltdown Dragon Darkness Blasthamut
+160015041 3 --Bluegrass High Stealer
+160015042 3 --Bandiva the Ballistic Battle Ballad
+160015043 3 --Plectclive the Dynamauve Deadly Dirge
+160015044 3 --Dark Hydro Cannon Neutron Bluefin
+160015045 3 --Pitch-Dark Surging-Wave Swordsman Onimaru Kunituna
+160015046 3 --Meteor Swarm Dragon
+160015047 3 --Meteor Black Drake
+160015048 3 --Meteor Black Mars Dragon
+160015049 3 --Galflare the Skysavior Shine
+160015050 3 --Dragonic Progress
+160015051 3 --Psyquip Fusion
+160015052 3 --Miracle Pick
+160015053 3 --Autumn Leaves of Blisstopia
+160015054 3 --Wave Fusion
+160015055 3 --Raging Waves
+160015057 3 --Meteor Flare Fusion
+160015058 3 --Meteorite Dragon Nails
+160015059 3 --Companions!
+160015060 3 --Maid's Mischief
+160015061 3 --Peace & Rock n' Roll
+160015062 3 --Fish Depth Charge (Rush)
+160015063 3 --Meteorite Fall
+160015064 3 --Skysavior Wish
+160015065 3 --Star Salvation Shield
+160015066 3 --Fusion Cancel
+160015121 3 --Cyber Shark (Rush)
+160015130 3 --Pure Love Angel
+160015160 3 --Maid's Mischief
+160015166 3 --Fusion Cancel
+160016000 3 --Black Skull Dragon (Rush)
+160016001 3 --Praime Dwarf
+160016002 3 --Praime Phantomite
+160016003 3 --Interspraime
+160016004 3 --Praime Claw Girl
+160016005 3 --Praime Tractiger
+160016006 3 --Praime Bandijo
+160016007 3 --Praime Dian Keto
+160016008 3 --Transamu Praime Armor Nova
+160016009 3 --Dice Angel
+160016010 3 --Dice Demon
+160016011 3 --Dice Archswordsman
+160016012 3 --Dice Archangel
+160016013 3 --Dice Archdemon
+160016014 3 --Dice Key Caramail
+160016015 3 --Dice Key Minna
+160016016 3 --Dicemite Girl Chirori
+160016017 3 --Jointech Nesstrydar Tank
+160016018 3 --Darkness Jointech Tyrant
+160016019 3 --Electro-Lion Bande
+160016020 3 --Steam Swallow Gem-zz
+160016021 3 --Abysslayer Quintiamat
+160016022 3 --Secret Investigator Misfire
+160016023 3 --Secret Base Guardian Misshot
+160016024 3 --Sevens Fear Magician
+160016025 3 --CAN - St:D
+160016026 3 --Jinzo #7.7
+160016027 3 --Jinzo - Returner (Rush)
+160016028 3 --Jinzo the Machine Menace (Rush)
+160016029 3 --Jinzo - Amplified
+160016030 3 --Catapult Baby Turtle
+160016031 3 --Animagica Witch
+160016032 3 --Obnoxious Celtic Guard (Rush)
+160016035 3 --Mist Assassin
+160016036 3 --Deity of Seven Treasures - Ryozai
+160016037 3 --Praime Pierce Giant
+160016038 3 --Praime Cat Straynya
+160016039 3 --Transamu Praime Full Armor Nova
+160016040 3 --Transamuvelgr Rainac
+160016041 3 --Jointech Tridynabase
+160016042 3 --Super Graphagas Archer
+160016043 3 --Prophecy Flail of the Colors of the Wind, Butterflies and Flowers
+160016044 3 --Celeb Rose Influencers
+160016045 3 --Murin Duke the Shadow Flower Wave
+160016046 3 --Nelkrita the Skysavior Hadal
+160016047 3 --Swift Gaia the Dragon Champion
+160016048 3 --Praime Call
+160016049 3 --Graceful Dice (Rush)
+160016050 3 --Dice of Greed
+160016051 3 --The Secret of Manifestation
+160016052 3 --Abysskite Mapping
+160016053 3 --Secret Alteration
+160016054 3 --Secret Investigation Mobile Thunderbird
+160016055 3 --Royal Rebel's King's Return
+160016056 3 --Accelerator
+160016057 3 --Machine Inspector
+160016058 3 --Jointech Joint
+160016059 3 --Threat from Outer Space
+160016060 3 --De-Spell (Rush)
+160016061 3 --Abysskite Ray Monochrome
+160016062 3 --Skull Dice (Rush)
+160016063 3 --Asura Dice
+160016064 3 --Fusionic Defense
+160016065 3 --Secret File 3000 - Final Tragedy
+160016066 3 --Sunset Rebirth
+160016116 3 --Dicemite Girl Chirori
+160016131 3 --Animagica Witch
+160016158 3 --Jointech Joint
+160016159 3 --Threat from Outer Space
+160201001 3 --Kimeruler the Dark Raider
+160201002 3 --Umegumi the Ruler's Squad
+160201003 3 --Yurushima Sage
+160201004 3 --Yurushima Warrior
+160201005 3 --Blue Falcon Tengu
+160201006 3 --Yurushima the Hermit
+160201007 3 --Masaki the Legendary Samurai
+160201008 3 --Crying Moon Rabbit
+160201010 3 --Bonded Bowing
+160201011 3 --Block Attack (Rush)
+160201012 3 --Powerful Pierce!!
+160201013 3 --Scroll of Salutation
+160201014 3 --Hermit's Soul
+160201015 3 --Royal Rebel's Invasion
+160201016 3 --Royal Rebel's Growl
+160201017 3 --Royal Rebel's Rocker
+160201018 3 --Royal Rebel's Shout
+160201019 3 --Palace Gargoyle
+160201020 3 --Followl of the Dark Wisdom
+160201021 3 --Garmr the Lone Wolf
+160201022 3 --Babysitter Goat
+160201023 3 --Royal Rebel's Fanatic
+160201024 3 --King's Reward
+160201025 3 --Genie's Fire Breath
+160201026 3 --King's Majesty
+160201027 3 --Rebel's Scream
+160201028 3 --Folder Blitz the Infinite Dream
+160201029 3 --Berry Bassist
+160201030 3 --Telepathic Agent
+160201031 3 --Amusi Performer
+160201032 3 --Psy Stage Bouncer
+160201033 3 --Concert Costume Creator
+160201034 3 --Keytar Kid
+160201035 3 --Howlingbird
+160201036 3 --Elepsychic Amp Up
+160201037 3 --Psychic Divergence
+160201038 3 --Climax Finale
+160201039 3 --Psychic Introduction
+160201040 3 --Severing Psychic Wall
+160202001 3 --Supreme Machine Magnum Overlord [L]
+160202002 3 --Supreme Machine Magnum Overlord
+160202003 3 --Supreme Machine Magnum Overlord [R]
+160202004 3 --Kuribot
+160202005 3 --Kuribotriple
+160202006 3 --Silent Learning
+160202007 3 --Cranked to Ten!!
+160202008 3 --Magiquartet Shock
+160202009 3 --Widening Whisper
+160202010 3 --Yggdrago the Sky Emperor [L]
+160202011 3 --Yggdrago the Sky Emperor
+160202012 3 --Yggdrago the Sky Emperor [R]
+160202013 3 --Peacock Picotron
+160202014 3 --Femtron
+160202015 3 --Attron
+160202016 3 --Zeptron
+160202017 3 --Yoctron
+160202018 3 --Pair Production
+160202020 3 --Quantum Hole
+160202021 3 --Clean Beret - Colonel Mop
+160202022 3 --Scrubbing Santa Cloth
+160202023 3 --Washsprayer the Cleansketeer
+160202024 3 --Bleach Mortar
+160202025 3 --Odd-Eyes Twin Tail Cat
+160202026 3 --Red-Eyes Black Cat
+160202027 3 --Blue-Eyes White Cat
+160202028 3 --Cat's Eye
+160202029 3 --Lost Cat
+160202030 3 --Thunderbeetle Bassdrum
+160202031 3 --Thunderbeetle Highhat
+160202032 3 --Thunderbeetle Snare
+160202033 3 --Thunderbeetle Gift
+160202034 3 --Thunderbeetle Storm
+160202035 3 --Thunderbeetle Boost
+160202036 3 --Throne of Darkness
+160202037 3 --Dahut, Dark Ruler of the Chair
+160202038 3 --Scarechair Gear
+160202039 3 --Scarechair Bone
+160202040 3 --Scarechair Saber
+160202041 3 --Collapsing Chairs
+160202042 3 --Cosmic String Noodryad
+160202043 3 --Galaxy Topping Troll
+160202044 3 --Cosmoscallion
+160202045 3 --Big Bang Egger
+160202046 3 --Outer Space
+160202047 3 --Chashooting Star
+160202049 3 --Shrinker Shrimp
+160202050 3 --Heavenly Gift
+160203001 3 --Supreme Skystream Magnum Overlord [L]
+160203002 3 --Supreme Skystream Magnum Overlord
+160203003 3 --Supreme Skystream Magnum Overlord [R]
+160203004 3 --Emergency Return
+160203005 3 --Dynamic Dino Dynarmix [L]
+160203006 3 --Dynamic Dino Dynarmix
+160203007 3 --Dynamic Dino Dynarmix [R]
+160203008 3 --Sneezing Greedizauls
+160203009 3 --Mech Therizinoraptor
+160203010 3 --Ritzy King Rex
+160203011 3 --Supressaurus Sternptera
+160203012 3 --Uraby (Rush)
+160203013 3 --Celebrontosaurus
+160203014 3 --Platnidon
+160203015 3 --Jurassic World (Rush)
+160203016 3 --Coevolutionary Miracle
+160203017 3 --Dinosaur Crush
+160203019 3 --Ascending Evolution
+160203020 3 --Dinomic Pressure
+160203021 3 --Seedchrotron Brusselun
+160203022 3 --Cycliptron
+160203024 3 --Dahut Abyss, Dark Mirror Ruler of the Chair
+160203025 3 --Scarechair Relaxer
+160203026 3 --Scarechair Scale
+160203027 3 --Darkness Ri-chair-al
+160203028 3 --Joining Chairs
+160203029 3 --Constructor Demolisher Wyrm Drake Crush
+160203030 3 --Silvermountain of Blisstopia
+160203031 3 --Constructor Art - Buildestruction
+160203032 3 --Hammer Crush
+160203033 3 --Constructor Resurrection
+160203034 3 --Clubinet the Music Princess
+160203035 3 --Horn Knives the Music Princess
+160203036 3 --Straight Pierce
+160203037 3 --Music Princess's Whirling Wind
+160203038 3 --Music Princess Art - Triplet
+160203039 3 --Agariel, the Finest Sushi Fairy
+160203040 3 --Dragon Roll the Sushi Fairy
+160203041 3 --Tiger Roll the Sushi Fairy
+160203042 3 --Monkey Roll the Sushi Fairy
+160203043 3 --Spider Roll the Sushi Fairy
+160203044 3 --Inside Out Roll
+160203045 3 --Angel Judge
+160203046 3 --Rolled Sticky Save
+160203047 3 --Rolled Hot Arrow
+160203048 3 --Startup Goblin
+160203049 3 --Heavenly Revelation
+160203050 3 --Turnback Shot
+160204001 3 --Metarion Ashurastar
+160204002 3 --Metarion Vritrastar
+160204003 3 --Metarion Eraclestar
+160204004 3 --Metarion Ladonstar
+160204005 3 --Fire Jester
+160204006 3 --Imaginary Actor
+160204007 3 --Glaciasaurus
+160204008 3 --Serpainter
+160204009 3 --Sword Dancer
+160204010 3 --Magic Juggler
+160204011 3 --Imaginary Arc Turbo
+160204012 3 --Imaginary Arc Tower
+160204013 3 --Imaginary Arc Turbulence
+160204014 3 --Imaginary Arc Turnback
+160204015 3 --Sevens Paladin
+160204016 3 --Whispark Fairy Girl
+160204017 3 --Straynge Cats
+160204018 3 --Kuribotorero
+160204019 3 --Kuribot
+160204020 3 --Mr. Alchemy
+160204021 3 --Swordsman of Roadstar
+160204022 3 --Hyperstrike Dragon Dragiastar F
+160204023 3 --Full Moon Dragon Umbralancer F
+160204024 3 --Sportsdragon Kickbase Master
+160204025 3 --The Wyvern
+160204026 3 --The Dragon
+160204027 3 --The Power Up
+160204028 3 --The Barrier
+160204029 3 --Amusi Howling Performer
+160204030 3 --Chemical Cure Purple
+160204031 3 --Chemical Cure Red
+160204032 3 --Red Medicine
+160204033 3 --Kengo Shogun of the Crescent Moon
+160204034 3 --Fearstute Followl
+160204035 3 --Permillind Hicrotron
+160204036 3 --Winged Celestial Dragon of Weal and Woe
+160204037 3 --Hyper Upstart King Rex
+160204038 3 --Worker Warrior - Sinister Chairman
+160204039 3 --Worker Warrior - Overhauled Organizer
+160204040 3 --Labyrinth Tank (Rush)
+160204041 3 --Cannon Soldier (Rush)
+160204042 3 --Giga-Tech Wolf (Rush)
+160204043 3 --Ether Seeker
+160204044 3 --Priestess of Star Salvation
+160204045 3 --Star Restart
+160204046 3 --Yami (Rush)
+160204047 3 --Spectral Swords of the Everloyal Guard
+160204050 3 --Fusion
+160204051 3 --Fusion
+160205002 3 --Galactica Oblivion
+160205003 3 --Sevens Road Magician
+160205004 3 --Supreme Machine Magnum Overlord [L]
+160205005 3 --Supreme Machine Magnum Overlord
+160205006 3 --Supreme Machine Magnum Overlord [R]
+160205007 3 --Doomblaze Fiend Overlord Despairacion [L]
+160205008 3 --Doomblaze Fiend Overlord Despairacion
+160205009 3 --Doomblaze Fiend Overlord Despairacion [R]
+160205010 3 --Blaze Fiend Overlords Beelucitaroth [L]
+160205011 3 --Blaze Fiend Overlords Beelucitaroth
+160205012 3 --Blaze Fiend Overlords Beelucitaroth [R]
+160205013 3 --Guide of the Blaze Fiends
+160205014 3 --Rage Serpent of the Blaze Fiends
+160205015 3 --Return of the Blaze Fiends
+160205016 3 --Corruption of the Blaze Fiends
+160205017 3 --Resurrection of the Blaze Fiends
+160205018 3 --Doomblaze Despair
+160205019 3 --Cyber End Dragon (Rush)
+160205020 3 --Cyber Twin Dragon (Rush)
+160205021 3 --Cyber Rush Dragon
+160205022 3 --Cyber Assault Dragon
+160205023 3 --Cyber Stealth Dragon
+160205024 3 --Cyber Dragon (Rush)
+160205025 3 --Cyber Gryphon
+160205026 3 --Proto-Cyber Dragon (Rush)
+160205027 3 --Cyber Serpent
+160205028 3 --Evolution Rush Burst
+160205029 3 --Cyber Entry
+160205030 3 --Multiple Adapter Unit
+160205031 3 --Excutie Lumiere
+160205032 3 --Excutie Leir
+160205033 3 --Excutie Floa
+160205034 3 --Excutie Lilius
+160205035 3 --Excutie Lucy
+160205036 3 --Excutie Ram
+160205037 3 --Excutie Prouty
+160205038 3 --Excutie Scout!
+160205039 3 --Excutie Scramble!
+160205040 3 --Excutie Emergency!
+160205041 3 --Excutie Catch!
+160205042 3 --Excutie Break!
+160205043 3 --Galactiara Eve
+160205044 3 --Jointech Stegosilos
+160205045 3 --H.D.D. - Hundred Divine Dragon
+160205046 3 --Finalize Phoenix
+160205047 3 --Voidvelgr Apocalypse
+160205048 3 --Dark Prophet
+160205049 3 --Destroyer of Dragon Sorcerers
+160205050 3 --Ultimate Flag Beast Lead Unicorn
+160205051 3 --Double Twin Dragon
+160205052 3 --Yamiruler the Dark Delayer - Supreme Soldier Spear
+160205053 3 --CAN - I:D
+160205054 3 --Future Aeromancer
+160205055 3 --Beast Gear Emperor Glider Fox
+160205056 3 --Rage Wrecker Dragon Angerogue
+160205057 3 --Almastra XI - Aquarius
+160205058 3 --Magic Mirror Youth
+160205059 3 --Rising Soldier
+160205060 3 --Cobalt Cobolt
+160205061 3 --Delirium Lampyris
+160205062 3 --Love Angel
+160205063 3 --Valkyrian Call
+160205064 3 --Saturnius' Orb
+160205065 3 --Heavenly Selection
+160205066 3 --Valkyrian Guard
+160205067 3 --Word Working
+160205068 3 --Dragonlion Pit Trap
+160205107 3 --Doomblaze Fiend Overlord Despairacion [L]
+160205108 3 --Doomblaze Fiend Overlord Despairacion
+160205109 3 --Doomblaze Fiend Overlord Despairacion [R]
+160205119 3 --Cyber End Dragon (Rush)
+160205120 3 --Cyber Twin Dragon (Rush)
+160205121 3 --Cyber Rush Dragon
+160205131 3 --Excutie Lumiere
+160205132 3 --Excutie Leir
+160205133 3 --Excutie Floa
+160205143 3 --Galactiara Eve
+160205144 3 --Jointech Stegosilos
+160205145 3 --H.D.D. - Hundred Divine Dragon
+160205146 3 --Finalize Phoenix
+160205147 3 --Voidvelgr Apocalypse
+160205149 3 --Destroyer of Dragon Sorcerers
+160205151 3 --Double Twin Dragon
+160205152 3 --Yamiruler the Dark Delayer - Supreme Soldier Spear
+160205153 3 --CAN - I:D
+160205157 3 --Almastra XI - Aquarius
+160205159 3 --Rising Soldier
+160206000 3 --Meteor Black Dragon (Rush)
+160206001 3 --Five-Headed Dragon (Rush)
+160206003 3 --Great-Tusked Mammoth
+160206004 3 --Maju Garzett (Rush)
+160206005 3 --Legend Magician
+160206006 3 --Pot of Arrogance
+160206007 3 --Legendary Swordsman - Buster Blader
+160206009 3 --Archfiend Warrior
+160206010 3 --Legend Saber
+160206011 3 --Goddess of Whimsy
+160206012 3 --Magician's Curtain
+160206013 3 --The Origin Stone of Legend
+160206016 3 --Steel Steed Martin Vinary
+160206017 3 --Hyozanryu (Rush)
+160206020 3 --Nimble Lemming
+160206021 3 --Embryonic Dark Ruler
+160206023 3 --Eve of the Big March
+160206024 3 --Dragon Tribe Fusion
+160206026 3 --Primordial Slash
+160206027 3 --Return (Rush)
+160206029 3 --Meteor Dragon (Rush)
+160206031 3 --Melchid the Four-Face Beast (Rush)
+160206032 3 --Grand Tiki Elder (Rush)
+160206033 3 --Goblin Holedigger Captain
+160206034 3 --Class-Change Mirror
+160206035 3 --Rogue of Archfiend
+160206036 3 --Master Craftsman Kotetsu
+160206037 3 --Witness of Dragon Destroyer
+160206038 3 --Slot Machine PG-7
+160206039 3 --Trap Mole
+160206040 3 --Malevolent Seller
+160206041 3 --Flapun
+160206043 3 --Cursed Sword of the East
+160206044 3 --Masenkou, the Lashing Light
+160206045 3 --Helmet of the Master Craftsman
+160207001 3 --Supreme Fullsteam Magnum Overlord [L]
+160207002 3 --Supreme Fullsteam Magnum Overlord
+160207003 3 --Supreme Fullsteam Magnum Overlord [R]
+160207004 3 --Supreme Wildgleam Magnum Overlord [L]
+160207005 3 --Supreme Wildgleam Magnum Overlord
+160207006 3 --Supreme Wildgleam Magnum Overlord [R]
+160207007 3 --Supreme Skystream Magnum Overlord [L]
+160207008 3 --Supreme Skystream Magnum Overlord
+160207009 3 --Supreme Skystream Magnum Overlord [R]
+160207013 3 --Abyssal Dragon Lord Abyss Poseidra [L]
+160207014 3 --Abyssal Dragon Lord Abyss Poseidra
+160207015 3 --Abyssal Dragon Lord Abyss Poseidra [R]
+160207016 3 --Abyssal Sea Dragon Abyss Kraken [L]
+160207017 3 --Abyssal Sea Dragon Abyss Kraken
+160207018 3 --Abyssal Sea Dragon Abyss Kraken [R]
+160207019 3 --Shinesteel Ultra Dragon Devastar Okeabyss [L]
+160207020 3 --Shinesteel Ultra Dragon Devastar Okeabyss
+160207021 3 --Shinesteel Ultra Dragon Devastar Okeabyss [R]
+160207022 3 --Supreme Dog Ropero
+160207024 3 --Super Electromagnetic Maximum
+160207026 3 --B.B.B. - Beast Brave Brandish
+160207028 3 --Abysslayer Apsaras
+160207029 3 --Abysslayer Makara
+160207030 3 --Abysslayer Cetus
+160207031 3 --Abysslayer Vodyanoy
+160207032 3 --Legacyrex Legarex
+160207033 3 --Darkglow Angler
+160207034 3 --Groundmaster Bathynomus
+160207036 3 --Manifestriction Dragon Maxseal
+160207037 3 --Mollusk Dragon Oumugailus
+160207039 3 --Ascending Weather Eel
+160207041 3 --Deep Sea Dragon Bat Eel
+160207042 3 --Abyss Flash
+160207046 3 --Abyss Gash
+160207047 3 --Wrath of Abyss
+160207048 3 --Abysskite Ultimail
+160207049 3 --Abysskite Prevent Wall
+160207050 3 --Abysskite Protection
+160207054 3 --Heavenly Invitation
+160207055 3 --Radiant Mirror Force (Rush)
+160207059 3 --Steel Mech Lord Mirror Innovator
+160208001 3 --Harpie Lady Sisters [L]
+160208002 3 --Harpie Lady Sisters
+160208003 3 --Harpie Lady Sisters [R]
+160208004 3 --Harpie Lady 1 (Rush)
+160208005 3 --Harpie Lady 2 (Rush)
+160208006 3 --Harpie Lady 3 (Rush)
+160208008 3 --Harpie Regina
+160208009 3 --Harpie Carla
+160208010 3 --Harpie's Pet Dragon (Rush)
+160208012 3 --Harpie's Full Dress
+160208013 3 --Triangle Ecstasy Spark (Rush)
+160208014 3 --Elegant Egotist (Rush)
+160208016 3 --Harpie's Feather Tempest
+160208018 3 --Divinebreath the Orchestral Music Fiend
+160208019 3 --Full Orchestra the Music Fiend
+160208020 3 --Axetion Melody the Music Princess
+160208022 3 --Trumpetiger the Music Fiend
+160208024 3 --Sansetsukontra the Music Fiend
+160208025 3 --Tubardiche the Music Princess
+160208027 3 --Ophiclaymore the Music Princess
+160208031 3 --Boton the Music Princess
+160208033 3 --Music Princess's Dance
+160208034 3 --Music Princess's Requiem
+160208035 3 --Tiger Glare
+160208036 3 --Destruction of the Universe
+160208037 3 --Giant Tiger Strike
+160208038 3 --Demolition Charge Dragon Dangerous Blasthamut
+160208039 3 --Demolition Charge Expert Warning Heavy Shock
+160208040 3 --Demolition Dragon Blasthamut
+160208041 3 --Demolition Soldier Kasetsu Baiten
+160208042 3 --Constructor Sentry Dragline
+160208043 3 --Demolition Soldier Hell Met
+160208044 3 --Constructor Wyrm Buildragon
+160208046 3 --Demolition Soldier Toby Shock
+160208047 3 --Demolition Soldier Sakan Yasan
+160208048 3 --Demolition Soldier High Kanko
+160208051 3 --Demolition Sword Constructedea
+160208052 3 --Demolition Shutter
+160208053 3 --Demolition Survey
+160208057 3 --Demolition Barricade
+160208058 3 --Demolition Art - Absolute Destruction
+160208059 3 --Gold Rush
+160209001 3 --Lightning Volteagle
+160209002 3 --Thunderbold, the Echoing Thunder
+160209003 3 --Lightning Voltkite
+160209005 3 --Flash Voltchick
+160209006 3 --Spark Voltegg
+160209012 3 --Accel Wonder Light
+160209013 3 --Ultimate Flag Beast Bolt Tricorn
+160209015 3 --Cyc the Child of Wind
+160209016 3 --Furtunate Cat
+160209018 3 --High Magic - Double Acceleration
+160209019 3 --Straynge Gathering
+160209020 3 --Straynge Cat Signal
+160209021 3 --Lightning Voltcharge
+160209024 3 --Straynge Cat Jealousy
+160209025 3 --Multistrike Dragon Dragias
+160209026 3 --Dragonic Demolisher
+160209028 3 --Dragonic Scout
+160209029 3 --Twin Edge Fire Dragon
+160209031 3 --Draco the Hand-Sewn
+160209032 3 --Gias x Gias
+160209033 3 --7 Shift
+160209034 3 --Dragonic Force
+160209036 3 --The Guard
+160209037 3 --The Block
+160209038 3 --Undulating Barrier
+160209039 3 --Descending Dragon of Clear Water
+160209040 3 --Kimeterasu the Divine Ruler
+160209042 3 --Hagoromo the Cloudle-Handling Celestial Seamstress
+160209043 3 --Yamiruler the Dark Delayer
+160209046 3 --Yamiluna the Dark Supporter
+160209047 3 --Koi of Winter Wonder
+160209048 3 --Shield in the Right Hand
+160209049 3 --Sword in the Left Hand
+160209050 3 --Seyanen the Combustion Commander
+160209052 3 --Kibatsu the Cutting Edge Deity
+160209054 3 --Resolve
+160209055 3 --Divine Transformation
+160209057 3 --Dark Ruler Battlegear
+160209059 3 --Vi-FRND
+160209060 3 --Prima Guitarna the Shining Superstar
+160209061 3 --Ordoll the Adorable Audio Idol
+160209062 3 --Star's Hand Director
+160209063 3 --Star's Hand Illuminator
+160209064 3 --Star's Hand Roadie
+160209066 3 --Psykickoff Concert
+160209067 3 --My Patience Has Run Out!
+160209068 3 --Shining Superstar Riff
+160209069 3 --Psychicomposition
+160209070 3 --Dream Ticket
+160209071 3 --Major Audition
+160209072 3 --Raging Rock
+160209073 3 --Lullalabind
+160209074 3 --True Beast Gear King Liogon
+160209075 3 --True Beast Gear Emperor Kong
+160209078 3 --Apocalypse - Beast Over World
+160209080 3 --Dark Sword Magician
+160209081 3 --Obsidian Magical Soldier
+160209082 3 --Mature Dark Magician
+160209083 3 --Jewel of the Dark Magician
+160209084 3 --Spellbook Rejection
+160209085 3 --Spell Extraction
+160209088 3 --Magician's Sense
+160209132 3 --Gias x Gias
+160210002 3 --Royal Rebel's Heavy Metal
+160210014 3 --Charis Magic Scepter - Death Wand
+160210017 3 --Royal Rebel's Progressive
+160210018 3 --Harpie Lady Pet Master
+160210019 3 --Voidvelgr Chaosmachia
+160210020 3 --Black Dragon Skull Archfiend
+160210021 3 --Engine of Destruction
+160210022 3 --Celeb Revelation
+160210023 3 --Skull Archfiend of Armageddon
+160210027 3 --Gravitiara Ai
+160210028 3 --Magical Retribution
+160210035 3 --Dark Executor Warlock
+160210036 3 --Blaze Fiend Overlord Luciless
+160210037 3 --Super Galaxy King Lord of Galactica [L]
+160210038 3 --Super Galaxy King Lord of Galactica
+160210039 3 --Super Galaxy King Lord of Galactica [R]
+160210040 3 --Abysskite Miracle Girls
+160210041 3 --Etraynze the Shadow Flower Restricter
+160210042 3 --Conduction Warrior Alchemicalizer Suirai
+160210046 3 --Celeb Rose Warlock
+160210048 3 --Royal Rebel's Elite Amp
+160210049 3 --Legend Magician
+160210050 3 --Celeb Rose Enchanter
+160210053 3 --Abysskite Party
+160210055 3 --Abysskite Violate Halo
+160210064 3 --Super Assistant Hiya
+160210065 3 --Super Assistant Biri
+160210067 3 --Shadow Flower Dance
+160210070 3 --Splendid Slash
+160210072 3 --Flower Fan Clematis
+160210073 3 --Eternal Wolf of the Blaze Fiends
+160210074 3 --Royal Rebel's Grunge
+160210075 3 --Twin Twinkle Star
+160210076 3 --Galacterial Pick
+160210077 3 --Soul Knight
+160210078 3 --Royal Rebel's Guardian
+160210081 3 --Abysspiny Turtle
+160210082 3 --Shining Shamaness
+160210083 3 --King's Greed
+160210084 3 --Magical Firestorm
+160210085 3 --Voidvelgr Morgenstein
+160210086 3 --Celeb Blade - Death Wild
+160210087 3 --Celeb Robe - Death Wind
+160210088 3 --King's Authority
+160211001 3 --Dark Magician Girl (Rush)
+160301001 3 --Sevens Road Magician
+160301002 3 --Torna the Windweaver
+160301003 3 --Ansler the Magical Swordsman
+160301004 3 --Hydro Magician
+160301005 3 --Dark Sorcerer
+160301006 3 --Mystic Dealer
+160301007 3 --Magical Beast Wolfang
+160301008 3 --Spell Archer
+160301009 3 --Shining Shaman
+160301010 3 --Straynge Cat
+160301011 3 --Wind Spirit's Protection
+160301012 3 --Magical Stream
+160301013 3 --Dark Revelation
+160301014 3 --Curtain of Sparks
+160302001 3 --Multistrike Dragon Dragias
+160302002 3 --Gravity Press Dragon
+160302003 3 --Fire Guardian
+160302004 3 --Dragon Knight of Darkness
+160302005 3 --Dragorite
+160302006 3 --Twin Edge Dragon
+160302007 3 --Dragon's Sage
+160302008 3 --Dragon Bat
+160302009 3 --Phoenix Dragon
+160302010 3 --Draco the Tiny
+160302011 3 --Dragonic Pressure
+160302012 3 --Dragon's Inferno
+160302013 3 --Dragon Encounter
+160302014 3 --Vengeful Dragon's Counterattack
+160303009 3 --Accel Wonder Splat
+160303010 3 --Accel Wonder Flare
+160303013 3 --Aqua Sorcerer
+160303019 3 --Amazing Dealer
+160303032 3 --Mystery Handcuffs
+160304003 3 --Sportsdragon Closer
+160304012 3 --Sylphidra
+160304022 3 --Stop Defense (Rush)
+160304023 3 --Sportsdragon Connection
+160304030 3 --Dragonic Disorder
+160305006 3 --Matsugumi the Ruler's Squad
+160305015 3 --Hero of the Yeast
+160305027 3 --Bowing Brotherhood
+160305030 3 --Ruler's Dance
+160306003 3 --Giftarist
+160306009 3 --Peace Holder
+160306012 3 --Dream Drummer
+160306026 3 --Psychic Trap Hole
+160307002 3 --Asbolus the Star Knight
+160307004 3 --Followl of the Fornether
+160307009 3 --Nessus the Star Knight
+160307026 3 --King's Right
+160308004 3 --Sigurstate Sol
+160308005 3 --Berceptacle Mani
+160308009 3 --Connector Dog
+160308015 3 --Particle Acceleration
+160309010 3 --Constructor Fighter Mixer
+160309011 3 --Coiled Dragon of Destruction
+160309017 3 --Constructor Engineer Draftannium
+160309021 3 --Barrier Armordillo
+160309027 3 --Vegetation of Blisstopia
+160310009 3 --Tribute Doll (Rush)
+160310010 3 --Ancient Rules (Rush)
+160311002 3 --Universe Dea
+160311003 3 --Cosmo Titan
+160311004 3 --Galactica Amnesia
+160311005 3 --Rebirth Cycle
+160311006 3 --Heaven Gancel
+160311007 3 --Silver Seyfert
+160311008 3 --Meteorhino
+160311009 3 --Strange Traveler
+160311011 3 --Bright Sentinel
+160311012 3 --Shadow Sentinel
+160311013 3 --Vortex Shooter
+160311014 3 --Giant Bulge
+160311015 3 --Orbit Skater
+160311016 3 --Sorapuyo
+160311017 3 --Transamu Craione
+160311018 3 --Interstellime
+160311019 3 --Asteroeva
+160311022 3 --Galactica Force
+160311025 3 --Universtorm
+160311026 3 --Vacua Annihilation
+160311028 3 --Transamu Arrive
+160311030 3 --Nebula Power
+160312006 3 --Gadget Soldier (Rush)
+160312008 3 --Elephound
+160312010 3 --Jointech Ace
+160312012 3 --Flare Sorcerer
+160312018 3 --Lightning Braver
+160312021 3 --Cliptera
+160312023 3 --Tamabot
+160312028 3 --Tribute Lock
+160312030 3 --Jointech Bumper
+160313001 3 --Vanishing Heliacal Riser
+160313006 3 --Cosmo Aurorizer
+160313011 3 --Transamu Jerai
+160313019 3 --Galactica Jamais Vu
+160313020 3 --Konpeitrion
+160313024 3 --Galactica Repulsion
+160313030 3 --Galactica Lattice
+160313032 3 --Nova Spark
+160314001 3 --Jointech Tossceratops
+160314009 3 --Corktrooper
+160314010 3 --Pantula
+160314012 3 --Ground Attacker Bugroth (Rush)
+160314014 3 --Carpendra
+160314018 3 --Forkhawk
+160314020 3 --Craftroll
+160314021 3 --Stud Hedgepeg
+160314022 3 --Screw Armadillo
+160314030 3 --Thunder Spark
+160315001 3 --Red Boot Boost Dragon
+160315008 3 --Dual Coretls
+160315011 3 --Beta Burn Dragon
+160315012 3 --Applizard
+160315020 3 --SSD Drake
+160315022 3 --Dragosite
+160315024 3 --Alpha Burn Drake
+160315029 3 --Dragon's Peak
+160315032 3 --RB Draphone
+160316001 3 --Analyze Phlogiston
+160316008 3 --Flame Cerebrus (Rush)
+160316010 3 --Flame Champion (Rush)
+160316013 3 --Barrier Statue of the Inferno (Rush)
+160316015 3 --Doctor Red Robe
+160316016 3 --Flame Seeker
+160316017 3 --Methyl the Flame Jinn of the Lamp
+160316018 3 --Ethyl the Flame Jinn of the Lamp
+160316023 3 --Super Assistant Achi
+160316028 3 --Scales of Flame
+160316032 3 --Fire Fall Blaze Barrier
+160317001 3 --Voidvelgr Elysium
+160317007 3 --Voidvelgr Hecatoncheir
+160317012 3 --Voidvelgr Pale Rider
+160317013 3 --Voidvelgr Hoplites
+160317014 3 --Dimension Others
+160317015 3 --Voidvelgr Globule
+160317018 3 --Voidvelgr Meteon
+160317019 3 --Meteorlarva
+160317020 3 --Voidvelgr Peltast
+160317021 3 --Void Corridor
+160317028 3 --Void Intercept
+160317029 3 --Void Veil
+160319001 3 --Blue-Eyes Ultimate Dragon (Rush)
+160319003 3 --Blue-Eyes Bright Dragon
+160319004 3 --Blue-Eyes Vision Dragon
+160319005 3 --Absolute Lord of D.
+160319006 3 --Node of Legend
+160319007 3 --Soul Drake
+160319008 3 --Phoenix Dragoon
+160319014 3 --Light Effigy (Rush)
+160319027 3 --The Ultimate Blue-Eyed Legend
+160319028 3 --Sanctum of Legend
+160319035 3 --Treasure of Eyes of Blue
+160401001 3 --Sevens Road Witch
+160401002 3 --Cosmic String Noodryad
+160401003 3 --Constructor Wyrm Buildragon
+160401004 3 --CAN:D
+160401005 3 --Kimeluna the Dark Shifter
+160401006 3 --CAN:D LIVE
+160401007 3 --Sevens Road Witch
+160401008 3 --Magical Sheep Girl Meeeg-chan
+160401009 3 --Prophecy Phrase of the Colors of the Wind
+160401010 3 --Cat Claw Girl
+160401011 3 --Machvio of the Ultimate Aria
+160401012 3 --Celeb Rose Magician
+160401013 3 --Celeb Rose Witch
+160402001 3 --Road Magic - Explosion
+160402002 3 --Righteous Dragon
+160402003 3 --Road Magic - Flowback
+160402004 3 --Royal Rebel's Blues
+160402005 3 --Bascule the Moving Fortress
+160402006 3 --Raidacross, Hero of the Dusk
+160402007 3 --Kumamon
+160402008 3 --Ultimate Flag Beast Cannon Rhino
+160402009 3 --The Star Dragon
+160402010 3 --Mach Mega Falcon
+160402011 3 --Douma the Talismanic Supreme Sage
+160402012 3 --Handsray Destleo
+160402013 3 --Unknown Flyleon
+160402014 3 --Pelion the Star Knight
+160402015 3 --Direct Dive Dragon
+160402016 3 --Rice Terrace Secure
+160402017 3 --Headhunters' Jaguar
+160402018 3 --Voidvelgr Transi
+160402019 3 --Drilling Tractiger
+160402020 3 --Combustion Oni Bunsel
+160402021 3 --Jointech Raptor
+160402022 3 --Cyber Search Dragon
+160402023 3 --Hacking Dragon
+160402024 3 --Transamu Raiker
+160402025 3 --Plectcrime of the Deadly Dirge
+160402026 3 --Deepsea Hunter
+160402027 3 --Satellite Soldier
+160402028 3 --Light Sorcerer of Sanctity
+160402029 3 --Defrostrooper
+160402030 3 --Fusionic Revivern
+160402031 3 --The Trinity Dragiastar
+160402032 3 --Straynge Cat Magician
+160402033 3 --Ecliceras Drakon
+160402034 3 --Cul-de-sac the Faceless
+160402035 3 --Jespell Wizard
+160402036 3 --Transamu Scraied
+160402037 3 --Voidvelgr God Requiem
+160403001 3 --Gaia The Fierce Knight (Rush)
+160403002 3 --Dian Keto the Security Master
+160404002 3 --Black Dragon's Chick (Rush)
+160404003 3 --Inferno Fire Blast (Rush)
+160405001 3 --Volcano Attack Dragon
+160405002 3 --Burst Breath of Destruction
+160405003 3 --Dragon's Fortitude
+160406001 3 --Celtic Guardian (Rush)
+160406002 3 --Cyber Falcon (Rush)
+160406003 3 --Necromaid Nana
+160406004 3 --Psychic Burial
+160406005 3 --Cure Shot
+160406006 3 --Mokey Mokey (Rush)
+160406007 3 --Shovel Crusher (Rush)
+160406008 3 --Gokibore (Rush)
+160406009 3 --Sky Dragon (Rush)
+160406010 3 --Ancient Telescope (Rush)
+160407001 3 --Amabie (Rush)
+160408001 3 --Sevens Road Warlock
+160408002 3 --Triad Drago
+160409001 3 --Nullstrike Dragon Zerogias
+160409002 3 --Cladsoul Dragon Gaigias
+160409003 3 --Void Strike Dragon Zerogaigias
+160409004 3 --Galactica Reminiscence
+160409005 3 --Transamu Rainac Overwrite
+160409006 3 --Transamu Valuable Rainac
+160409011 3 --Accel Wonder Pebble
+160409012 3 --Star Tri-Leo
+160410001 3 --Sevens Road Magician
+160410002 3 --Multistrike Dragon Dragias
+160410003 3 --Sevens Road Witch
+160410004 3 --Illusion Strike Dragon Miragias
+160411001 3 --Ultimate Flag Mech Ace Breaker
+160411002 3 --Dark Magician Girl (Rush)
+160412001 3 --Dian Keto the Cure Master (Rush)
+160412002 3 --Yuri the Shadow Flower Fiend
+160412003 3 --Stardom Light
+160412004 3 --Constructor Sword Foreman
+160412005 3 --Trumpet Charge
+160412006 3 --Volcanic Rat (Rush)
+160412007 3 --Tristegatops
+160412008 3 --Tyhone (Rush)
+160412009 3 --Bean Soldier (Rush)
+160412010 3 --Tyhone #2 (Rush)
+160413001 3 --Nightbringer Dragon
+160414001 3 --Ultimate Flag Beast Surge Bicorn
+160414002 3 --Cosmo Predictor
+160415001 3 --Ultimate Flag Mech Tough Striker
+160415002 3 --Ultimate Flag Beast Avant Wolf
+160415003 3 --Ultimate Flag Beast Aim Eagle
+160416001 3 --Sevens Road Magician
+160416002 3 --Sevens Road Witch
+160416003 3 --Sevens Road Mage
+160416004 3 --Sevens Road Warlock
+160416005 3 --Kuribot
+160416006 3 --Kuribot
+160416007 3 --Kuribot
+160418002 3 --Sevens Road Enchanter
+160419001 3 --Flame Swordsman (Rush)
+160419002 3 --Cyber Soldier of Darkworld (Rush)
+160419003 3 --Heavy Roller
+160419006 3 --Haniwaffle
+160419007 3 --Flame Manipulator (Rush)
+160419008 3 --The All-Seeing White Tiger (Rush)
+160419009 3 --Masaki the Legendary Swordsman (Rush)
+160419010 3 --Spike Seadra (Rush)
+160420001 3 --Donpen & Donko
+160421001 3 --Sevens Road Magician
+160421002 3 --Multistrike Dragon Dragias
+160421003 3 --Prima Guitarna the Shining Superstar
+160421004 3 --Yamiruler the Dark Delayer
+160421005 3 --Royal Rebel's Heavy Metal
+160421006 3 --Yggdrago the Sky Emperor
+160421007 3 --Constructor Wyrm Buildragon
+160421008 3 --Ultimate Flag Mech Gold Rush
+160421009 3 --Ancient Arrive Dragon
+160421010 3 --CAN - Melo:D
+160421011 3 --Kimeterasu the Rising Luna
+160421012 3 --Royal Rebel's Hard Rock
+160421013 3 --Attolashoot Highdron
+160421014 3 --Infinite Constructor Wyrm Buildream
+160421018 3 --Elegant Fire Bird Harpuia
+160421019 3 --Daigyakutenno Megami
+160421020 3 --Pholus the Star Knight
+160421021 3 --Crystal Brain
+160421022 3 --Ether Finder
+160421024 3 --Secret Order
+160421027 3 --Dark Resonance Burst
+160421028 3 --Burst Stream of Destruction (Rush)
+160421029 3 --Magical Stone Excavation (Rush)
+160421030 3 --Temporary Storm Blockade
+160421031 3 --Counter Back
+160421033 3 --Heavenly Rest
+160421034 3 --Gyakutenno Megami (Rush)
+160421035 3 --Alligator's Sword (Rush)
+160421036 3 --Beaver Warrior (Rush)
+160421037 3 --Constructor Princess Pylon
+160421038 3 --Karatake the Talismanic Warrior
+160421039 3 --Unfulfilled Goblin
+160421040 3 --Kaibaman (Rush)
+160421045 3 --Crack Fall
+160421053 3 --Black Dragon's Roar
+160421108 3 --Ultimate Flag Mech Gold Rush
+160421109 3 --Ancient Arrive Dragon
+160421110 3 --CAN - Melo:D
+160421111 3 --Kimeterasu the Rising Luna
+160421112 3 --Royal Rebel's Hard Rock
+160421113 3 --Attolashoot Highdron
+160421114 3 --Infinite Constructor Wyrm Buildream
+160422001 3 --Great Multistrike Dragon Dragias Burst [L]
+160422002 3 --Great Multistrike Dragon Dragias Burst
+160422003 3 --Great Multistrike Dragon Dragias Burst [R]
+160423001 3 --Alligator's Sword Dragon (Rush)
+160423006 3 --Mechaleon (Rush)
+160423007 3 --Blue-Eyed Silver Zombie (Rush)
+160423008 3 --Yormungarde (Rush)
+160423009 3 --Emperor of the Land and Sea (Rush)
+160424001 3 --Sevens Road Witch
+160424002 3 --Illusion Strike Dragon Miragias
+160424007 3 --Harpie Lady (Rush)
+160424008 3 --Winged Dragon, Guardian of the Fortress #1 (Rush)
+160425001 3 --Transamu Rainac
+160425006 3 --Stone Dragon (Rush)
+160426005 3 --Delight of the Mighty
+160426006 3 --Fancy Ladybug Pastel
+160426007 3 --Dream Ladybug Rainbow
+160426008 3 --Archfiend Marmot of Nefariousness (Rush)
+160426009 3 --Hero of the East (Rush)
+160426010 3 --Frenzied Panda (Rush)
+160427001 3 --Strong Boy Sevens Road
+160428001 3 --Supreme Wildgleam Magnum Overlord [L]
+160428002 3 --Supreme Wildgleam Magnum Overlord
+160428003 3 --Supreme Wildgleam Magnum Overlord [R]
+160428004 3 --Sturdy Strike Dragon Metagiastar F
+160428005 3 --Magician of Dark Sevens
+160428006 3 --Darkness Zerorogue
+160428007 3 --Darkness Fource Seeker
+160428008 3 --Darkness Rogue
+160428009 3 --Sevens Road Magician
+160428010 3 --Sevens Road Witch
+160428018 3 --Magic Curtain
+160428019 3 --Road Magic - Dark Twilight
+160428020 3 --Darkness Lode
+160428021 3 --Sevens Road Protection
+160428023 3 --Magic Fire Guard
+160428024 3 --Omega Guitarna the Shining Megastar
+160428025 3 --Princess Omega the Shining Megastar
+160428027 3 --CAN:D ALL
+160428029 3 --CAN - Sp:D
+160428035 3 --Progress Potter
+160428037 3 --Ice Pop Bear
+160428042 3 --Ama Lilith
+160428044 3 --Psychic Omega Blast
+160428048 3 --Cross Target
+160428049 3 --Featuring Omega
+160428052 3 --Dian Keto the Cooking Master
+160428053 3 --Brick Phone Nyan Nyan
+160428054 3 --Fashion of Faith
+160428056 3 --Tiramisu Dark Witch
+160428059 3 --Frenzied Panda Cotta
+160428061 3 --Change of Dessert
+160428062 3 --Mother's Storm
+160428065 3 --Bubbleburst Shock!
+160428067 3 --Party Up
+160428068 3 --Master's Cure
+160428071 3 --Dark Skeleton Dead Ruler
+160428073 3 --Crawling Torso
+160428074 3 --Cyber-Stein Frankenshrine
+160428075 3 --Ghoulish Gal
+160428076 3 --The Thing In the Purple Mirror
+160428077 3 --Doll of Dread
+160428078 3 --Samba Zombie Rio
+160428079 3 --Nightmare Knock
+160428080 3 --Frightening Fan Mail
+160428081 3 --Zombie Carnival
+160428082 3 --Zombie Fireworks
+160428083 3 --Surprising Zomvictory
+160428084 3 --It's Right Behind You!
+160428085 3 --I Hear Footsteps
+160428086 3 --The Cursed Cat Counting Dishes
+160428087 3 --Terrorphone Number
+160428088 3 --Oriental Tiger
+160428089 3 --Shadow Ghoul (Rush)
+160428090 3 --Cursed Skeletal Dragon Diarga
+160428091 3 --Peeking Magician
+160428092 3 --Specter of Heaven's End
+160428093 3 --Magical Ghost (Rush)
+160428094 3 --Sacrificial Summon
+160428096 3 --Trade-In (Rush)
+160428098 3 --Imptailing Crisis
+160430001 3 --Curse of Dragon (Rush)
+160430002 3 --Mystical Sandbox
+160430003 3 --Kanan the Swordmaiden
+160430006 3 --Spirit of the Mini Harp
+160430007 3 --Heartless Hound Blade Aikuchihuahua
+160430008 3 --Psychic Kappa (Rush)
+160430009 3 --Kappa Rapper
+160430010 3 --Kappa Avenger (Rush)
+160431001 3 --Transamu Rainac
+160431002 3 --Galactica Oblivion
+160431003 3 --Jointech Rex
+160431004 3 --Blue Tooth Burst Dragon
+160431005 3 --Chemicalize Salamander
+160431006 3 --Voidvelgr Requiem
+160431007 3 --Magical Sheep Girl Meeeg-chan
+160432001 3 --Greystorm Reverie
+160433001 3 --Gaia the Dragon Champion (Rush)
+160433002 3 --Blast Examiner
+160433003 3 --Update Wyvern
+160433006 3 --Begonia the Pressed Shadow Flower
+160433007 3 --Dahlia the Sprouting Shadow Flower
+160433008 3 --Kudzu the Bruised Shadow Flower
+160433009 3 --Quadcopter GA84
+160433010 3 --Full Jersey
+160434001 3 --Transamu Rainac - War To Zen!
+160434002 3 --Jointech Leo
+160434003 3 --Lightwave Dragon
+160434004 3 --Dark Magician Girl (Rush)
+160435001 3 --Excutie Lumiere
+160436001 3 --Garnecia Elefantis (Rush)
+160436002 3 --Wave Crest Madoor
+160436003 3 --Nikotamabot
+160436004 3 --Silent Doom (Rush)
+160437006 3 --Digger Skipper
+160437007 3 --Princessleon
+160437008 3 --Fairy Dragon (Rush)
+160437009 3 --Aitsu (Rush)
+160437010 3 --Level Blast
+160438001 3 --Majestic Masterburst
+160438002 3 --Majestic Masterburst
+160439004 3 --Crack Neutron
+160439007 3 --Tamabot
+160439008 3 --Soitsu (Rush)
+160439009 3 --Dragon Bird
+160439010 3 --Legendary Sword (Rush)
+160440004 3 --Dragon Tribe Fusion
+160440005 3 --Specter of Heaven's End
+160440006 3 --Magical Stone Excavation (Rush)
+160440007 3 --Hammer Crush
+160440008 3 --Grand Extreme
+160440009 3 --Wicked Shadow Dark Lurker
+160440012 3 --Pot of Arrogance
+160441003 3 --Eternal Galactica Oblivion
+160442001 3 --Ruthless Slash - Megaplunder
+160443001 3 --Sevens Road Magician
+160443002 3 --Multistrike Dragon Dragias
+160443003 3 --Prima Guitarna the Shining Superstar
+160443004 3 --Galactica Oblivion
+160443005 3 --Jointech Rex
+160443006 3 --Blue Tooth Burst Dragon
+160443007 3 --Cocosh the Spellcaster of Happiness
+160444006 3 --Fireyarou (Rush)
+160444008 3 --Gravity Plus Dragon
+160444010 3 --Three Cavalteers
+160445001 3 --Gaia The Fierce Knight (Rush)
+160445002 3 --Curse of Dragon (Rush)
+160445003 3 --Gaia the Dragon Champion (Rush)
+160446001 3 --Thousand Dragon (Rush)
+160446003 3 --Harpie Cielo
+160446004 3 --Cyber Tutu (Rush)
+160446005 3 --Swift Gaia the Fierce Knight (Rush)
+160446006 3 --Red Archery Girl (Rush)
+160446007 3 --Destroyer Golem (Rush)
+160446008 3 --The Snake Hair (Rush)
+160446009 3 --Confiscation (Rush)
+160446010 3 --Silver's Cry
+160446011 3 --Sevens Road Magician
+160446012 3 --Multistrike Dragon Dragias
+160446013 3 --CAN:D
+160446014 3 --Kimeluna the Dark Shifter
+160446015 3 --Royal Rebel's Rocker
+160446016 3 --Transamu Rainac
+160446017 3 --Jointech Raptor
+160446018 3 --Red Boot Boost Dragon
+160446019 3 --Combustion Oni Bunsel
+160446020 3 --Voidvelgr Transi
+160447006 3 --Royal Rebel's Beginitar
+160447007 3 --Royal Rebel's Babybass
+160447008 3 --Royal Rebel's Kidrum
+160448002 3 --CAN:D
+160448005 3 --Secret Order
+160448006 3 --Ship of Seven Treasures
+160449001 3 --Yaranzo (Rush)
+160449002 3 --Interstellive
+160449003 3 --Peace Dragon
+160449004 3 --Kaiser Dragon (Rush)
+160449005 3 --Remove Trap (Rush)
+160450006 3 --Zero Drake
+160451001 3 --Kanan the Swordmistress (Rush)
+160451002 3 --Excite Ground Dragon
+160451003 3 --LED Pigeon
+160451004 3 --Dream Live
+160451005 3 --Cheater's Hidden Ball Trick
+160452001 3 --Straynge Cat
+160452002 3 --Chromatographagas
+160452003 3 --Negatwor Dragon
+160452004 3 --Dragonic Slayer
+160452005 3 --Legend Strike
+# Prereleases
+160017003 3 --Hybridrive Scale
+160017004 3 --Hybridrive Tusk
+160017005 3 --Hybridrive Lizard
+160017006 3 --Hybridrive Screwdriver
+160017007 3 --Straynge Cat Witch
+160017008 3 --Releaslayer
+160017044 3 --Bluetech Burst Rex
+160017045 3 --Sevens Road Ultima Witch
+160017052 3 --Hybridrive Back Fusion
+160017053 3 --Hybridrive Restruct
+160017059 3 --Hybridrive Bumper
+160211007 3 --Deep Space Yggdrago
+160211008 3 --Dual Space Yggdrago
+160211009 3 --Space Yggdrago
+160211010 3 --Multi-Space Yggdrago
+160211012 3 --Chaos Femtron
+160211014 3 --Guardian of Cyberse
+160211015 3 --Space Bud Exploit
+160211016 3 --Space Seed Driver
+160211018 3 --Space Call
+160211019 3 --Space Resonance
+160211020 3 --Deep Warning Fusion
+160211022 3 --Critical Service
+160211023 3 --Deep Space Impact
+160211024 3 --Valkyrion the Magna Wings
+160211025 3 --Valkyrion the Unity Warrior
+160211026 3 --Alpha the Magnet Cavalry
+160211028 3 --Protorion the Magna Warrior
+160211029 3 --Alpha the Magnet Warrior (Rush)
+160211030 3 --Beta the Magnet Warrior (Rush)
+160211031 3 --Gamma the Magnet Warrior (Rush)
+160211032 3 --Alpha the Eternal Magnet Warrior
+160211033 3 --Beta the Eternal Magnet Warrior
+160211034 3 --Gamma the Eternal Magnet Warrior
+160211036 3 --Magnet Return
+160211037 3 --Magnet Twin Saber
+160211038 3 --Repulsive Force
+160211039 3 --All Love Goddess
+160211040 3 --Peace Love Ángel
+160211041 3 --Love Ángel
+160211042 3 --Cutie Love Anela
+160211043 3 --Love Anela
+160211047 3 --Love Dove
+160211048 3 --Love Shoot
+160211049 3 --Love Study
+160211050 3 --Love Letter
+160211051 3 --Love Safety
+160211052 3 --Love Protection
+160211054 3 --Love Memory
+160211055 3 --Love Return
+160211058 3 --Transamu Power Rainac
+160211062 3 --Sevens Road Charm Witch
+160211063 3 --Super Graphagas Vapor Lancer
+160211064 3 --Dian Keto the Gourmet Maiden
+160211065 3 --Dian Keto the Cleaning Maiden
+160211067 3 --Dicemite Girl Laps
+160211068 3 --Dice Key Nel
+160211069 3 --Supreme Manchine Burning Overlord
+160211070 3 --Impactor Comet
+160211071 3 --Trombow the Music Princess
+160211072 3 --Scarechair Code
+160211073 3 --Tribute Kaiser
+160211074 3 --Animagica Leader
+160211075 3 --Oriental Statue
+160211079 3 --Shiny Shady
+160402038 3 --Sky Emperor Minion
+160448001 3 --Seiyaryu (Rush)
+160448003 3 --Progrigger Vancing
+160448004 3 --Jundee of the Dark Path
+# Legends
+160001000 3 --Blue-Eyes White Dragon (Rush)
+160002000 3 --Dark Magician (Rush)
+160003000 3 --Summoned Skull (Rush)
+160004000 3 --Jinzo (Rush)
+160005000 3 --Buster Blader (Rush)
+160006000 3 --Cyber-Tech Alligator (Rush)
+160007000 3 --Levia-Dragon - Daedalus (Rush)
+160008000 3 --The Creator (Rush)
+160009000 3 --Barrel Dragon (Rush)
+160010000 3 --Abyss Soldier (Rush)
+160011000 3 --Darklord Zerato (Rush)
+160012000 3 --Gilford the Lightning (Rush)
+160013020 3 --Zaborg the Thunder Monarch (Rush)
+160014065 3 --Negate Attack (Rush)
+160015056 3 --Salvage (Rush)
+160016033 3 --Snipe Hunter (Rush)
+160016034 3 --Golden Flying Fish (Rush)
+160201009 3 --Shield & Sword (Rush)
+160202019 3 --Trap Hole (Rush)
+160202048 3 --Card Destruction (Rush)
+160203018 3 --Upstart Goblin (Rush)
+160203023 3 --Tribute to The Doomed (Rush)
+160204048 3 --The Warrior Returning Alive (Rush)
+160204049 3 --Graceful Charity (Rush)
+160205001 3 --Blue-Eyes White Dragon (Rush)
+160205069 3 --Dark Hole (Rush)
+160205070 3 --Power Bond (Rush)
+160206002 3 --Behemoth the King of All Animals (Rush)
+160206008 3 --Vanity's Fiend (Rush)
+160206019 3 --Great Maju Garzett (Rush)
+160206022 3 --Final Destiny (Rush)
+160206025 3 --Polymerization (Rush)
+160206028 3 --Malevolent Catastrophe (Rush)
+160207060 3 --Levia-Dragon - Daedalus (Rush)
+160208063 3 --Phantasm Spiral Dragon (Rush)
+160208064 3 --Raiza the Storm Monarch (Rush)
+160208065 3 --Icarus Attack (Rush)
+160210001 3 --Dark Magician (Rush)
+160210029 3 --Gemini Elf (Rush)
+160210032 3 --Compulsory Evacuation Device (Rush)
+160210058 3 --Hammer Shot (Rush)
+160310001 3 --Pitch-Black Warwolf (Rush)
+160310002 3 --Alien Shocktrooper (Rush)
+160310003 3 --Dark Factory of Mass Production (Rush)
+160318001 3 --Twin-Barrel Dragon (Rush)
+160318002 3 --Mirage Dragon (Rush)
+160318003 3 --Flame Ruler (Rush)
+160318004 3 --Archfiend Soldier (Rush)
+160318005 3 --Torrential Tribute (Rush)
+160318006 3 --Graceful Charity (Rush)
+160404001 3 --Red-Eyes Black Dragon (Rush)
+160408003 3 --Monster Reincarnation (Rush)
+160411003 3 --Pot of Greed (Rush)
+160417001 3 --Millennium Shield (Rush)
+160417002 3 --Vorse Raider (Rush)
+160417003 3 --Mystical Elf (Rush)
+160417004 3 --Monster Reborn (Rush)
+160417005 3 --Sakuretsu Armor (Rush)
+160417006 3 --Monster Reborn (Rush)
+160418001 3 --Blue-Eyes White Dragon (Rush)
+160418003 3 --Mirror Force (Rush)
+160421015 3 --Dark Magician (Rush)
+160421016 3 --Red-Eyes Black Dragon (Rush)
+160421017 3 --Smashing Ground (Rush)
+160428099 3 --Recurring Nightmare (Rush)
+160428100 3 --Pot of Avarice (Rush)
+160429001 3 --Luster Dragon (Rush)
+160429002 3 --Thestalos the Firestorm Monarch (Rush)
+160432002 3 --Magician's Valkyria (Rush)
+160432003 3 --Heavy Storm (Rush)
+160432004 3 --Red-Eyes Black Dragon (Rush)
+160434005 3 --Magic Cylinder (Rush)
+160436005 3 --Widespread Ruin (Rush)
+160437001 3 --Widespread Ruin (Rush)
+160440001 3 --Buster Blader (Rush)
+160440002 3 --Recurring Nightmare (Rush)
+160440003 3 --Summoned Skull (Rush)
+160440010 3 --Negate Attack (Rush)
+160440011 3 --Pot of Avarice (Rush)
+160446002 3 --Time Wizard (Rush)
+# Prerelease Legends
+160211080 3 --Labyrinth Wall (Rush)
+1 -1
+#Forbidden
+160316013 0 --Barrier Statue of the Inferno
+# Limited
+160004049 1 --Grand Extreme
+160440008 1 --Grand Extreme
+160006015 1 --Thunderbold the Lightningfire Deity
+160203040 1 --Dragon Roll the Sushi Fairy
+160209081 1 --Obsidian Magical Soldier
+160406003 1 --Necromaid Nana
+160421029 1 --Magical Stone Excavation
+160440006 1 --Magical Stone Excavation
+160012024 1 --Ciela the Skysavior Knight
+160014055 1 --Cat-trois Choice
+# Semi-Limited
+160013054 2 --Sevens Wonder Fusion
+160428035 2 --Progress Potter
+160205034 2 --Excutie Lilius
+160013055 2 --Magical Lance - Grace Spear
+160208018 2 --Triangle Ecstacy Spark
+160014057 2 --Legend Strike
+160452005 2 --Legend Strike

--- a/0Rush.lflist.conf
+++ b/0Rush.lflist.conf
@@ -1,0 +1,2120 @@
+#[2024.04.01 Rush Duel]
+!2024.01.01 Rush Duel
+$whitelist
+160001001 3 --Lizard Soldier (Rush)
+160001002 3 --Lesser Dragon (Rush)
+160001003 3 --Ancient Turtle Protector
+160001004 3 --Binding Chain (Rush)
+160001005 3 --Tang the Noodle Ninja
+160001006 3 --Little D (Rush)
+160001007 3 --Arma Knight (Rush)
+160001008 3 --Petit Moth (Rush)
+160001009 3 --Skull Servant (Rush)
+160001010 3 --Silver Fang (Rush)
+160001011 3 --Feral Imp (Rush)
+160001012 3 --Faith Bird (Rush)
+160001013 3 --LaMoon (Rush)
+160001014 3 --Machine Attacker (Rush)
+160001015 3 --Crawling Dragon (Rush)
+160001016 3 --Max Raider
+160001017 3 --Kuribot
+160001018 3 --Whispering Fairy
+160001019 3 --Fire Golem
+160001020 3 --Hilt, the Bearer of Noble Arms
+160001022 3 --Raidacross, Hero of the Dawn
+160001024 3 --Sportsdragon Pitcher
+160001025 3 --Sportsdragon Slugger
+160001026 3 --Dragonic Slayer
+160001028 3 --Prima Guitarna the Shining Superstar
+160001029 3 --Yamiruler the Dark Delayer
+160001030 3 --Spice the Elite Noodle Ninja
+160001031 3 --Defender of Dragon Sorcerers
+160001032 3 --Thunder the Thunder
+160001033 3 --Sonic Attacker
+160001034 3 --Mask of Volos
+160001035 3 --Diabolic King Beetle
+160001036 3 --Battle Shark Samegalon
+160001037 3 --Pierce!
+160001038 3 --Recovery Force
+160001039 3 --Road Magic - Tempest
+160001040 3 --Seal of the Ancients (Rush)
+160001041 3 --Hammer Crush
+160001042 3 --Sparks (Rush)
+160001043 3 --Darkness Approaches (Rush)
+160001044 3 --One-Side Reverse
+160001045 3 --Mountain (Rush)
+160001046 3 --Counter Cannonball
+160001047 3 --Call of the Earthbound (Rush)
+160001048 3 --Gust (Rush)
+160001049 3 --Brutal Retribution
+160001050 3 --1-Up
+160002001 3 --Sportsdragon Keeper
+160002002 3 --Wattkiss
+160002003 3 --Watangel
+160002004 3 --Mammoth Graveyard (Rush)
+160002005 3 --Megazowler (Rush)
+160002006 3 --Bubbly Elf
+160002007 3 --LaMoon the Party Princess
+160002008 3 --Kanan the Sword Diva
+160002009 3 --Beast Gear Gyro Jackal
+160002010 3 --Beast Gear Buggy Dog
+160002011 3 --Beast Gear Moto Wolf
+160002012 3 --Jet Barracuda
+160002013 3 --Heat Dartfish
+160002014 3 --Harpie Girl (Rush)
+160002015 3 --Vishwar Randi (Rush)
+160002016 3 --Sevens Road Mage
+160002017 3 --Lightning Voltcondor
+160002018 3 --Full Meteor Impact
+160002019 3 --Sportsdragon Defender
+160002020 3 --Sportsdragon Striker
+160002021 3 --Shock Dragon
+160002022 3 --Piercing Dragon Bunker Strike
+160002023 3 --Romanpick
+160002024 3 --Romic n' Roller
+160002025 3 --Esperade the Smashing Superstar
+160002026 3 --Nandes the Fire Awakener
+160002027 3 --Dian Keto the Boogie Master
+160002028 3 --Beast Gear Emperor Catapult Kong
+160002029 3 --Super King Rex
+160002030 3 --Wicked Shadow Dark Lurker
+160002031 3 --Royal Rebel's Heavy Metal
+160002032 3 --Hydro Cannon Big Bluefin
+160002033 3 --Archfiend's Summoning Flute
+160002034 3 --Shaman Octopus
+160002035 3 --Innocent Lancer
+160002036 3 --Road Magic - Tectonic Shift
+160002037 3 --Lullabind
+160002038 3 --Party Party Party
+160002039 3 --Apocalypse - Beast Gear World
+160002040 3 --Thousand Knives (Rush)
+160002041 3 --Dark Magic Attack (Rush)
+160002042 3 --Blades of Divine Wind
+160002043 3 --Attribute Shift Bomb
+160002044 3 --Blue Medicine (Rush)
+160002045 3 --Party Time - Disco Ball
+160002046 3 --Rage and Conspiracy
+160002047 3 --Siesta Hold
+160002048 3 --Phantom Bind
+160002049 3 --Double Block
+160002050 3 --Driving Snow (Rush)
+160003001 3 --Light Sorcerer
+160003002 3 --Scoop Scooter
+160003003 3 --Stock the Noodle Ninja
+160003004 3 --Mushroom Man (Rush)
+160003005 3 --Niwatori (Rush)
+160003006 3 --Chu-Ske the Mouse Fighter (Rush)
+160003007 3 --Baby Dragon (Rush)
+160003008 3 --Hitotsu-Me Giant (Rush)
+160003009 3 --Doriado (Rush)
+160003010 3 --Water Magician (Rush)
+160003011 3 --Gazelle the King of Mythical Beasts (Rush)
+160003012 3 --Ojisan
+160003013 3 --Echeclus the Star Knight
+160003014 3 --Sparkhearts Girl
+160003015 3 --Silver Wolf
+160003016 3 --Beast Summoner
+160003017 3 --Sieth, the Scabbard of Noble Arms
+160003018 3 --Bendorbreak the Conqueror
+160003019 3 --Savage Claw Tiger
+160003020 3 --Treasure Dragon
+160003021 3 --Dragon Merchant
+160003022 3 --Clear Ice Dragon
+160003023 3 --Burning Blaze Dragon
+160003024 3 --Ancient Arise Dragon
+160003025 3 --Illusion Strike Dragon Miragias
+160003026 3 --Kesshin the Dark Decimator
+160003027 3 --Seahorse Server
+160003028 3 --Seahorse Carrier
+160003029 3 --Vishwar Lambadi
+160003030 3 --Beast Gear Trike Fox
+160003031 3 --Beast Gear King Convoy Liogon
+160003032 3 --Printing Presser
+160003033 3 --Extra Spice the Elite Noodle Ninja
+160003034 3 --Anchor Moray
+160003035 3 --Trick Pigeon
+160003036 3 --Luminous Parrot
+160003037 3 --Long Shield Gardna
+160003038 3 --Eldign Patrol Ship
+160003039 3 --Survival Swordfish
+160003040 3 --Darkness Crested Hawk
+160003041 3 --Sea Dragon King Granganus
+160003042 3 --Rightful Magic
+160003043 3 --Dragon's Return
+160003044 3 --Blazing Chestnut
+160003045 3 --The Noodle Art of Spicery
+160003046 3 --The Noodle Art of Savory
+160003047 3 --Triple Threat Thunder
+160003048 3 --Shining City Nights
+160003049 3 --Aqua Boost
+160003050 3 --Big Umi
+160003051 3 --Thousand Attack Rocket
+160003052 3 --Umi (Rush)
+160003053 3 --Forest (Rush)
+160003054 3 --Soul of a Reporter
+160003055 3 --Bait Bite Ball
+160003056 3 --Counter Shield
+160003057 3 --Counter Pigeons
+160003058 3 --Giant Tortoise of Greed
+160003059 3 --Triple Trio
+160003060 3 --Faulty Fire
+160004001 3 --Constructor Soldier Drillzard
+160004002 3 --Constructor Warrior Shovelon
+160004003 3 --Constructor Battler Big Roller
+160004004 3 --Brassaxophone the Music Princess
+160004005 3 --Flutomahawk the Music Princess
+160004006 3 --Bull Breaker
+160004007 3 --Oppressed Ant
+160004008 3 --United Ants
+160004009 3 --Ants Running About
+160004010 3 --Tsuvolcano
+160004011 3 --Enchanting Mermaid (Rush)
+160004012 3 --Descendant of Titans
+160004013 3 --Grace Princess Kana
+160004014 3 --Silent Assailant
+160004015 3 --Steel Mech Lord Mirror Innovator
+160004016 3 --Insurrection Dragon
+160004017 3 --Chemical Cure Blue
+160004018 3 --Tama the Mancer Cat
+160004019 3 --Modorina the Light Retriever
+160004020 3 --Semeruler the Dark Summoner
+160004021 3 --Wyrm Excavator the Heavy Cavalry Draco [L]
+160004022 3 --Wyrm Excavator the Heavy Cavalry Draco
+160004023 3 --Wyrm Excavator the Heavy Cavalry Draco [R]
+160004024 3 --Constructor Wyrm Buildragon
+160004025 3 --Picklon the Constructor Fairy
+160004026 3 --Nuncharinet the Music Princess
+160004027 3 --Trumpetonfa the Music Princess
+160004028 3 --Ensembullfighter the Music Fiend
+160004029 3 --Digisoon the Music Fiend
+160004030 3 --Gingangel, the Deluxe Sushi Fairy
+160004031 3 --Drilling Mandrill
+160004032 3 --Shield Boring Kong
+160004033 3 --Antrebellion of the Rebellion
+160004034 3 --Anmagmabear
+160004035 3 --Aromagmabear
+160004036 3 --Magmassage
+160004037 3 --Magmax Mantleveda
+160004038 3 --Sakakaze the Talismanic Warrior
+160004039 3 --Type Change Beam
+160004040 3 --Ancient Barrier
+160004041 3 --Evil Star Beacon
+160004042 3 --Peaks of Blisstopia
+160004043 3 --Geological Survey
+160004044 3 --Primal Howling
+160004045 3 --Music Princess's Breath
+160004046 3 --Heavy Cavalry Tactics
+160004047 3 --Apocalypse - Legend of the Warrior
+160004048 3 --Fiery Blaze
+160004049 3 --Grand Extreme
+160004050 3 --Sogen (Rush)
+160004051 3 --Triangle Reborn
+160004052 3 --Sword & Shield
+160004053 3 --Constructor Ambush
+160004054 3 --Constructor Blockade
+160004055 3 --Heavy Cavalry Starter
+160004056 3 --Gi-ant Revolution
+160004057 3 --Antiberty Flag
+160004058 3 --Earth Pressure Explosion
+160004059 3 --Jewelry Trap Hole
+160004060 3 --Beast Gear Secret Art - Primal Fist
+160005001 3 --The Fire Dragon
+160005002 3 --CAN:D
+160005003 3 --Royal Rebel's No Wave
+160005004 3 --Guarding Mermaid
+160005005 3 --Kanan the Security Guard
+160005006 3 --Kurobana the Shadow Flower Wolf
+160005007 3 --Lindo the Shadow Flower Warrior
+160005008 3 --Bombing Bird
+160005009 3 --Grass
+160005010 3 --Surge Bolt Lizard
+160005011 3 --Baked Bean Soldier
+160005012 3 --Metal Armored Ant
+160005013 3 --Ice Age Catapult
+160005014 3 --Hyper Engine Vast Vulcan [L]
+160005015 3 --Hyper Engine Vast Vulcan
+160005016 3 --Hyper Engine Vast Vulcan [R]
+160005017 3 --Fortitude Dragon
+160005018 3 --Endoll
+160005019 3 --CAN - Re:D
+160005020 3 --Takegumi the Ruler's Squad
+160005021 3 --Wondering Warrior
+160005022 3 --Icezark the Unequaled
+160005023 3 --Royal Rebel's Phaser
+160005024 3 --Royal Rebel's Doom Metal
+160005025 3 --Vice Jacker
+160005026 3 --Dian Keto the Security Master
+160005027 3 --Acacia the Shadow Flower Priestess
+160005028 3 --Gekka the Shadow Flower Beauty
+160005029 3 --Etraynze the Shadow Flower Ninja
+160005030 3 --Gajumaru the Shadow Flower Lion
+160005031 3 --Garland the True Shadow Flower Ninja
+160005032 3 --Gatling the Shadow Flower Shinobi
+160005033 3 --Blasting Bird
+160005034 3 --Night Vision the Phantom Pigeon
+160005035 3 --Siesta Torero
+160005036 3 --Maginical Miracle
+160005037 3 --Coiled Dragon of Fertility
+160005038 3 --Cheron the Star Knight
+160005039 3 --JAM:P Up!
+160005040 3 --JAM:P Start!
+160005041 3 --Royal Rebel's Command
+160005042 3 --Royal Rebel's Arena
+160005043 3 --Vicissitude of Providence
+160005044 3 --The Menacing Eyes of the Sky Emperor
+160005045 3 --Prison Island - Cell Block 5 & 6
+160005046 3 --Last Day of the Pretty☆Witch
+160005047 3 --Hydration
+160005048 3 --Shadow Flower Spore
+160005049 3 --Apocalypse - The Unstoppable Beast-Warrior
+160005050 3 --Majinrai, the Striking Storm
+160005051 3 --Invading Nature
+160005052 3 --Judgment of the Rising Light
+160005053 3 --Avian Spell Tactics
+160005054 3 --Wasteland (Rush)
+160005055 3 --Pretty☆Witch Imprisonment
+160005056 3 --All For Naught - Bubble Burst
+160005057 3 --Shadow Flower Stance
+160005058 3 --Shadow Flower Return
+160005059 3 --Brocoohearted Pigeon
+160005060 3 --Clowning Cookoo Clock
+160005061 3 --Music Princess's Recital
+160005062 3 --Archfiend's Revival
+160005063 3 --Maraimei, the Igniting Inferno
+160005064 3 --Cheering Grass
+160005065 3 --Acetic Acid Trap Hole
+160006001 3 --Sunny Fairy Spinangel
+160006002 3 --Worker Warrior - New Recruit
+160006003 3 --Worker Warrior - Bad Boss
+160006004 3 --Barbeque Ox
+160006005 3 --Mystic Roastman
+160006006 3 --Archfiend Marmot of Deliciousness
+160006007 3 --Hampering Hippo
+160006008 3 --Dogulce Jomont Blanc
+160006009 3 --Pangoflame
+160006010 3 --Flying Kamakiri #2 (Rush)
+160006011 3 --Northern Dumplina
+160006012 3 --Fazuzu the King of Mythical Wind Beasts
+160006013 3 --Handy Lady
+160006014 3 --Sevens Road Wiz
+160006015 3 --Thunderbold, the Blazing Thunder
+160006016 3 --Stock Buster Dragon
+160006017 3 --Steel Strike Dragon Metagias
+160006018 3 --Speedy Performer
+160006019 3 --Future Diviner
+160006020 3 --Betrayer of Peace
+160006021 3 --Karchizark the Unequaled
+160006022 3 --Air Formula Eagle
+160006023 3 --Secret Service Shine Guard
+160006024 3 --Worker Warrior - Sinister CEO
+160006025 3 --Shichirin Samurai - Kushiro the Skewer Master
+160006026 3 --Beast Drive Mega Elephant
+160006027 3 --Dogulce Langue de Shakoki
+160006028 3 --Doki Doki Hexenhaus
+160006029 3 --Jasmine the Shadow Flower Festival
+160006030 3 --Crafter Drone
+160006031 3 --Assault Armato
+160006032 3 --Heat Hyena
+160006033 3 --Reset Runner
+160006034 3 --Lindmühle
+160006035 3 --Gate Gargoyle
+160006036 3 --Vietor the Prevailing Wind
+160006037 3 --Bladesaurus
+160006038 3 --Arzareth the Sweeping Wind
+160006039 3 --Road Magic - Uplifter
+160006040 3 --Hypernova
+160006041 3 --JAM:P Set!
+160006042 3 --Ruler's Current
+160006043 3 --Against Buster
+160006044 3 --Storm Sonic
+160006045 3 --Following World
+160006046 3 --Business Card Barrage
+160006047 3 --Nutrient Zero
+160006048 3 --Best Bite
+160006049 3 --B・B・Q
+160006050 3 --Wild Kitchen
+160006051 3 --Beast Battlefield Barrier
+160006052 3 --Dekorelic Dessert
+160006053 3 --Talismanic Seal Array
+160006054 3 --Iron Onslaught
+160006055 3 --Rage of the Beasts
+160006056 3 --Berserker Colosseum
+160006057 3 --Mismatched Rivalry
+160006058 3 --7 Chance
+160006059 3 --Psychicounter
+160006060 3 --Dark Ruler Battle Slash
+160006061 3 --Covering Barrage
+160006062 3 --Salary Slash
+160006063 3 --Battle Demotion
+160006064 3 --Eternal Freeze
+160006065 3 --Scaredy Cats
+160007001 3 --Needlkyrie the Celestial Seamstress
+160007002 3 --Takriminos (Rush)
+160007003 3 --Dolphin King Iruqua
+160007004 3 --Gagaga Outfielder
+160007005 3 --Achacha Catcher
+160007006 3 --Zubaba Batter
+160007007 3 --ExPress Train
+160007008 3 --Flavor Inspector
+160007009 3 --Cross Promotion the Elite Noodle Ninja
+160007010 3 --Unidentified Mysterious Urchin
+160007011 3 --Necroman the Third
+160007012 3 --Daybreak Warrior
+160007013 3 --Porcupine Dragon
+160007014 3 --Psypickupper
+160007015 3 --Mezame the Ringing Alarm
+160007016 3 --Piercing Samurai
+160007017 3 --Kimeluna the Dark Shifter
+160007018 3 --Royal Rebel's Break
+160007019 3 --Viscom Nanotron
+160007020 3 --Constructor Sky Wyrm Gantry Dragon
+160007021 3 --Light Dolphin
+160007022 3 --Sea Star Trooper
+160007023 3 --Kataomoiruka
+160007024 3 --Headbutt Cachalot
+160007025 3 --Dododo Second
+160007026 3 --Gogogo Umpire
+160007027 3 --Player #99: Grand Slam Dragon
+160007028 3 --Player #39: Home Run Hitter
+160007029 3 --Reporter Raccoon
+160007030 3 --Clean Machine Newsweeper
+160007031 3 --Sea Dragon Cranedross
+160007032 3 --Sea Dragon Knight
+160007033 3 --Dosodon
+160007034 3 --Raidacross Ash, Hero of Chaos
+160007035 3 --CAN:D LIVE
+160007036 3 --Yamiterasu the Divine Ruler
+160007037 3 --Newsflash the Journalistic Juggernaut
+160007038 3 --Meat Spice the Special Noodle Ninja
+160007039 3 --Miso Instant the Special Noodle Ninja
+160007040 3 --Hunter of Titans
+160007041 3 --Fenrirewritter Sol
+160007042 3 --Supreme Marine Fortress Magnum Overbase
+160007043 3 --Five Types of Assistance
+160007044 3 --Bizarrmor
+160007045 3 --Shape of Aqua
+160007046 3 --Vanishing Torrent
+160007047 3 --Feverous Spirit Stadium
+160007048 3 --Hot Off the Press
+160007049 3 --Reprinter
+160007050 3 --The Noodle Art of Roastery
+160007051 3 --The Noodle Art of Saucery
+160007052 3 --Ship of Seven Treasures
+160007053 3 --Back Beat
+160007054 3 --Stream
+160007055 3 --Card Devastation
+160007056 3 --Shocking Comeback!!
+160007057 3 --Pair Collision
+160007058 3 --Dolphin Counterattack
+160007059 3 --Seastorm of Iruqua
+160007060 3 --Gagagaguts
+160007061 3 --Requesting 9
+160007062 3 --Reporting from the Scene!
+160007063 3 --Breaking News!
+160007064 3 --Spiral Geyser
+160007065 3 --Hardefense Mission
+160008001 3 --Dark Femtron
+160008002 3 --Snake Clown
+160008003 3 --Ancient Lizard Warrior (Rush)
+160008004 3 --Armored Lizard (Rush)
+160008005 3 --Boosturtle
+160008006 3 --Pluggyfish
+160008007 3 --Anglercoilfish
+160008008 3 --Antsgiving
+160008009 3 --Lauan Adventurers
+160008010 3 --Germalewe
+160008011 3 --Sevens Road Sorcerer
+160008012 3 --Rhythmical Performer
+160008013 3 --Excutie Feena
+160008014 3 --Shearkyrie the Celestial Seamstress
+160008015 3 --Mecha Ambulator
+160008016 3 --Captain #39: Home Plate Pinch Hitter
+160008017 3 --Kamaleon
+160008018 3 --Clawmeleon
+160008019 3 --Fiery Infernleon
+160008020 3 --Metal Megaleon
+160008021 3 --Predator Gunleon
+160008022 3 --Ecdysis Caesarleon
+160008023 3 --Spyturtle
+160008024 3 --Rocketortoise Modularchelon
+160008025 3 --Zap Zap Octospark
+160008026 3 --Spirit of Bolt of Inspiration
+160008027 3 --Sensor Duckbill
+160008028 3 --Emitter Stag
+160008029 3 --Blast Jaws
+160008030 3 --Stormbolt Destroyer
+160008031 3 --Blitzkrieg Cavalry Triggerdrago
+160008032 3 --Master of the Sevens Road
+160008033 3 --Hazy Strike Dragon Miragiastar F
+160008034 3 --Endless Romance Blitz
+160008035 3 --Hero of the Assist
+160008036 3 --Semeterasu the Divine Ruler
+160008037 3 --Meika Etraynze the Shadow Flower Venus
+160008038 3 --Durga the Shadow Flower Submarine
+160008039 3 --Metarion King Cobrastar
+160008040 3 --Poseigyon Advencharger
+160008041 3 --Showering Seaferno
+160008042 3 --Prime Roast Beef Horseman
+160008043 3 --Hormone GunMcQueen, the Magnificent Shichirin
+160008044 3 --Ether Fast Striker
+160008045 3 --Vulcan Ignite Hyperdrive
+160008046 3 --Royal Rebel's Echo
+160008047 3 --Shadow Flower Flurry
+160008048 3 --Shadow Flower Wish
+160008049 3 --Tag-Up-Magic Sacrifice Force
+160008050 3 --Bobble Header
+160008051 3 --Release Wrath
+160008052 3 --Fire Wrath
+160008053 3 --Spy Observation
+160008054 3 --Destructurtle Meteor
+160008055 3 --Clapping Thunder
+160008056 3 --Trailblitzing Thunderbolt
+160008057 3 --Parallel Birth Gate
+160008058 3 --Makiu, the Magical Mist (Rush)
+160008059 3 --Jurassic Oasis
+160008060 3 --Buried Shield
+160008061 3 --Wrath of Light
+160008062 3 --Ultimate Fighting Spirit
+160008063 3 --Sakuretsu Force
+160008064 3 --Electrical Discharge
+160008065 3 --Maid's Baneful Gift
+160009001 3 --Milky Wave Neo
+160009002 3 --Galactica Oblivion
+160009003 3 --Ewekai Grounmouton
+160009004 3 --Ewekai Pyrowool
+160009005 3 --Ewekai Nightmutton
+160009006 3 --Magical Sheep Girl Meeeg-chan
+160009007 3 --One Year Broom
+160009008 3 --Decennium Mystic Sword
+160009009 3 --Centennial Wooden Blade
+160009010 3 --Atlas Combat Beetle
+160009011 3 --Protector of the Throne (Rush)
+160009012 3 --Griffore (Rush)
+160009013 3 --Black Handshaker
+160009014 3 --Astrorescue
+160009015 3 --Ozone Layer
+160009016 3 --Transamu Ephyrai
+160009017 3 --Satellite Pegasus
+160009018 3 --Great Cosmonarch
+160009019 3 --Jointech Rex
+160009020 3 --Ewekai Planeau
+160009021 3 --Poet Fairy
+160009022 3 --Swordfish Vanguard Gaju
+160009023 3 --Princess Ladybug White
+160009024 3 --Pakupakuchu
+160009025 3 --Swapling Silkworm Fibron
+160009026 3 --Therappi
+160009027 3 --Rapid Carriearth
+160009028 3 --Dramoth Caterpillar
+160009029 3 --Shitotsu the Talismanic Warrior
+160009030 3 --Bio Mechamantis
+160009031 3 --Crusher Drone
+160009032 3 --Ravenous Insect Matiless
+160009033 3 --Excutie Fermi
+160009034 3 --Anglered Digra
+160009035 3 --Ground Cerberus
+160009036 3 --Bladearmor King Dynas Dorcus
+160009037 3 --Sevensgias the Magical Dragon Knight
+160009038 3 --Constructor Ridge Wyrm Handtoolon
+160009039 3 --Meika Etraynzeyes the Shadow Flower Lunatic
+160009040 3 --Hero of the Sweep
+160009041 3 --Samurai of the Wooden Sword
+160009042 3 --Surge Vortex Dragoon
+160009043 3 --Meteor Charge
+160009044 3 --Meet and Greed
+160009045 3 --Future Mining
+160009046 3 --Sword Skill - Ruler's Slash
+160009047 3 --Defense Destroying Sword
+160009048 3 --Telegraphed Strike
+160009049 3 --Sunny Forest
+160009050 3 --Insect Rampage
+160009051 3 --Intruding Beetles
+160009052 3 --Excutie Up!
+160009053 3 --Ghost Cyclone
+160009054 3 --Strange Wall
+160009055 3 --Ewekai - Grudges from the Grave
+160009056 3 --Lucky Mask of Omens
+160009057 3 --Card Reprinting
+160009058 3 --Security Hole
+160009059 3 --Demolisher Wyrm Roar
+160009060 3 --Climax Clash
+160009061 3 --Engage and Strike!
+160009062 3 --Anciant Barrier
+160009063 3 --Ignoring Insect
+160009064 3 --Hunting Strawberries
+160009065 3 --Crisis at the Sacred Tower
+160010001 3 --Ewekai Aquasheep
+160010002 3 --Ewekai Thunderlambda
+160010003 3 --Ewekai Airaries
+160010004 3 --Hyosube (Rush)
+160010005 3 --Tutumes Dark Witch
+160010006 3 --Heartless Hound Blaster Gundog
+160010007 3 --Heartless Hound Blade Bulldosu
+160010008 3 --Heartless Hound Striking Kai Ken Knuckle
+160010009 3 --Heartless Hound Blaster Chaka Chow Chow
+160010010 3 --Heartless Hound Apex Katana Danbiramatian
+160010011 3 --Sannomiya Golden G Robo MK-III
+160010012 3 --Alien 33
+160010013 3 --The Three Warp-Granny Sisters
+160010014 3 --Alien Count of the White Dwarf, St. Germain
+160010015 3 --Ichtyosterguard
+160010016 3 --Nekogal #2 (Rush)
+160010018 3 --Cremation Dog Nitro
+160010019 3 --Dynamo Might
+160010020 3 --Chemicalize Salamander
+160010021 3 --Parashroom Colony
+160010022 3 --Burstray Gunman
+160010023 3 --Star Trancer
+160010024 3 --Ultra Violady
+160010025 3 --Voidvelgr Requiem
+160010026 3 --Ewekai Waveschaf
+160010027 3 --Infernal Kappa Diwet
+160010029 3 --Nuvia the Wicked Mischief Maker
+160010030 3 --Dian Keto the Cure Maiden
+160010031 3 --Heartless Hound Thunder Emperor Drainu
+160010032 3 --Heartless Hound Martial Master Shiba
+160010033 3 --Beast Gear Sage Roller Stag
+160010034 3 --Berry Fresh Happiness
+160010035 3 --Delirium Papillon
+160010036 3 --Splitter Slime
+160010037 3 --Miginagi the Talismanic Warrior
+160010038 3 --Rice Terrace Ripple
+160010039 3 --Headhunters' Digmole
+160010040 3 --Thunder Gazelle
+160010041 3 --Man-Thro' Tro' (Rush)
+160010042 3 --Abare Ushioni (Rush)
+160010043 3 --Diabearical Lilith
+160010044 3 --Splendid Floor Master
+160010045 3 --Eclipse
+160010046 3 --Melo Melo Meeeg☆Uuultra Beam
+160010047 3 --Caught in the Rain
+160010048 3 --Rainy Megalopolis
+160010049 3 --Bubble Kingdom
+160010050 3 --Woofderful Heartless Hound
+160010051 3 --300 Light-Year Red Cloak
+160010052 3 --Third Coming of the Reptilian Count
+160010053 3 --Area 33
+160010054 3 --Dolphin's Treasure Chest
+160010055 3 --Strange Seas
+160010056 3 --Yamata no Tsurugi
+160010057 3 --Yokai Tiger Orient Strike
+160010058 3 --Power Shock
+160010059 3 --Paxcyclinder
+160010060 3 --Kappa's River Flow
+160010061 3 --Sunbathing Kappa
+160010062 3 --Kappa's Gas
+160010063 3 --The Three Moonlit Mystery Geckos
+160010064 3 --Trap Lid
+160010065 3 --Boost Rescue
+160010101 3 --Blue Tooth Burst Dragon
+160010102 3 --Kappa Emperor River Slider
+160011001 3 --Police Scoop
+160011002 3 --Arts Angel Guard Dolby
+160011003 3 --Arts Angel Glyco Razer
+160011004 3 --Arts Angel CD Fender
+160011005 3 --Bean Soljersey
+160011006 3 --Black Luster Soljersey
+160011007 3 --Blanc de Blanc the Snow Shadow Flower
+160011008 3 --Robbarim
+160011009 3 --Ampler Glee
+160011010 3 --Astrosoldier
+160011011 3 --Galactica Tabula Rasa
+160011012 3 --Alco the Flame Emperor of the Lamp
+160011013 3 --Arts Angel Dia Needle
+160011014 3 --Arts Angel Metal Position
+160011015 3 --Penguin Soljersey
+160011016 3 --Cannon Soljersey
+160011017 3 --Black Luster Soljersey - Envoy of the Drying
+160011018 3 --Iris the Rare Shadow Flower
+160011019 3 --Alpiris the Sower
+160011020 3 --Radrogue Mael
+160011021 3 --Taiban Bluemai
+160011022 3 --Bluegrass Stealer
+160011023 3 --Heel Healer
+160011024 3 --Prophecy Phrase of the Colors of the Wind
+160011025 3 --Asport Pirate the Wind Crusher
+160011026 3 --Bandijo of the Battle Ballad
+160011027 3 --Beast Gear Side Fennec
+160011028 3 --Shariel, the Novice Sushi Fairy
+160011029 3 --Brain Harvester
+160011030 3 --Seraph of Darkness
+160011031 3 --Philan Dwarf
+160011032 3 --Shadow Buyer
+160011033 3 --Ghost Vicious
+160011034 3 --Watchman of the Apocalypse
+160011035 3 --Neo Plandish
+160011036 3 --Salvage Wolfish
+160011037 3 --Doushin Kaika the Shadow Flower Full Moon
+160011038 3 --Javelin Dux the Shadow Flower Piercer
+160011039 3 --Kuzuha the Talismanic Supreme Sage
+160011040 3 --Galactica Xiphos
+160011041 3 --Jointech Rushhorn
+160011042 3 --QWERTY Keyblade
+160011043 3 --Chemicalizer Red
+160011044 3 --Voidvelgr Tyrfing
+160011045 3 --Auto Reverse
+160011046 3 --Black Luster Jersey Ritual
+160011047 3 --Preparation of Jersey Rites
+160011048 3 --Shadow Flower Sewing
+160011049 3 --Shadow Flower Duplication
+160011050 3 --Road Arms - Sevens Lance
+160011051 3 --Flame Arms - Fretberge
+160011052 3 --Heavy Arms - Double Nexcalibur
+160011053 3 --Sacred Arms - Strabishop
+160011054 3 --JAM:P Check!
+160011055 3 --Music Princess's Prelude
+160011056 3 --Atrium's Wind
+160011057 3 --Descent of the Sweeping Spirit
+160011058 3 --Beast Swords - Tiger Sabre
+160011059 3 --Armaments of Ascension
+160011060 3 --Site Preview
+160011061 3 --Indigo Prison
+160011062 3 --Slash Halo
+160011063 3 --Back Jersey
+160011064 3 --Force of Thief
+160011065 3 --Revenge MAX
+160012001 3 --Chromatographagas
+160012002 3 --Ray Dragon
+160012003 3 --The Dragias
+160012004 3 --Silver-Eyes Star Cat
+160012005 3 --Golden-Eyes Star Cat
+160012006 3 --Jointech Tinplatesaurus
+160012007 3 --Red Riser
+160012008 3 --Voidvelgr Kataphraktos
+160012009 3 --Voidvelgr Black Dwarf
+160012010 3 --Machvio of the Ultimate Aria
+160012011 3 --Double-Doom Dragon
+160012012 3 --The Clone
+160012013 3 --Mirroring Wyvern
+160012014 3 --Purple-Eyes Star Cat
+160012015 3 --Green-Eyes Star Cat
+160012016 3 --Cat Claw Girl
+160012017 3 --Dark-Eyes Breakstar Cat
+160012018 3 --Cyber Coatl
+160012019 3 --Excutie Flame
+160012020 3 --Soleil the Skysavior Angel
+160012021 3 --Lua the Skysavior Angel
+160012022 3 --Ranga the Skysavior Knight
+160012023 3 --Seir the Skysavior Knight
+160012024 3 --Ciela the Skysavior Knight
+160012025 3 --Dunkes the Skysavior Knight
+160012026 3 --Astrobio Drake
+160012027 3 --Engine Reviver
+160012028 3 --Gilford the Rising
+160012029 3 --Gilford the Legend (Rush)
+160012030 3 --Transamuroad Rainac
+160012031 3 --Melel the Beautiful Flame Spirit of the Lamp
+160012032 3 --Alchemicalize Salamandra
+160012033 3 --Voidvelgr Protostar
+160012034 3 --Double Ray Dragons
+160012035 3 --The Dragiastar
+160012036 3 --Star Cat Straynya
+160012037 3 --Star Cat Destronya
+160012038 3 --Solcier the Skysavior Lightflash
+160012039 3 --Altierra the Skysavior Transience
+160012040 3 --Digrace the Skysavior Radiance
+160012041 3 --Drukmoor the Skysavior Phantom
+160012042 3 --Stemagic
+160012043 3 --Cracking Claw
+160012044 3 --Voidvelgr Phalanx
+160012045 3 --Road Arms - Sword Breaker
+160012046 3 --The Copy
+160012047 3 --Back to The Fusion
+160012048 3 --Vice Slasher
+160012049 3 --Meowonderful Rush
+160012050 3 --Rising Luna Radiant Luster
+160012051 3 --Blaze Fiend Assault
+160012052 3 --Skysavior Prayer
+160012053 3 --Skysavior Watch
+160012054 3 --Skysavior Symbol
+160012055 3 --Ring of Storms
+160012056 3 --Transamu Lightning
+160012057 3 --Jointech Great Wall
+160012058 3 --Tribute Block
+160012059 3 --Dark Nebula
+160012060 3 --Dragon Double-Doom
+160012061 3 --Stray Force
+160012062 3 --Ether Escape
+160012063 3 --Traditional Tax
+160012064 3 --Buffered Slime
+160012065 3 --Phantom Roar
+160012066 3 --Multistrike Dragon Dragias
+160013000 3 --Sevens Road Witch
+160013001 3 --Earth Sorcerer
+160013002 3 --Aero Sorcerer
+160013003 3 --Galactica Deja Vu
+160013004 3 --Booster Wyvern
+160013005 3 --DBF Rebuildra
+160013006 3 --Voidvelgr Kyrie
+160013007 3 --Voidvelgr Logistikos
+160013008 3 --Voidvelgr Chrysaor
+160013009 3 --Celeb Rose Mage
+160013010 3 --Celeb Rose Sorcerer
+160013011 3 --Celeb Rose Witch
+160013012 3 --Celeb Rose Magician
+160013013 3 --Magiarms Beast Gearpard
+160013014 3 --Zuse the Wisdom Vassal
+160013015 3 --Hebe the Star Vassal
+160013016 3 --Wilhel the Wisdom Monarch
+160013017 3 --Estrome the Star Monarch
+160013018 3 --Wilhel the Mega Monarch
+160013019 3 --Estrome the Mega Monarch
+160013021 3 --Cyber Processor
+160013022 3 --Star Replacer
+160013023 3 --Don A. Corn of the Verdant Vast
+160013024 3 --Braid Blade Reader
+160013025 3 --Skyporter Max
+160013026 3 --Devil Foolish
+160013027 3 --Splame
+160013028 3 --Elegant Aurum Avian
+160013029 3 --Plaster Scout
+160013030 3 --Mad Rare Aquila
+160013031 3 --EXTRAplorer
+160013032 3 --Manifestation Master Dortheo
+160013033 3 --Pureglass Spears
+160013034 3 --Galactiara Fuse Eve
+160013035 3 --Eternal Galactica Oblivion
+160013036 3 --Tamabot Burst Dragon
+160013037 3 --Blue Tooth Enhanced Burst Dragon
+160013038 3 --Red Boot Enhanced Boost Dragon
+160013039 3 --Voidvelgr Theogonia
+160013040 3 --Voidvelgr Gigantomachia
+160013041 3 --Celeb Rose Fabulous Magician
+160013042 3 --Celeb Rose Luxury Magicians
+160013043 3 --Sevens Chariot the Magical Knight
+160013044 3 --Cyber Tactical Dragon
+160013045 3 --Space Fusion - EXTRAplasmer
+160013046 3 --Advance Impact
+160013047 3 --Galactica Addergatling
+160013048 3 --Dragon's Burst Fusion
+160013049 3 --Dragon's Boost Fusion
+160013050 3 --Voidvelgr Gullinbursti
+160013051 3 --Voidvelgr Shroud
+160013052 3 --Charis Magic - Elegant Change
+160013053 3 --Charis Magic Scepter - Death Wand
+160013054 3 --Sevens Wonder Fusion
+160013055 3 --Magical Lance - Grace Spear
+160013056 3 --Emperor Realm
+160013057 3 --Protection of Arthenée
+160013058 3 --Dead or Arainac
+160013059 3 --Recombination Galactica
+160013060 3 --Nobody Scat Thief
+160013061 3 --Rose Chain Salvage
+160013062 3 --Machinations of the Monarchs
+160013063 3 --Nativity of the Monarchs
+160013064 3 --Shared Sentiments
+160013065 3 --Vortex of Shattered Light
+160013066 3 --Rice Terrace Crisis
+160013122 3 --Star Replacer
+160013130 3 --Mad Rare Aquila
+160013157 3 --Protection of Arthenée
+160013166 3 --Rice Terrace Crisis
+160014000 3 --Gaia The Fierce Knight (Rush)
+160014001 3 --Worm Drake (Rush)
+160014002 3 --Jointech Cobra
+160014003 3 --Mega Jointech Fortrex [L]
+160014004 3 --Mega Jointech Fortrex
+160014005 3 --Mega Jointech Fortrex [R]
+160014006 3 --Jointech Arc Scorpio
+160014007 3 --Jointech Spike Centipede
+160014008 3 --Jointech Hero
+160014009 3 --Chemispet Nyanko
+160014010 3 --Chemispet Wanko
+160014011 3 --Melt the Aqueous Spirit
+160014012 3 --Bolt the Conduction Spirit
+160014013 3 --Hot the Combustion Spirit
+160014014 3 --Hyper Assistant Achi
+160014015 3 --Blazebolt Chemistorm Fenghuang Volcalize Phoenix [L]
+160014016 3 --Blazebolt Chemistorm Fenghuang Volcalize Phoenix
+160014017 3 --Blazebolt Chemistorm Fenghuang Volcalize Phoenix [R]
+160014018 3 --Secret Investigator Miscast
+160014019 3 --Secret Investigator Mistake
+160014020 3 --Secret Investigator Mismatch
+160014021 3 --Secret Investigator Mislead
+160014022 3 --Elite Secret Investigator Mystery
+160014023 3 --Abysslayer Leviaknight
+160014024 3 --Abysskite Ange
+160014025 3 --Abysskite Liem
+160014026 3 --Abysskite Karen
+160014027 3 --Constructor Driver Soldier Trailon
+160014028 3 --Change Slime - Dragon Champion Mode
+160014029 3 --Dragoncurse Magician
+160014030 3 --Launcher Catapult Turtle
+160014031 3 --Veteran Curse of Dragon
+160014032 3 --Veteran Gaia the Fierce Knight
+160014033 3 --Polygon Butterfly
+160014034 3 --Negatwor Dragon
+160014035 3 --The Strange Specter of Celestial Starts
+160014036 3 --Steel Soldier Gale Vinary
+160014037 3 --Rising Light Angel Esser
+160014038 3 --Galacterial Ore
+160014039 3 --Dino Skeleton Pushcera
+160014040 3 --All-Seeing Harvey
+160014041 3 --Landporter MAX
+160014042 3 --Snake Princess of Purity
+160014043 3 --Jointech Fighter
+160014044 3 --Jointech Killer Stinger
+160014045 3 --Jointech Burst Dragon
+160014046 3 --Gaia the Battle Ruler
+160014047 3 --Jointech Dig Up
+160014048 3 --Volcalize Compound
+160014049 3 --Chemicalize Structure Force
+160014050 3 --Dark Hole Device
+160014051 3 --Aura Buster
+160014052 3 --Monster Convocation
+160014053 3 --Dark Battle Grounds
+160014054 3 --Gameboard Ablaze and Alight
+160014055 3 --Cat-trois Choice
+160014056 3 --Psymprinting
+160014057 3 --Legend Strike
+160014058 3 --Jointech Ignition
+160014059 3 --Chemicalize Despise
+160014060 3 --Secret File 33 - Noble Death of Resentment
+160014061 3 --Intercepting Gaia
+160014062 3 --Dragonic Escape
+160014063 3 --Amusi Annoyance
+160014064 3 --Excutie Riding!
+160014066 3 --Automatic Accident Prevention
+160014135 3 --The Strange Specter of Celestial Starts
+160014136 3 --Steel Soldier Gale Vinary
+160014137 3 --Rising Light Angel Esser
+160014163 3 --Amusi Annoyance
+160015000 3 --Esperade the Smashing Superstar
+160015001 3 --Darkness Drake
+160015002 3 --Surging-Wave Swordsman Yoshimitsu Shark
+160015003 3 --Darkness Dwarf
+160015004 3 --Darkness Transamu Craisis
+160015005 3 --Striping Wyvern
+160015006 3 --Flap Dragon
+160015007 3 --Flip Dragon
+160015008 3 --Celeb Rose Wiz
+160015009 3 --Darkness Paparazzi
+160015010 3 --Darkness Phantomite
+160015011 3 --Demolition Soldier Ashiba Bikke
+160015012 3 --Fiddlebadour
+160015013 3 --Vibra Brigand
+160015014 3 --Plandolin
+160015015 3 --Star's Hand Camera Lady
+160015016 3 --Surging-Wave Swordsman Tanegashima Tuna
+160015017 3 --Hydro Gun Mini Bluefin
+160015018 3 --Charge Remora
+160015019 3 --Carrier Manta Ray
+160015020 3 --Cyber Fish
+160015021 3 --Cyber Shark (Rush)
+160015022 3 --Surging-Wave Swordsman Onimaru Kunituna
+160015023 3 --Infernal Kappa River Sprinter
+160015024 3 --Meteorite Dragon's Chick
+160015025 3 --Red-Eyes Moon Dragon
+160015026 3 --Alligator's Black Knight
+160015027 3 --Rocket Satellite Medic
+160015028 3 --Meteor Drake
+160015029 3 --Planting Pixie
+160015030 3 --Pure Love Angel
+160015031 3 --Owlchannel
+160015032 3 --Dark Effigy (Rush)
+160015033 3 --Dead End the Mad Fiend of Despair
+160015034 3 --Glacies the Snowmeister of Sacred Splendor
+160015035 3 --Darkness Doom Giant
+160015036 3 --Darkness Galactica Oblivion
+160015037 3 --Red Reboot Enhanced Boost Dragon
+160015038 3 --Celeb Rose Gossip Witch
+160015039 3 --Celeb Rose Gossip Magician
+160015040 3 --Demolition Meltdown Dragon Darkness Blasthamut
+160015041 3 --Bluegrass High Stealer
+160015042 3 --Bandiva the Ballistic Battle Ballad
+160015043 3 --Plectclive the Dynamauve Deadly Dirge
+160015044 3 --Dark Hydro Cannon Neutron Bluefin
+160015045 3 --Pitch-Dark Surging-Wave Swordsman Onimaru Kunituna
+160015046 3 --Meteor Swarm Dragon
+160015047 3 --Meteor Black Drake
+160015048 3 --Meteor Black Mars Dragon
+160015049 3 --Galflare the Skysavior Shine
+160015050 3 --Dragonic Progress
+160015051 3 --Psyquip Fusion
+160015052 3 --Miracle Pick
+160015053 3 --Autumn Leaves of Blisstopia
+160015054 3 --Wave Fusion
+160015055 3 --Raging Waves
+160015057 3 --Meteor Flare Fusion
+160015058 3 --Meteorite Dragon Nails
+160015059 3 --Companions!
+160015060 3 --Maid's Mischief
+160015061 3 --Peace & Rock n' Roll
+160015062 3 --Fish Depth Charge (Rush)
+160015063 3 --Meteorite Fall
+160015064 3 --Skysavior Wish
+160015065 3 --Star Salvation Shield
+160015066 3 --Fusion Cancel
+160015121 3 --Cyber Shark (Rush)
+160015130 3 --Pure Love Angel
+160015160 3 --Maid's Mischief
+160015166 3 --Fusion Cancel
+160016000 3 --Black Skull Dragon (Rush)
+160016001 3 --Praime Dwarf
+160016002 3 --Praime Phantomite
+160016003 3 --Interspraime
+160016004 3 --Praime Claw Girl
+160016005 3 --Praime Tractiger
+160016006 3 --Praime Bandijo
+160016007 3 --Praime Dian Keto
+160016008 3 --Transamu Praime Armor Nova
+160016009 3 --Dice Angel
+160016010 3 --Dice Demon
+160016011 3 --Dice Archswordsman
+160016012 3 --Dice Archangel
+160016013 3 --Dice Archdemon
+160016014 3 --Dice Key Caramail
+160016015 3 --Dice Key Minna
+160016016 3 --Dicemite Girl Chirori
+160016017 3 --Jointech Nesstrydar Tank
+160016018 3 --Darkness Jointech Tyrant
+160016019 3 --Electro-Lion Bande
+160016020 3 --Steam Swallow Gem-zz
+160016021 3 --Abysslayer Quintiamat
+160016022 3 --Secret Investigator Misfire
+160016023 3 --Secret Base Guardian Misshot
+160016024 3 --Sevens Fear Magician
+160016025 3 --CAN - St:D
+160016026 3 --Jinzo #7.7
+160016027 3 --Jinzo - Returner (Rush)
+160016028 3 --Jinzo the Machine Menace (Rush)
+160016029 3 --Jinzo - Amplified
+160016030 3 --Catapult Baby Turtle
+160016031 3 --Animagica Witch
+160016032 3 --Obnoxious Celtic Guard (Rush)
+160016035 3 --Mist Assassin
+160016036 3 --Deity of Seven Treasures - Ryozai
+160016037 3 --Praime Pierce Giant
+160016038 3 --Praime Cat Straynya
+160016039 3 --Transamu Praime Full Armor Nova
+160016040 3 --Transamuvelgr Rainac
+160016041 3 --Jointech Tridynabase
+160016042 3 --Super Graphagas Archer
+160016043 3 --Prophecy Flail of the Colors of the Wind, Butterflies and Flowers
+160016044 3 --Celeb Rose Influencers
+160016045 3 --Murin Duke the Shadow Flower Wave
+160016046 3 --Nelkrita the Skysavior Hadal
+160016047 3 --Swift Gaia the Dragon Champion
+160016048 3 --Praime Call
+160016049 3 --Graceful Dice (Rush)
+160016050 3 --Dice of Greed
+160016051 3 --The Secret of Manifestation
+160016052 3 --Abysskite Mapping
+160016053 3 --Secret Alteration
+160016054 3 --Secret Investigation Mobile Thunderbird
+160016055 3 --Royal Rebel's King's Return
+160016056 3 --Accelerator
+160016057 3 --Machine Inspector
+160016058 3 --Jointech Joint
+160016059 3 --Threat from Outer Space
+160016060 3 --De-Spell (Rush)
+160016061 3 --Abysskite Ray Monochrome
+160016062 3 --Skull Dice (Rush)
+160016063 3 --Asura Dice
+160016064 3 --Fusionic Defense
+160016065 3 --Secret File 3000 - Final Tragedy
+160016066 3 --Sunset Rebirth
+160016116 3 --Dicemite Girl Chirori
+160016131 3 --Animagica Witch
+160016158 3 --Jointech Joint
+160016159 3 --Threat from Outer Space
+160201001 3 --Kimeruler the Dark Raider
+160201002 3 --Umegumi the Ruler's Squad
+160201003 3 --Yurushima Sage
+160201004 3 --Yurushima Warrior
+160201005 3 --Blue Falcon Tengu
+160201006 3 --Yurushima the Hermit
+160201007 3 --Masaki the Legendary Samurai
+160201008 3 --Crying Moon Rabbit
+160201010 3 --Bonded Bowing
+160201011 3 --Block Attack (Rush)
+160201012 3 --Powerful Pierce!!
+160201013 3 --Scroll of Salutation
+160201014 3 --Hermit's Soul
+160201015 3 --Royal Rebel's Invasion
+160201016 3 --Royal Rebel's Growl
+160201017 3 --Royal Rebel's Rocker
+160201018 3 --Royal Rebel's Shout
+160201019 3 --Palace Gargoyle
+160201020 3 --Followl of the Dark Wisdom
+160201021 3 --Garmr the Lone Wolf
+160201022 3 --Babysitter Goat
+160201023 3 --Royal Rebel's Fanatic
+160201024 3 --King's Reward
+160201025 3 --Genie's Fire Breath
+160201026 3 --King's Majesty
+160201027 3 --Rebel's Scream
+160201028 3 --Folder Blitz the Infinite Dream
+160201029 3 --Berry Bassist
+160201030 3 --Telepathic Agent
+160201031 3 --Amusi Performer
+160201032 3 --Psy Stage Bouncer
+160201033 3 --Concert Costume Creator
+160201034 3 --Keytar Kid
+160201035 3 --Howlingbird
+160201036 3 --Elepsychic Amp Up
+160201037 3 --Psychic Divergence
+160201038 3 --Climax Finale
+160201039 3 --Psychic Introduction
+160201040 3 --Severing Psychic Wall
+160202001 3 --Supreme Machine Magnum Overlord [L]
+160202002 3 --Supreme Machine Magnum Overlord
+160202003 3 --Supreme Machine Magnum Overlord [R]
+160202004 3 --Kuribot
+160202005 3 --Kuribotriple
+160202006 3 --Silent Learning
+160202007 3 --Cranked to Ten!!
+160202008 3 --Magiquartet Shock
+160202009 3 --Widening Whisper
+160202010 3 --Yggdrago the Sky Emperor [L]
+160202011 3 --Yggdrago the Sky Emperor
+160202012 3 --Yggdrago the Sky Emperor [R]
+160202013 3 --Peacock Picotron
+160202014 3 --Femtron
+160202015 3 --Attron
+160202016 3 --Zeptron
+160202017 3 --Yoctron
+160202018 3 --Pair Production
+160202020 3 --Quantum Hole
+160202021 3 --Clean Beret - Colonel Mop
+160202022 3 --Scrubbing Santa Cloth
+160202023 3 --Washsprayer the Cleansketeer
+160202024 3 --Bleach Mortar
+160202025 3 --Odd-Eyes Twin Tail Cat
+160202026 3 --Red-Eyes Black Cat
+160202027 3 --Blue-Eyes White Cat
+160202028 3 --Cat's Eye
+160202029 3 --Lost Cat
+160202030 3 --Thunderbeetle Bassdrum
+160202031 3 --Thunderbeetle Highhat
+160202032 3 --Thunderbeetle Snare
+160202033 3 --Thunderbeetle Gift
+160202034 3 --Thunderbeetle Storm
+160202035 3 --Thunderbeetle Boost
+160202036 3 --Throne of Darkness
+160202037 3 --Dahut, Dark Ruler of the Chair
+160202038 3 --Scarechair Gear
+160202039 3 --Scarechair Bone
+160202040 3 --Scarechair Saber
+160202041 3 --Collapsing Chairs
+160202042 3 --Cosmic String Noodryad
+160202043 3 --Galaxy Topping Troll
+160202044 3 --Cosmoscallion
+160202045 3 --Big Bang Egger
+160202046 3 --Outer Space
+160202047 3 --Chashooting Star
+160202049 3 --Shrinker Shrimp
+160202050 3 --Heavenly Gift
+160203001 3 --Supreme Skystream Magnum Overlord [L]
+160203002 3 --Supreme Skystream Magnum Overlord
+160203003 3 --Supreme Skystream Magnum Overlord [R]
+160203004 3 --Emergency Return
+160203005 3 --Dynamic Dino Dynarmix [L]
+160203006 3 --Dynamic Dino Dynarmix
+160203007 3 --Dynamic Dino Dynarmix [R]
+160203008 3 --Sneezing Greedizauls
+160203009 3 --Mech Therizinoraptor
+160203010 3 --Ritzy King Rex
+160203011 3 --Supressaurus Sternptera
+160203012 3 --Uraby (Rush)
+160203013 3 --Celebrontosaurus
+160203014 3 --Platnidon
+160203015 3 --Jurassic World (Rush)
+160203016 3 --Coevolutionary Miracle
+160203017 3 --Dinosaur Crush
+160203019 3 --Ascending Evolution
+160203020 3 --Dinomic Pressure
+160203021 3 --Seedchrotron Brusselun
+160203022 3 --Cycliptron
+160203024 3 --Dahut Abyss, Dark Mirror Ruler of the Chair
+160203025 3 --Scarechair Relaxer
+160203026 3 --Scarechair Scale
+160203027 3 --Darkness Ri-chair-al
+160203028 3 --Joining Chairs
+160203029 3 --Constructor Demolisher Wyrm Drake Crush
+160203030 3 --Silvermountain of Blisstopia
+160203031 3 --Constructor Art - Buildestruction
+160203032 3 --Hammer Crush
+160203033 3 --Constructor Resurrection
+160203034 3 --Clubinet the Music Princess
+160203035 3 --Horn Knives the Music Princess
+160203036 3 --Straight Pierce
+160203037 3 --Music Princess's Whirling Wind
+160203038 3 --Music Princess Art - Triplet
+160203039 3 --Agariel, the Finest Sushi Fairy
+160203040 3 --Dragon Roll the Sushi Fairy
+160203041 3 --Tiger Roll the Sushi Fairy
+160203042 3 --Monkey Roll the Sushi Fairy
+160203043 3 --Spider Roll the Sushi Fairy
+160203044 3 --Inside Out Roll
+160203045 3 --Angel Judge
+160203046 3 --Rolled Sticky Save
+160203047 3 --Rolled Hot Arrow
+160203048 3 --Startup Goblin
+160203049 3 --Heavenly Revelation
+160203050 3 --Turnback Shot
+160204001 3 --Metarion Ashurastar
+160204002 3 --Metarion Vritrastar
+160204003 3 --Metarion Eraclestar
+160204004 3 --Metarion Ladonstar
+160204005 3 --Fire Jester
+160204006 3 --Imaginary Actor
+160204007 3 --Glaciasaurus
+160204008 3 --Serpainter
+160204009 3 --Sword Dancer
+160204010 3 --Magic Juggler
+160204011 3 --Imaginary Arc Turbo
+160204012 3 --Imaginary Arc Tower
+160204013 3 --Imaginary Arc Turbulence
+160204014 3 --Imaginary Arc Turnback
+160204015 3 --Sevens Paladin
+160204016 3 --Whispark Fairy Girl
+160204017 3 --Straynge Cats
+160204018 3 --Kuribotorero
+160204019 3 --Kuribot
+160204020 3 --Mr. Alchemy
+160204021 3 --Swordsman of Roadstar
+160204022 3 --Hyperstrike Dragon Dragiastar F
+160204023 3 --Full Moon Dragon Umbralancer F
+160204024 3 --Sportsdragon Kickbase Master
+160204025 3 --The Wyvern
+160204026 3 --The Dragon
+160204027 3 --The Power Up
+160204028 3 --The Barrier
+160204029 3 --Amusi Howling Performer
+160204030 3 --Chemical Cure Purple
+160204031 3 --Chemical Cure Red
+160204032 3 --Red Medicine
+160204033 3 --Kengo Shogun of the Crescent Moon
+160204034 3 --Fearstute Followl
+160204035 3 --Permillind Hicrotron
+160204036 3 --Winged Celestial Dragon of Weal and Woe
+160204037 3 --Hyper Upstart King Rex
+160204038 3 --Worker Warrior - Sinister Chairman
+160204039 3 --Worker Warrior - Overhauled Organizer
+160204040 3 --Labyrinth Tank (Rush)
+160204041 3 --Cannon Soldier (Rush)
+160204042 3 --Giga-Tech Wolf (Rush)
+160204043 3 --Ether Seeker
+160204044 3 --Priestess of Star Salvation
+160204045 3 --Star Restart
+160204046 3 --Yami (Rush)
+160204047 3 --Spectral Swords of the Everloyal Guard
+160204050 3 --Fusion
+160204051 3 --Fusion
+160205002 3 --Galactica Oblivion
+160205003 3 --Sevens Road Magician
+160205004 3 --Supreme Machine Magnum Overlord [L]
+160205005 3 --Supreme Machine Magnum Overlord
+160205006 3 --Supreme Machine Magnum Overlord [R]
+160205007 3 --Doomblaze Fiend Overlord Despairacion [L]
+160205008 3 --Doomblaze Fiend Overlord Despairacion
+160205009 3 --Doomblaze Fiend Overlord Despairacion [R]
+160205010 3 --Blaze Fiend Overlords Beelucitaroth [L]
+160205011 3 --Blaze Fiend Overlords Beelucitaroth
+160205012 3 --Blaze Fiend Overlords Beelucitaroth [R]
+160205013 3 --Guide of the Blaze Fiends
+160205014 3 --Rage Serpent of the Blaze Fiends
+160205015 3 --Return of the Blaze Fiends
+160205016 3 --Corruption of the Blaze Fiends
+160205017 3 --Resurrection of the Blaze Fiends
+160205018 3 --Doomblaze Despair
+160205019 3 --Cyber End Dragon (Rush)
+160205020 3 --Cyber Twin Dragon (Rush)
+160205021 3 --Cyber Rush Dragon
+160205022 3 --Cyber Assault Dragon
+160205023 3 --Cyber Stealth Dragon
+160205024 3 --Cyber Dragon (Rush)
+160205025 3 --Cyber Gryphon
+160205026 3 --Proto-Cyber Dragon (Rush)
+160205027 3 --Cyber Serpent
+160205028 3 --Evolution Rush Burst
+160205029 3 --Cyber Entry
+160205030 3 --Multiple Adapter Unit
+160205031 3 --Excutie Lumiere
+160205032 3 --Excutie Leir
+160205033 3 --Excutie Floa
+160205034 3 --Excutie Lilius
+160205035 3 --Excutie Lucy
+160205036 3 --Excutie Ram
+160205037 3 --Excutie Prouty
+160205038 3 --Excutie Scout!
+160205039 3 --Excutie Scramble!
+160205040 3 --Excutie Emergency!
+160205041 3 --Excutie Catch!
+160205042 3 --Excutie Break!
+160205043 3 --Galactiara Eve
+160205044 3 --Jointech Stegosilos
+160205045 3 --H.D.D. - Hundred Divine Dragon
+160205046 3 --Finalize Phoenix
+160205047 3 --Voidvelgr Apocalypse
+160205048 3 --Dark Prophet
+160205049 3 --Destroyer of Dragon Sorcerers
+160205050 3 --Ultimate Flag Beast Lead Unicorn
+160205051 3 --Double Twin Dragon
+160205052 3 --Yamiruler the Dark Delayer - Supreme Soldier Spear
+160205053 3 --CAN - I:D
+160205054 3 --Future Aeromancer
+160205055 3 --Beast Gear Emperor Glider Fox
+160205056 3 --Rage Wrecker Dragon Angerogue
+160205057 3 --Almastra XI - Aquarius
+160205058 3 --Magic Mirror Youth
+160205059 3 --Rising Soldier
+160205060 3 --Cobalt Cobolt
+160205061 3 --Delirium Lampyris
+160205062 3 --Love Angel
+160205063 3 --Valkyrian Call
+160205064 3 --Saturnius' Orb
+160205065 3 --Heavenly Selection
+160205066 3 --Valkyrian Guard
+160205067 3 --Word Working
+160205068 3 --Dragonlion Pit Trap
+160205107 3 --Doomblaze Fiend Overlord Despairacion [L]
+160205108 3 --Doomblaze Fiend Overlord Despairacion
+160205109 3 --Doomblaze Fiend Overlord Despairacion [R]
+160205119 3 --Cyber End Dragon (Rush)
+160205120 3 --Cyber Twin Dragon (Rush)
+160205121 3 --Cyber Rush Dragon
+160205131 3 --Excutie Lumiere
+160205132 3 --Excutie Leir
+160205133 3 --Excutie Floa
+160205143 3 --Galactiara Eve
+160205144 3 --Jointech Stegosilos
+160205145 3 --H.D.D. - Hundred Divine Dragon
+160205146 3 --Finalize Phoenix
+160205147 3 --Voidvelgr Apocalypse
+160205149 3 --Destroyer of Dragon Sorcerers
+160205151 3 --Double Twin Dragon
+160205152 3 --Yamiruler the Dark Delayer - Supreme Soldier Spear
+160205153 3 --CAN - I:D
+160205157 3 --Almastra XI - Aquarius
+160205159 3 --Rising Soldier
+160206000 3 --Meteor Black Dragon (Rush)
+160206001 3 --Five-Headed Dragon (Rush)
+160206003 3 --Great-Tusked Mammoth
+160206004 3 --Maju Garzett (Rush)
+160206005 3 --Legend Magician
+160206006 3 --Pot of Arrogance
+160206007 3 --Legendary Swordsman - Buster Blader
+160206009 3 --Archfiend Warrior
+160206010 3 --Legend Saber
+160206011 3 --Goddess of Whimsy
+160206012 3 --Magician's Curtain
+160206013 3 --The Origin Stone of Legend
+160206016 3 --Steel Steed Martin Vinary
+160206017 3 --Hyozanryu (Rush)
+160206020 3 --Nimble Lemming
+160206021 3 --Embryonic Dark Ruler
+160206023 3 --Eve of the Big March
+160206024 3 --Dragon Tribe Fusion
+160206026 3 --Primordial Slash
+160206027 3 --Return (Rush)
+160206029 3 --Meteor Dragon (Rush)
+160206031 3 --Melchid the Four-Face Beast (Rush)
+160206032 3 --Grand Tiki Elder (Rush)
+160206033 3 --Goblin Holedigger Captain
+160206034 3 --Class-Change Mirror
+160206035 3 --Rogue of Archfiend
+160206036 3 --Master Craftsman Kotetsu
+160206037 3 --Witness of Dragon Destroyer
+160206038 3 --Slot Machine PG-7
+160206039 3 --Trap Mole
+160206040 3 --Malevolent Seller
+160206041 3 --Flapun
+160206043 3 --Cursed Sword of the East
+160206044 3 --Masenkou, the Lashing Light
+160206045 3 --Helmet of the Master Craftsman
+160207001 3 --Supreme Fullsteam Magnum Overlord [L]
+160207002 3 --Supreme Fullsteam Magnum Overlord
+160207003 3 --Supreme Fullsteam Magnum Overlord [R]
+160207004 3 --Supreme Wildgleam Magnum Overlord [L]
+160207005 3 --Supreme Wildgleam Magnum Overlord
+160207006 3 --Supreme Wildgleam Magnum Overlord [R]
+160207007 3 --Supreme Skystream Magnum Overlord [L]
+160207008 3 --Supreme Skystream Magnum Overlord
+160207009 3 --Supreme Skystream Magnum Overlord [R]
+160207013 3 --Abyssal Dragon Lord Abyss Poseidra [L]
+160207014 3 --Abyssal Dragon Lord Abyss Poseidra
+160207015 3 --Abyssal Dragon Lord Abyss Poseidra [R]
+160207016 3 --Abyssal Sea Dragon Abyss Kraken [L]
+160207017 3 --Abyssal Sea Dragon Abyss Kraken
+160207018 3 --Abyssal Sea Dragon Abyss Kraken [R]
+160207019 3 --Shinesteel Ultra Dragon Devastar Okeabyss [L]
+160207020 3 --Shinesteel Ultra Dragon Devastar Okeabyss
+160207021 3 --Shinesteel Ultra Dragon Devastar Okeabyss [R]
+160207022 3 --Supreme Dog Ropero
+160207024 3 --Super Electromagnetic Maximum
+160207026 3 --B.B.B. - Beast Brave Brandish
+160207028 3 --Abysslayer Apsaras
+160207029 3 --Abysslayer Makara
+160207030 3 --Abysslayer Cetus
+160207031 3 --Abysslayer Vodyanoy
+160207032 3 --Legacyrex Legarex
+160207033 3 --Darkglow Angler
+160207034 3 --Groundmaster Bathynomus
+160207036 3 --Manifestriction Dragon Maxseal
+160207037 3 --Mollusk Dragon Oumugailus
+160207039 3 --Ascending Weather Eel
+160207041 3 --Deep Sea Dragon Bat Eel
+160207042 3 --Abyss Flash
+160207046 3 --Abyss Gash
+160207047 3 --Wrath of Abyss
+160207048 3 --Abysskite Ultimail
+160207049 3 --Abysskite Prevent Wall
+160207050 3 --Abysskite Protection
+160207054 3 --Heavenly Invitation
+160207055 3 --Radiant Mirror Force (Rush)
+160207059 3 --Steel Mech Lord Mirror Innovator
+160208001 3 --Harpie Lady Sisters [L]
+160208002 3 --Harpie Lady Sisters
+160208003 3 --Harpie Lady Sisters [R]
+160208004 3 --Harpie Lady 1 (Rush)
+160208005 3 --Harpie Lady 2 (Rush)
+160208006 3 --Harpie Lady 3 (Rush)
+160208008 3 --Harpie Regina
+160208009 3 --Harpie Carla
+160208010 3 --Harpie's Pet Dragon (Rush)
+160208012 3 --Harpie's Full Dress
+160208013 3 --Triangle Ecstasy Spark (Rush)
+160208014 3 --Elegant Egotist (Rush)
+160208016 3 --Harpie's Feather Tempest
+160208018 3 --Divinebreath the Orchestral Music Fiend
+160208019 3 --Full Orchestra the Music Fiend
+160208020 3 --Axetion Melody the Music Princess
+160208022 3 --Trumpetiger the Music Fiend
+160208024 3 --Sansetsukontra the Music Fiend
+160208025 3 --Tubardiche the Music Princess
+160208027 3 --Ophiclaymore the Music Princess
+160208031 3 --Boton the Music Princess
+160208033 3 --Music Princess's Dance
+160208034 3 --Music Princess's Requiem
+160208035 3 --Tiger Glare
+160208036 3 --Destruction of the Universe
+160208037 3 --Giant Tiger Strike
+160208038 3 --Demolition Charge Dragon Dangerous Blasthamut
+160208039 3 --Demolition Charge Expert Warning Heavy Shock
+160208040 3 --Demolition Dragon Blasthamut
+160208041 3 --Demolition Soldier Kasetsu Baiten
+160208042 3 --Constructor Sentry Dragline
+160208043 3 --Demolition Soldier Hell Met
+160208044 3 --Constructor Wyrm Buildragon
+160208046 3 --Demolition Soldier Toby Shock
+160208047 3 --Demolition Soldier Sakan Yasan
+160208048 3 --Demolition Soldier High Kanko
+160208051 3 --Demolition Sword Constructedea
+160208052 3 --Demolition Shutter
+160208053 3 --Demolition Survey
+160208057 3 --Demolition Barricade
+160208058 3 --Demolition Art - Absolute Destruction
+160208059 3 --Gold Rush
+160209001 3 --Lightning Volteagle
+160209002 3 --Thunderbold, the Echoing Thunder
+160209003 3 --Lightning Voltkite
+160209005 3 --Flash Voltchick
+160209006 3 --Spark Voltegg
+160209012 3 --Accel Wonder Light
+160209013 3 --Ultimate Flag Beast Bolt Tricorn
+160209015 3 --Cyc the Child of Wind
+160209016 3 --Furtunate Cat
+160209018 3 --High Magic - Double Acceleration
+160209019 3 --Straynge Gathering
+160209020 3 --Straynge Cat Signal
+160209021 3 --Lightning Voltcharge
+160209024 3 --Straynge Cat Jealousy
+160209025 3 --Multistrike Dragon Dragias
+160209026 3 --Dragonic Demolisher
+160209028 3 --Dragonic Scout
+160209029 3 --Twin Edge Fire Dragon
+160209031 3 --Draco the Hand-Sewn
+160209032 3 --Gias x Gias
+160209033 3 --7 Shift
+160209034 3 --Dragonic Force
+160209036 3 --The Guard
+160209037 3 --The Block
+160209038 3 --Undulating Barrier
+160209039 3 --Descending Dragon of Clear Water
+160209040 3 --Kimeterasu the Divine Ruler
+160209042 3 --Hagoromo the Cloudle-Handling Celestial Seamstress
+160209043 3 --Yamiruler the Dark Delayer
+160209046 3 --Yamiluna the Dark Supporter
+160209047 3 --Koi of Winter Wonder
+160209048 3 --Shield in the Right Hand
+160209049 3 --Sword in the Left Hand
+160209050 3 --Seyanen the Combustion Commander
+160209052 3 --Kibatsu the Cutting Edge Deity
+160209054 3 --Resolve
+160209055 3 --Divine Transformation
+160209057 3 --Dark Ruler Battlegear
+160209059 3 --Vi-FRND
+160209060 3 --Prima Guitarna the Shining Superstar
+160209061 3 --Ordoll the Adorable Audio Idol
+160209062 3 --Star's Hand Director
+160209063 3 --Star's Hand Illuminator
+160209064 3 --Star's Hand Roadie
+160209066 3 --Psykickoff Concert
+160209067 3 --My Patience Has Run Out!
+160209068 3 --Shining Superstar Riff
+160209069 3 --Psychicomposition
+160209070 3 --Dream Ticket
+160209071 3 --Major Audition
+160209072 3 --Raging Rock
+160209073 3 --Lullalabind
+160209074 3 --True Beast Gear King Liogon
+160209075 3 --True Beast Gear Emperor Kong
+160209078 3 --Apocalypse - Beast Over World
+160209080 3 --Dark Sword Magician
+160209081 3 --Obsidian Magical Soldier
+160209082 3 --Mature Dark Magician
+160209083 3 --Jewel of the Dark Magician
+160209084 3 --Spellbook Rejection
+160209085 3 --Spell Extraction
+160209088 3 --Magician's Sense
+160209132 3 --Gias x Gias
+160210002 3 --Royal Rebel's Heavy Metal
+160210014 3 --Charis Magic Scepter - Death Wand
+160210017 3 --Royal Rebel's Progressive
+160210018 3 --Harpie Lady Pet Master
+160210019 3 --Voidvelgr Chaosmachia
+160210020 3 --Black Dragon Skull Archfiend
+160210021 3 --Engine of Destruction
+160210022 3 --Celeb Revelation
+160210023 3 --Skull Archfiend of Armageddon
+160210027 3 --Gravitiara Ai
+160210028 3 --Magical Retribution
+160210035 3 --Dark Executor Warlock
+160210036 3 --Blaze Fiend Overlord Luciless
+160210037 3 --Super Galaxy King Lord of Galactica [L]
+160210038 3 --Super Galaxy King Lord of Galactica
+160210039 3 --Super Galaxy King Lord of Galactica [R]
+160210040 3 --Abysskite Miracle Girls
+160210041 3 --Etraynze the Shadow Flower Restricter
+160210042 3 --Conduction Warrior Alchemicalizer Suirai
+160210046 3 --Celeb Rose Warlock
+160210048 3 --Royal Rebel's Elite Amp
+160210049 3 --Legend Magician
+160210050 3 --Celeb Rose Enchanter
+160210053 3 --Abysskite Party
+160210055 3 --Abysskite Violate Halo
+160210064 3 --Super Assistant Hiya
+160210065 3 --Super Assistant Biri
+160210067 3 --Shadow Flower Dance
+160210070 3 --Splendid Slash
+160210072 3 --Flower Fan Clematis
+160210073 3 --Eternal Wolf of the Blaze Fiends
+160210074 3 --Royal Rebel's Grunge
+160210075 3 --Twin Twinkle Star
+160210076 3 --Galacterial Pick
+160210077 3 --Soul Knight
+160210078 3 --Royal Rebel's Guardian
+160210081 3 --Abysspiny Turtle
+160210082 3 --Shining Shamaness
+160210083 3 --King's Greed
+160210084 3 --Magical Firestorm
+160210085 3 --Voidvelgr Morgenstein
+160210086 3 --Celeb Blade - Death Wild
+160210087 3 --Celeb Robe - Death Wind
+160210088 3 --King's Authority
+160211001 3 --Dark Magician Girl (Rush)
+160301001 3 --Sevens Road Magician
+160301002 3 --Torna the Windweaver
+160301003 3 --Ansler the Magical Swordsman
+160301004 3 --Hydro Magician
+160301005 3 --Dark Sorcerer
+160301006 3 --Mystic Dealer
+160301007 3 --Magical Beast Wolfang
+160301008 3 --Spell Archer
+160301009 3 --Shining Shaman
+160301010 3 --Straynge Cat
+160301011 3 --Wind Spirit's Protection
+160301012 3 --Magical Stream
+160301013 3 --Dark Revelation
+160301014 3 --Curtain of Sparks
+160302001 3 --Multistrike Dragon Dragias
+160302002 3 --Gravity Press Dragon
+160302003 3 --Fire Guardian
+160302004 3 --Dragon Knight of Darkness
+160302005 3 --Dragorite
+160302006 3 --Twin Edge Dragon
+160302007 3 --Dragon's Sage
+160302008 3 --Dragon Bat
+160302009 3 --Phoenix Dragon
+160302010 3 --Draco the Tiny
+160302011 3 --Dragonic Pressure
+160302012 3 --Dragon's Inferno
+160302013 3 --Dragon Encounter
+160302014 3 --Vengeful Dragon's Counterattack
+160303009 3 --Accel Wonder Splat
+160303010 3 --Accel Wonder Flare
+160303013 3 --Aqua Sorcerer
+160303019 3 --Amazing Dealer
+160303032 3 --Mystery Handcuffs
+160304003 3 --Sportsdragon Closer
+160304012 3 --Sylphidra
+160304022 3 --Stop Defense (Rush)
+160304023 3 --Sportsdragon Connection
+160304030 3 --Dragonic Disorder
+160305006 3 --Matsugumi the Ruler's Squad
+160305015 3 --Hero of the Yeast
+160305027 3 --Bowing Brotherhood
+160305030 3 --Ruler's Dance
+160306003 3 --Giftarist
+160306009 3 --Peace Holder
+160306012 3 --Dream Drummer
+160306026 3 --Psychic Trap Hole
+160307002 3 --Asbolus the Star Knight
+160307004 3 --Followl of the Fornether
+160307009 3 --Nessus the Star Knight
+160307026 3 --King's Right
+160308004 3 --Sigurstate Sol
+160308005 3 --Berceptacle Mani
+160308009 3 --Connector Dog
+160308015 3 --Particle Acceleration
+160309010 3 --Constructor Fighter Mixer
+160309011 3 --Coiled Dragon of Destruction
+160309017 3 --Constructor Engineer Draftannium
+160309021 3 --Barrier Armordillo
+160309027 3 --Vegetation of Blisstopia
+160310009 3 --Tribute Doll (Rush)
+160310010 3 --Ancient Rules (Rush)
+160311002 3 --Universe Dea
+160311003 3 --Cosmo Titan
+160311004 3 --Galactica Amnesia
+160311005 3 --Rebirth Cycle
+160311006 3 --Heaven Gancel
+160311007 3 --Silver Seyfert
+160311008 3 --Meteorhino
+160311009 3 --Strange Traveler
+160311011 3 --Bright Sentinel
+160311012 3 --Shadow Sentinel
+160311013 3 --Vortex Shooter
+160311014 3 --Giant Bulge
+160311015 3 --Orbit Skater
+160311016 3 --Sorapuyo
+160311017 3 --Transamu Craione
+160311018 3 --Interstellime
+160311019 3 --Asteroeva
+160311022 3 --Galactica Force
+160311025 3 --Universtorm
+160311026 3 --Vacua Annihilation
+160311028 3 --Transamu Arrive
+160311030 3 --Nebula Power
+160312006 3 --Gadget Soldier (Rush)
+160312008 3 --Elephound
+160312010 3 --Jointech Ace
+160312012 3 --Flare Sorcerer
+160312018 3 --Lightning Braver
+160312021 3 --Cliptera
+160312023 3 --Tamabot
+160312028 3 --Tribute Lock
+160312030 3 --Jointech Bumper
+160313001 3 --Vanishing Heliacal Riser
+160313006 3 --Cosmo Aurorizer
+160313011 3 --Transamu Jerai
+160313019 3 --Galactica Jamais Vu
+160313020 3 --Konpeitrion
+160313024 3 --Galactica Repulsion
+160313030 3 --Galactica Lattice
+160313032 3 --Nova Spark
+160314001 3 --Jointech Tossceratops
+160314009 3 --Corktrooper
+160314010 3 --Pantula
+160314012 3 --Ground Attacker Bugroth (Rush)
+160314014 3 --Carpendra
+160314018 3 --Forkhawk
+160314020 3 --Craftroll
+160314021 3 --Stud Hedgepeg
+160314022 3 --Screw Armadillo
+160314030 3 --Thunder Spark
+160315001 3 --Red Boot Boost Dragon
+160315008 3 --Dual Coretls
+160315011 3 --Beta Burn Dragon
+160315012 3 --Applizard
+160315020 3 --SSD Drake
+160315022 3 --Dragosite
+160315024 3 --Alpha Burn Drake
+160315029 3 --Dragon's Peak
+160315032 3 --RB Draphone
+160316001 3 --Analyze Phlogiston
+160316008 3 --Flame Cerebrus (Rush)
+160316010 3 --Flame Champion (Rush)
+160316013 3 --Barrier Statue of the Inferno (Rush)
+160316015 3 --Doctor Red Robe
+160316016 3 --Flame Seeker
+160316017 3 --Methyl the Flame Jinn of the Lamp
+160316018 3 --Ethyl the Flame Jinn of the Lamp
+160316023 3 --Super Assistant Achi
+160316028 3 --Scales of Flame
+160316032 3 --Fire Fall Blaze Barrier
+160317001 3 --Voidvelgr Elysium
+160317007 3 --Voidvelgr Hecatoncheir
+160317012 3 --Voidvelgr Pale Rider
+160317013 3 --Voidvelgr Hoplites
+160317014 3 --Dimension Others
+160317015 3 --Voidvelgr Globule
+160317018 3 --Voidvelgr Meteon
+160317019 3 --Meteorlarva
+160317020 3 --Voidvelgr Peltast
+160317021 3 --Void Corridor
+160317028 3 --Void Intercept
+160317029 3 --Void Veil
+160319001 3 --Blue-Eyes Ultimate Dragon (Rush)
+160319003 3 --Blue-Eyes Bright Dragon
+160319004 3 --Blue-Eyes Vision Dragon
+160319005 3 --Absolute Lord of D.
+160319006 3 --Node of Legend
+160319007 3 --Soul Drake
+160319008 3 --Phoenix Dragoon
+160319014 3 --Light Effigy (Rush)
+160319027 3 --The Ultimate Blue-Eyed Legend
+160319028 3 --Sanctum of Legend
+160319035 3 --Treasure of Eyes of Blue
+160401001 3 --Sevens Road Witch
+160401002 3 --Cosmic String Noodryad
+160401003 3 --Constructor Wyrm Buildragon
+160401004 3 --CAN:D
+160401005 3 --Kimeluna the Dark Shifter
+160401006 3 --CAN:D LIVE
+160401007 3 --Sevens Road Witch
+160401008 3 --Magical Sheep Girl Meeeg-chan
+160401009 3 --Prophecy Phrase of the Colors of the Wind
+160401010 3 --Cat Claw Girl
+160401011 3 --Machvio of the Ultimate Aria
+160401012 3 --Celeb Rose Magician
+160401013 3 --Celeb Rose Witch
+160402001 3 --Road Magic - Explosion
+160402002 3 --Righteous Dragon
+160402003 3 --Road Magic - Flowback
+160402004 3 --Royal Rebel's Blues
+160402005 3 --Bascule the Moving Fortress
+160402006 3 --Raidacross, Hero of the Dusk
+160402007 3 --Kumamon
+160402008 3 --Ultimate Flag Beast Cannon Rhino
+160402009 3 --The Star Dragon
+160402010 3 --Mach Mega Falcon
+160402011 3 --Douma the Talismanic Supreme Sage
+160402012 3 --Handsray Destleo
+160402013 3 --Unknown Flyleon
+160402014 3 --Pelion the Star Knight
+160402015 3 --Direct Dive Dragon
+160402016 3 --Rice Terrace Secure
+160402017 3 --Headhunters' Jaguar
+160402018 3 --Voidvelgr Transi
+160402019 3 --Drilling Tractiger
+160402020 3 --Combustion Oni Bunsel
+160402021 3 --Jointech Raptor
+160402022 3 --Cyber Search Dragon
+160402023 3 --Hacking Dragon
+160402024 3 --Transamu Raiker
+160402025 3 --Plectcrime of the Deadly Dirge
+160402026 3 --Deepsea Hunter
+160402027 3 --Satellite Soldier
+160402028 3 --Light Sorcerer of Sanctity
+160402029 3 --Defrostrooper
+160402030 3 --Fusionic Revivern
+160402031 3 --The Trinity Dragiastar
+160402032 3 --Straynge Cat Magician
+160402033 3 --Ecliceras Drakon
+160402034 3 --Cul-de-sac the Faceless
+160402035 3 --Jespell Wizard
+160402036 3 --Transamu Scraied
+160402037 3 --Voidvelgr God Requiem
+160403001 3 --Gaia The Fierce Knight (Rush)
+160403002 3 --Dian Keto the Security Master
+160404002 3 --Black Dragon's Chick (Rush)
+160404003 3 --Inferno Fire Blast (Rush)
+160405001 3 --Volcano Attack Dragon
+160405002 3 --Burst Breath of Destruction
+160405003 3 --Dragon's Fortitude
+160406001 3 --Celtic Guardian (Rush)
+160406002 3 --Cyber Falcon (Rush)
+160406003 3 --Necromaid Nana
+160406004 3 --Psychic Burial
+160406005 3 --Cure Shot
+160406006 3 --Mokey Mokey (Rush)
+160406007 3 --Shovel Crusher (Rush)
+160406008 3 --Gokibore (Rush)
+160406009 3 --Sky Dragon (Rush)
+160406010 3 --Ancient Telescope (Rush)
+160407001 3 --Amabie (Rush)
+160408001 3 --Sevens Road Warlock
+160408002 3 --Triad Drago
+160409001 3 --Nullstrike Dragon Zerogias
+160409002 3 --Cladsoul Dragon Gaigias
+160409003 3 --Void Strike Dragon Zerogaigias
+160409004 3 --Galactica Reminiscence
+160409005 3 --Transamu Rainac Overwrite
+160409006 3 --Transamu Valuable Rainac
+160409011 3 --Accel Wonder Pebble
+160409012 3 --Star Tri-Leo
+160410001 3 --Sevens Road Magician
+160410002 3 --Multistrike Dragon Dragias
+160410003 3 --Sevens Road Witch
+160410004 3 --Illusion Strike Dragon Miragias
+160411001 3 --Ultimate Flag Mech Ace Breaker
+160411002 3 --Dark Magician Girl (Rush)
+160412001 3 --Dian Keto the Cure Master (Rush)
+160412002 3 --Yuri the Shadow Flower Fiend
+160412003 3 --Stardom Light
+160412004 3 --Constructor Sword Foreman
+160412005 3 --Trumpet Charge
+160412006 3 --Volcanic Rat (Rush)
+160412007 3 --Tristegatops
+160412008 3 --Tyhone (Rush)
+160412009 3 --Bean Soldier (Rush)
+160412010 3 --Tyhone #2 (Rush)
+160413001 3 --Nightbringer Dragon
+160414001 3 --Ultimate Flag Beast Surge Bicorn
+160414002 3 --Cosmo Predictor
+160415001 3 --Ultimate Flag Mech Tough Striker
+160415002 3 --Ultimate Flag Beast Avant Wolf
+160415003 3 --Ultimate Flag Beast Aim Eagle
+160416001 3 --Sevens Road Magician
+160416002 3 --Sevens Road Witch
+160416003 3 --Sevens Road Mage
+160416004 3 --Sevens Road Warlock
+160416005 3 --Kuribot
+160416006 3 --Kuribot
+160416007 3 --Kuribot
+160418002 3 --Sevens Road Enchanter
+160419001 3 --Flame Swordsman (Rush)
+160419002 3 --Cyber Soldier of Darkworld (Rush)
+160419003 3 --Heavy Roller
+160419006 3 --Haniwaffle
+160419007 3 --Flame Manipulator (Rush)
+160419008 3 --The All-Seeing White Tiger (Rush)
+160419009 3 --Masaki the Legendary Swordsman (Rush)
+160419010 3 --Spike Seadra (Rush)
+160420001 3 --Donpen & Donko
+160421001 3 --Sevens Road Magician
+160421002 3 --Multistrike Dragon Dragias
+160421003 3 --Prima Guitarna the Shining Superstar
+160421004 3 --Yamiruler the Dark Delayer
+160421005 3 --Royal Rebel's Heavy Metal
+160421006 3 --Yggdrago the Sky Emperor
+160421007 3 --Constructor Wyrm Buildragon
+160421008 3 --Ultimate Flag Mech Gold Rush
+160421009 3 --Ancient Arrive Dragon
+160421010 3 --CAN - Melo:D
+160421011 3 --Kimeterasu the Rising Luna
+160421012 3 --Royal Rebel's Hard Rock
+160421013 3 --Attolashoot Highdron
+160421014 3 --Infinite Constructor Wyrm Buildream
+160421018 3 --Elegant Fire Bird Harpuia
+160421019 3 --Daigyakutenno Megami
+160421020 3 --Pholus the Star Knight
+160421021 3 --Crystal Brain
+160421022 3 --Ether Finder
+160421024 3 --Secret Order
+160421027 3 --Dark Resonance Burst
+160421028 3 --Burst Stream of Destruction (Rush)
+160421029 3 --Magical Stone Excavation (Rush)
+160421030 3 --Temporary Storm Blockade
+160421031 3 --Counter Back
+160421033 3 --Heavenly Rest
+160421034 3 --Gyakutenno Megami (Rush)
+160421035 3 --Alligator's Sword (Rush)
+160421036 3 --Beaver Warrior (Rush)
+160421037 3 --Constructor Princess Pylon
+160421038 3 --Karatake the Talismanic Warrior
+160421039 3 --Unfulfilled Goblin
+160421040 3 --Kaibaman (Rush)
+160421045 3 --Crack Fall
+160421053 3 --Black Dragon's Roar
+160421108 3 --Ultimate Flag Mech Gold Rush
+160421109 3 --Ancient Arrive Dragon
+160421110 3 --CAN - Melo:D
+160421111 3 --Kimeterasu the Rising Luna
+160421112 3 --Royal Rebel's Hard Rock
+160421113 3 --Attolashoot Highdron
+160421114 3 --Infinite Constructor Wyrm Buildream
+160422001 3 --Great Multistrike Dragon Dragias Burst [L]
+160422002 3 --Great Multistrike Dragon Dragias Burst
+160422003 3 --Great Multistrike Dragon Dragias Burst [R]
+160423001 3 --Alligator's Sword Dragon (Rush)
+160423006 3 --Mechaleon (Rush)
+160423007 3 --Blue-Eyed Silver Zombie (Rush)
+160423008 3 --Yormungarde (Rush)
+160423009 3 --Emperor of the Land and Sea (Rush)
+160424001 3 --Sevens Road Witch
+160424002 3 --Illusion Strike Dragon Miragias
+160424007 3 --Harpie Lady (Rush)
+160424008 3 --Winged Dragon, Guardian of the Fortress #1 (Rush)
+160425001 3 --Transamu Rainac
+160425006 3 --Stone Dragon (Rush)
+160426005 3 --Delight of the Mighty
+160426006 3 --Fancy Ladybug Pastel
+160426007 3 --Dream Ladybug Rainbow
+160426008 3 --Archfiend Marmot of Nefariousness (Rush)
+160426009 3 --Hero of the East (Rush)
+160426010 3 --Frenzied Panda (Rush)
+160427001 3 --Strong Boy Sevens Road
+160428001 3 --Supreme Wildgleam Magnum Overlord [L]
+160428002 3 --Supreme Wildgleam Magnum Overlord
+160428003 3 --Supreme Wildgleam Magnum Overlord [R]
+160428004 3 --Sturdy Strike Dragon Metagiastar F
+160428005 3 --Magician of Dark Sevens
+160428006 3 --Darkness Zerorogue
+160428007 3 --Darkness Fource Seeker
+160428008 3 --Darkness Rogue
+160428009 3 --Sevens Road Magician
+160428010 3 --Sevens Road Witch
+160428018 3 --Magic Curtain
+160428019 3 --Road Magic - Dark Twilight
+160428020 3 --Darkness Lode
+160428021 3 --Sevens Road Protection
+160428023 3 --Magic Fire Guard
+160428024 3 --Omega Guitarna the Shining Megastar
+160428025 3 --Princess Omega the Shining Megastar
+160428027 3 --CAN:D ALL
+160428029 3 --CAN - Sp:D
+160428035 3 --Progress Potter
+160428037 3 --Ice Pop Bear
+160428042 3 --Ama Lilith
+160428044 3 --Psychic Omega Blast
+160428048 3 --Cross Target
+160428049 3 --Featuring Omega
+160428052 3 --Dian Keto the Cooking Master
+160428053 3 --Brick Phone Nyan Nyan
+160428054 3 --Fashion of Faith
+160428056 3 --Tiramisu Dark Witch
+160428059 3 --Frenzied Panda Cotta
+160428061 3 --Change of Dessert
+160428062 3 --Mother's Storm
+160428065 3 --Bubbleburst Shock!
+160428067 3 --Party Up
+160428068 3 --Master's Cure
+160428071 3 --Dark Skeleton Dead Ruler
+160428073 3 --Crawling Torso
+160428074 3 --Cyber-Stein Frankenshrine
+160428075 3 --Ghoulish Gal
+160428076 3 --The Thing In the Purple Mirror
+160428077 3 --Doll of Dread
+160428078 3 --Samba Zombie Rio
+160428079 3 --Nightmare Knock
+160428080 3 --Frightening Fan Mail
+160428081 3 --Zombie Carnival
+160428082 3 --Zombie Fireworks
+160428083 3 --Surprising Zomvictory
+160428084 3 --It's Right Behind You!
+160428085 3 --I Hear Footsteps
+160428086 3 --The Cursed Cat Counting Dishes
+160428087 3 --Terrorphone Number
+160428088 3 --Oriental Tiger
+160428089 3 --Shadow Ghoul (Rush)
+160428090 3 --Cursed Skeletal Dragon Diarga
+160428091 3 --Peeking Magician
+160428092 3 --Specter of Heaven's End
+160428093 3 --Magical Ghost (Rush)
+160428094 3 --Sacrificial Summon
+160428096 3 --Trade-In (Rush)
+160428098 3 --Imptailing Crisis
+160430001 3 --Curse of Dragon (Rush)
+160430002 3 --Mystical Sandbox
+160430003 3 --Kanan the Swordmaiden
+160430006 3 --Spirit of the Mini Harp
+160430007 3 --Heartless Hound Blade Aikuchihuahua
+160430008 3 --Psychic Kappa (Rush)
+160430009 3 --Kappa Rapper
+160430010 3 --Kappa Avenger (Rush)
+160431001 3 --Transamu Rainac
+160431002 3 --Galactica Oblivion
+160431003 3 --Jointech Rex
+160431004 3 --Blue Tooth Burst Dragon
+160431005 3 --Chemicalize Salamander
+160431006 3 --Voidvelgr Requiem
+160431007 3 --Magical Sheep Girl Meeeg-chan
+160432001 3 --Greystorm Reverie
+160433001 3 --Gaia the Dragon Champion (Rush)
+160433002 3 --Blast Examiner
+160433003 3 --Update Wyvern
+160433006 3 --Begonia the Pressed Shadow Flower
+160433007 3 --Dahlia the Sprouting Shadow Flower
+160433008 3 --Kudzu the Bruised Shadow Flower
+160433009 3 --Quadcopter GA84
+160433010 3 --Full Jersey
+160434001 3 --Transamu Rainac - War To Zen!
+160434002 3 --Jointech Leo
+160434003 3 --Lightwave Dragon
+160434004 3 --Dark Magician Girl (Rush)
+160435001 3 --Excutie Lumiere
+160436001 3 --Garnecia Elefantis (Rush)
+160436002 3 --Wave Crest Madoor
+160436003 3 --Nikotamabot
+160436004 3 --Silent Doom (Rush)
+160437006 3 --Digger Skipper
+160437007 3 --Princessleon
+160437008 3 --Fairy Dragon (Rush)
+160437009 3 --Aitsu (Rush)
+160437010 3 --Level Blast
+160438001 3 --Majestic Masterburst
+160438002 3 --Majestic Masterburst
+160439004 3 --Crack Neutron
+160439007 3 --Tamabot
+160439008 3 --Soitsu (Rush)
+160439009 3 --Dragon Bird
+160439010 3 --Legendary Sword (Rush)
+160440004 3 --Dragon Tribe Fusion
+160440005 3 --Specter of Heaven's End
+160440006 3 --Magical Stone Excavation (Rush)
+160440007 3 --Hammer Crush
+160440008 3 --Grand Extreme
+160440009 3 --Wicked Shadow Dark Lurker
+160440012 3 --Pot of Arrogance
+160441003 3 --Eternal Galactica Oblivion
+160442001 3 --Ruthless Slash - Megaplunder
+160443001 3 --Sevens Road Magician
+160443002 3 --Multistrike Dragon Dragias
+160443003 3 --Prima Guitarna the Shining Superstar
+160443004 3 --Galactica Oblivion
+160443005 3 --Jointech Rex
+160443006 3 --Blue Tooth Burst Dragon
+160443007 3 --Cocosh the Spellcaster of Happiness
+160444006 3 --Fireyarou (Rush)
+160444008 3 --Gravity Plus Dragon
+160444010 3 --Three Cavalteers
+160445001 3 --Gaia The Fierce Knight (Rush)
+160445002 3 --Curse of Dragon (Rush)
+160445003 3 --Gaia the Dragon Champion (Rush)
+160446001 3 --Thousand Dragon (Rush)
+160446003 3 --Harpie Cielo
+160446004 3 --Cyber Tutu (Rush)
+160446005 3 --Swift Gaia the Fierce Knight (Rush)
+160446006 3 --Red Archery Girl (Rush)
+160446007 3 --Destroyer Golem (Rush)
+160446008 3 --The Snake Hair (Rush)
+160446009 3 --Confiscation (Rush)
+160446010 3 --Silver's Cry
+160446011 3 --Sevens Road Magician
+160446012 3 --Multistrike Dragon Dragias
+160446013 3 --CAN:D
+160446014 3 --Kimeluna the Dark Shifter
+160446015 3 --Royal Rebel's Rocker
+160446016 3 --Transamu Rainac
+160446017 3 --Jointech Raptor
+160446018 3 --Red Boot Boost Dragon
+160446019 3 --Combustion Oni Bunsel
+160446020 3 --Voidvelgr Transi
+160447006 3 --Royal Rebel's Beginitar
+160447007 3 --Royal Rebel's Babybass
+160447008 3 --Royal Rebel's Kidrum
+160448002 3 --CAN:D
+160448005 3 --Secret Order
+160448006 3 --Ship of Seven Treasures
+160449001 3 --Yaranzo (Rush)
+160449002 3 --Interstellive
+160449003 3 --Peace Dragon
+160449004 3 --Kaiser Dragon (Rush)
+160449005 3 --Remove Trap (Rush)
+160450006 3 --Zero Drake
+160451001 3 --Kanan the Swordmistress (Rush)
+160451002 3 --Excite Ground Dragon
+160451003 3 --LED Pigeon
+160451004 3 --Dream Live
+160451005 3 --Cheater's Hidden Ball Trick
+160452001 3 --Straynge Cat
+160452002 3 --Chromatographagas
+160452003 3 --Negatwor Dragon
+160452004 3 --Dragonic Slayer
+160452005 3 --Legend Strike
+# Legends
+160001000 3 --Blue-Eyes White Dragon (Rush)
+160002000 3 --Dark Magician (Rush)
+160003000 3 --Summoned Skull (Rush)
+160004000 3 --Jinzo (Rush)
+160005000 3 --Buster Blader (Rush)
+160006000 3 --Cyber-Tech Alligator (Rush)
+160007000 3 --Levia-Dragon - Daedalus (Rush)
+160008000 3 --The Creator (Rush)
+160009000 3 --Barrel Dragon (Rush)
+160010000 3 --Abyss Soldier (Rush)
+160011000 3 --Darklord Zerato (Rush)
+160012000 3 --Gilford the Lightning (Rush)
+160013020 3 --Zaborg the Thunder Monarch (Rush)
+160014065 3 --Negate Attack (Rush)
+160015056 3 --Salvage (Rush)
+160016033 3 --Snipe Hunter (Rush)
+160016034 3 --Golden Flying Fish (Rush)
+160201009 3 --Shield & Sword (Rush)
+160202019 3 --Trap Hole (Rush)
+160202048 3 --Card Destruction (Rush)
+160203018 3 --Upstart Goblin (Rush)
+160203023 3 --Tribute to The Doomed (Rush)
+160204048 3 --The Warrior Returning Alive (Rush)
+160204049 3 --Graceful Charity (Rush)
+160205001 3 --Blue-Eyes White Dragon (Rush)
+160205069 3 --Dark Hole (Rush)
+160205070 3 --Power Bond (Rush)
+160206002 3 --Behemoth the King of All Animals (Rush)
+160206008 3 --Vanity's Fiend (Rush)
+160206019 3 --Great Maju Garzett (Rush)
+160206022 3 --Final Destiny (Rush)
+160206025 3 --Polymerization (Rush)
+160206028 3 --Malevolent Catastrophe (Rush)
+160207060 3 --Levia-Dragon - Daedalus (Rush)
+160208063 3 --Phantasm Spiral Dragon (Rush)
+160208064 3 --Raiza the Storm Monarch (Rush)
+160208065 3 --Icarus Attack (Rush)
+160210001 3 --Dark Magician (Rush)
+160210029 3 --Gemini Elf (Rush)
+160210032 3 --Compulsory Evacuation Device (Rush)
+160210058 3 --Hammer Shot (Rush)
+160310001 3 --Pitch-Black Warwolf (Rush)
+160310002 3 --Alien Shocktrooper (Rush)
+160310003 3 --Dark Factory of Mass Production (Rush)
+160318001 3 --Twin-Barrel Dragon (Rush)
+160318002 3 --Mirage Dragon (Rush)
+160318003 3 --Flame Ruler (Rush)
+160318004 3 --Archfiend Soldier (Rush)
+160318005 3 --Torrential Tribute (Rush)
+160318006 3 --Graceful Charity (Rush)
+160404001 3 --Red-Eyes Black Dragon (Rush)
+160408003 3 --Monster Reincarnation (Rush)
+160411003 3 --Pot of Greed (Rush)
+160417001 3 --Millennium Shield (Rush)
+160417002 3 --Vorse Raider (Rush)
+160417003 3 --Mystical Elf (Rush)
+160417004 3 --Monster Reborn (Rush)
+160417005 3 --Sakuretsu Armor (Rush)
+160417006 3 --Monster Reborn (Rush)
+160418001 3 --Blue-Eyes White Dragon (Rush)
+160418003 3 --Mirror Force (Rush)
+160421015 3 --Dark Magician (Rush)
+160421016 3 --Red-Eyes Black Dragon (Rush)
+160421017 3 --Smashing Ground (Rush)
+160428099 3 --Recurring Nightmare (Rush)
+160428100 3 --Pot of Avarice (Rush)
+160429001 3 --Luster Dragon (Rush)
+160429002 3 --Thestalos the Firestorm Monarch (Rush)
+160432002 3 --Magician's Valkyria (Rush)
+160432003 3 --Heavy Storm (Rush)
+160432004 3 --Red-Eyes Black Dragon (Rush)
+160434005 3 --Magic Cylinder (Rush)
+160436005 3 --Widespread Ruin (Rush)
+160437001 3 --Widespread Ruin (Rush)
+160440001 3 --Buster Blader (Rush)
+160440002 3 --Recurring Nightmare (Rush)
+160440003 3 --Summoned Skull (Rush)
+160440010 3 --Negate Attack (Rush)
+160440011 3 --Pot of Avarice (Rush)
+160446002 3 --Time Wizard (Rush)
+#Forbidden
+160316013 0 --Barrier Statue of the Inferno
+# Limited
+160004049 1 --Grand Extreme
+160440008 1 --Grand Extreme
+160006015 1 --Thunderbold the Lightningfire Deity
+160203040 1 --Dragon Roll the Sushi Fairy
+160209081 1 --Obsidian Magical Soldier
+160406003 1 --Necromaid Nana
+160421029 1 --Magical Stone Excavation
+160440006 1 --Magical Stone Excavation
+160012024 1 --Ciela the Skysavior Knight
+160014055 1 --Cat-trois Choice
+# Semi-Limited
+160013054 2 --Sevens Wonder Fusion
+160428035 2 --Progress Potter
+160205034 2 --Excutie Lilius
+160013055 2 --Magical Lance - Grace Spear
+160208018 2 --Triangle Ecstacy Spark
+160014057 2 --Legend Strike
+160452005 2 --Legend Strike

--- a/Speed.lflist.conf
+++ b/Speed.lflist.conf
@@ -1,7 +1,35 @@
-#[2023.09 Speed Duel]
-!2023.09 Speed Duel
+#[2023.04 Speed Duel]
+!2023.04 Speed Duel
 $whitelist
-#Unlimited
+#limited
+77585513 1 --Jinzo
+19230408 1 --Offerings to the Doomed
+32807846 1 --Reinforcement of the Army	
+54704216 1 --Nightmare Wheel
+79852326 1 --Zoma the Spirit
+#semi limited
+300104004 2 --Cocoon of Ultra Evolution (Skill Card)
+87102774 2 --Golden Ladybug
+14457896 2 --Parasite Paranoid
+33365932 2 --Volcanic Shell
+1475311 2 --Allure of Darkness
+81439173 2 --Foolish Burial
+66399653 2 --Union Hangar
+#2023 unlimited
+300303012 3 --I'm Just Gonna Attack!(Skill Card)
+300205004 3 --Twisted Personality (Skill Card)
+77235086 3 --Cyber Angel Benten
+71413901 3 --Breaker the Magical Warrior
+70095154 3 --Cyber Dragon
+7572887 3 --D.D. Warrior Lady
+39996157 3 --Machine Angel Ritual
+14087893 3 --Book of Moon
+8267140 3 --Cosmic Cyclone
+96331676 3 --Crystal Raigeki
+69599136 3 --Floodgate Trap Hole
+58169731 3 --Wall of Disruption
+
+#unlimited
 86198326 3 --7 Completed
 24140059 3 --A Cat of Ill Omen
 32207100 3 --A Major Upset
@@ -501,6 +529,7 @@ $whitelist
 65338781 3 --Skilled Red Magician
 99789342 3 --Dark Magic Curtain
 95286165 3 --De-Fusion
+14087893 3 --Book of Moon
 6390406 3 --Emblem of Dragon Destroyer
 41940225 3 --Destruction Swordsman Fusion
 22829942 3 --Fusion Recycling Plant
@@ -563,7 +592,6 @@ $whitelist
 56747793 3 --United We Stand
 46181000 3 --Frontline Base	
 25518020 3 --Machine Assembly Line
-66399653 3 --Union Hangar
 93377803 3 --Solitary Sword of Poison
 26931058 3 --Formation Union
 12503902 3 --Rare Metalmorph	
@@ -627,7 +655,7 @@ $whitelist
 1353770 3 --Valhalla, Hall of the Fallen
 12607053 3 --Waboku
 55773067 3 --Drop off
-74003290 3 --Lost Wind
+74003290 3 --Lost Wind	
 66362965 3 --The Fiend Megacyber
 49681811 3 --Freed the Matchless General
 1347977 3 --Mysterious Guard
@@ -691,38 +719,28 @@ $whitelist
 300303007 3 --Union Combination
 300303008 3 --Spell of Mask
 300303009 3 --Magician's Act
-300303010 3 --Guardians of the Tomb
+300303010 3 --Endless Traps
 300303011 3 --No More Mrs. Nice Mai!
 300303013 3 --Rise of the Fallen
 300303014 3 --Beasts of Phantom
 300303015 3 --Magnetic Attraction
 300303016 3 --Power of Friendship
-##SGX1
-300304001 3 --Here Goes Something!
-300304002 3 --Powerful Group of Guys
-300304003 3 --Land of the Ojamas
-300304004 3 --Ancient Fusion
-300304005 3 --Cyber Blade Fusion
-300304006 3 --Crystal Transcendence
-300304007 3 --Forbidden Cyber Style Technique
-300304008 3 --Blaze Accelerator Deployment
-300304009 3 --The Right Hero for the Job
-300304010 3 --Looking into the Future
-300304011 3 --Armed and Ready!
-300304012 3 --Middle Age Mechs
-300304013 3 --Machine Angel Ascension
-300304014 3 --Rainbow Crystal Collection
-300304015 3 --Cyberdark Style
-300304016 3 --Volcanic Cannon
-300304017 3 --Energizing Elements
-300304018 3 --Room for Growth
-300304019 3 --I've Got Dino DNA!
-300304020 3 --Consumed By Darkness
+#STP5
+86188410 3 --Elemental HERO Wildheart
+60493189 3 --Elemental HERO Plasma Vice
+76263644 3 --Destiny End Dragoon
+53493204 3 --Goddess with the Third Eye
+10509340 3 --Ancient Gear Beast
+13093792 3 --Destiny HERO - Diamond Dude
+32933942 3 --Crystal Beast Amethyst Cat
+20586572 3 --Exploder Dragon
+64627453 3 --Ojama Blue
+#Duel Academy Box
 57116033 3 --Winged Kuriboh
 35809262 3 --Elemental HERO Flame Wingman
 83965310 3 --Destiny HERO - Plasma
-81866673 3 --Destiny HERO - Dasher
-73879377 3 --Armed Dragon LV7
+81866673 3 --DDestiny HERO - Dasher
+73879377 3 --Armed Dragon LV7"
 90140980 3 --Ojama King
 83104731 3 --Ancient Gear Golem
 12652643 3 --Ultimate Ancient Gear Golem
@@ -733,251 +751,411 @@ $whitelist
 32543380 3 --Volcanic Doomfire
 76459806 3 --Volcanic Rocket
 22587018 3 --Hydrogeddon
+21597117 3 --A Hero Emerges
 21844576 3 --Elemental HERO Avian
+59793705 3 --Elemental HERO Bladedge
+79979666 3 --Elemental HERO Bubbleman
 58932615 3 --Elemental HERO Burstinatrix
 84327329 3 --Elemental HERO Clayman
-20721928 3 --Elemental HERO Sparkman
-53493204 3 --Goddess with the Third Eye
-6480253 3 --Wroughtweiler
-79979666 3 --Elemental HERO Bubbleman
-59793705 3 --Elemental HERO Bladedge
-86188410 3 --Elemental HERO Wildheart
-89252153 3 --Elemental HERO Necroshade
-26902560 3 --Fusion Sage
-63035430 3 --Skyscraper
-37318031 3 --R - Righteous Justice
-21597117 3 --A Hero Emerges
-22020907 3 --Hero Signal
-61204971 3 --Elemental HERO Thunder Giant
-47737087 3 --Elemental HERO Rampart Blaster
-81197327 3 --Elemental HERO Steam Healer
 41517968 3 --Elemental HERO Darkbright
-60493189 3 --Elemental HERO Plasma Vice
-41613948 3 --Destiny HERO - Doom Lord
-13093792 3 --Destiny HERO - Diamond Dude
-55461064 3 --Destiny HERO - Blade Master
-80744121 3 --Destiny HERO - Fear Monger
-17132130 3 --Destiny HERO - Dogma
-9411399 3 --Destiny HERO - Malicious
-26964762 3 --Destiny HERO - Dark Angel
-37684215 3 --Fusion Sword Murasame Blade
-53527835 3 --Dark City
-89899996 3 --D - Spirit
-72204747 3 --Over Destiny
-35464895 3 --Destiny Signal
+89252153 3 --Elemental HERO Necroshade
+47737087 3 --Elemental HERO Rampart Blaster
+20721928 3 --Elemental HERO Sparkman
+81197327 3 --Elemental HERO Steam Healer
+61204971 3 --Elemental HERO Thunder Giant
+26902560 3 --Fusion Sage
+22020907 3 --Hero Signal
+37318031 3 --R - Righteous Justice
+63035430 3 --Skyscraper
+6480253 3 --Wroughtweiler
 43405287 3 --D - Chain
 8698851 3 --D - Counter
-76263644 3 --Destiny End Dragoon
+89899996 3 --D - Spirit
+53527835 3 --Dark City
+55461064 3 --Destiny HERO - Blade Master
 30757127 3 --Destiny HERO - Dangerous
-42941100 3 --Ojama Yellow
-12482652 3 --Ojama Green
-79335209 3 --Ojama Black
-51638941 3 --V-Tiger Jet
-16956455 3 --Chiron the Mage
+26964762 3 --Destiny HERO - Dark Angel
+17132130 3 --Destiny HERO - Dogma
+41613948 3 --Destiny HERO - Doom Lord
+80744121 3 --Destiny HERO - Fear Monger
+9411399 3 --Destiny HERO - Malicious
+35464895 3 --Destiny Signal
+37684215 3 --Fusion Sword Murasame Blade
+72204747 3 --Over Destiny
 980973 3 --Armed Dragon LV3
 46384672 3 --Armed Dragon LV5
-96300057 3 --W-Wing Catapult
-37132349 3 --Ojama Red
-64627453 3 --Ojama Blue
-8251996 3 --Ojama Delta Hurricane!!
-24643836 3 --Ojamagic
-96383838 3 --Tri-Wight
-38395123 3 --Ojamatch
-84136000 3 --The Grave of Enkindling
-32854013 3 --Super Rush Recklessly
-6691855 3 --Spikeshield with Chain
-58859575 3 --VW-Tiger Catapult
+16956455 3 --Chiron the Mage
+79335209 3 --Ojama Black
+8251996 3 --Ojama Delta Hurricane!
+12482652 3 --Ojama Green
 40391316 3 --Ojama Knight
-7359741 3 --Mechanicalchaser
-38479725 3 --The Trojan Horse
-10509340 3 --Ancient Gear Beast
+37132349 3 --Ojama Red
+42941100 3 --Ojama Yellow
+24643836 3 --Ojamagic
+38395123 3 --Ojamatch
+6691855 3 --Spikeshield with Chain
+32854013 3 --Super Rush Recklessly
+84136000 3 --The Grave of Enkindling
+96383838 3 --Tri-Wight
+51638941 3 --V-Tiger Jet
+58859575 3 --VW-Tiger Catapult
+96300057 3 --W-Wing Catapult
+92001300 3 --Ancient Gear Castle
+1953925 3 --Ancient Gear Engineer
+18486927 3 --Ancient Gear Gadget
+39303359 3 --Ancient Gear Knight
 56094445 3 --Ancient Gear Soldier
 31557782 3 --Ancient Gear
-1953925 3 --Ancient Gear Engineer
-39303359 3 --Ancient Gear Knight
-18486927 3 --Ancient Gear Gadget
-82828051 3 --Earthquake
-92001300 3 --Ancient Gear Castle
-37694547 3 --Geartown
-65810489 3 --Statue of the Wicked
 28378427 3 --Damage Condenser
+82828051 3 --Earthquake
+37694547 3 --Geartown
+7359741 3 --Mechanicalchaser
 34815282 3 --Miniaturize
+65810489 3 --Statue of the Wicked
+38479725 3 --The Trojan Horse
+52497105 3 --Berserk Scales
 97023549 3 --Blade Skater
-5438492 3 --Warrior Lady of the Wasteland
-11460577 3 --Etoile Cyber
-49375719 3 --Cyber Tutu
-76763417 3 --Cyber Gymnast
-2158562 3 --Cyber Prima
 3629090 3 --Cyber Angel Idaten
 91668401 3 --Cyber Angel Izana
-54351224 3 --Ritual Weapon
-52497105 3 --Berserk Scales
-88789641 3 --Hallowed Life Barrier
+76763417 3 --Cyber Gymnast
+2158562 3 --Cyber Prima
+49375719 3 --Cyber Tutu
 79997591 3 --Doble Passe
-32933942 3 --Crystal Beast Amethyst Cat
-69937550 3 --Crystal Beast Amber Mammoth
-32710364 3 --Crystal Beast Ruby Carbuncle
-68215963 3 --Crystal Beast Emerald Tortoise
-95600067 3 --Crystal Beast Topaz Tiger
-21698716 3 --Crystal Beast Cobalt Eagle
+11460577 3 --Etoile Cyber
+88789641 3 --Hallowed Life Barrier
+54351224 3 --Ritual Weapon
+5438492 3 --Warrior Lady of the Wasteland
 34487429 3 --Ancient City - Rainbow Ruins
-60876124 3 --Rare Value
+69937550 3 --Crystal Beast Amber Mammoth
+21698716 3 --Crystal Beast Cobalt Eagle
+68215963 3 --Crystal Beast Emerald Tortoise
+32710364 3 --Crystal Beast Ruby Carbuncle
+95600067 3 --Crystal Beast Topaz Tiger
 35486099 3 --Crystal Blessing
+87259933 3 --Crystal Conclave
 8275702 3 --Crystal Promise
 10004783 3 --Crystal Release
 47408488 3 --Crystal Tree
-96331676 3 --Crystal Raigeki
-34002992 3 --Rainbow Life
-63806265 3 --Rainbow Gravity
 48135190 3 --Gravelstorm
-87259933 3 --Crystal Conclave
+63806265 3 --Rainbow Gravity
+34002992 3 --Rainbow Life
 37440988 3 --Rainbow Overdragon
-96005454 3 --Hunter Dragon
-26439287 3 --Proto-Cyber Dragon
+60876124 3 --Rare Value
+64599569 3 --Chimeratech Overdragon
+12670770 3 --Cyber Network
 3370104 3 --Cyber Phoenix
-41230939 3 --Cyberdark Horn
-77625948 3 --Cyberdark Edge
-3019642 3 --Cyberdark Keel
-20586572 3 --Exploder Dragon
+90440725 3 --Cyber Shadow Gardna
 3657444 3 --Cyber Valley
 82562802 3 --Cyberdark Claw
+40418351 3 --Cyberdark Dragon
+77625948 3 --Cyberdark Edge
+41230939 3 --Cyberdark Horn
+80033124 3 --Cyberdark Impact!
+3019642 3 --Cyberdark Keel
 11961740 3 --Different Dimension Capsule
 77565204 3 --Future Fusion
-3659803 3 --Overload Fusion
-80033124 3 --Cyberdark Impact!
-90440725 3 --Cyber Shadow Gardna
-25173686 3 --Straight Flush
+96005454 3 --Hunter Dragon
 71098407 3 --Memory Loss
-12670770 3 --Cyber Network
-64599569 3 --Chimeratech Overdragon
-40418351 3 --Cyberdark Dragon
+3659803 3 --Overload Fusion
+26439287 3 --Proto-Cyber Dragon
+25173686 3 --Straight Flush
+69537999 3 --Blaze Accelerator
 5464695 3 --Blazing Inpachi
 13179332 3 --Charcoal Inpachi
-60806437 3 --UFO Turtle
-13522325 3 --Spirit of Flames
-90810762 3 --Raging Flame Sprite
-81020140 3 --Volcanic Blaster
-54514594 3 --Volcanic Hammerer
-54040221 3 --Royal Firestorm Guards
-32268901 3 --Salamandra
-69537999 3 --Blaze Accelerator
-21420702 3 --Tri-Blaze Accelerator
-68815401 3 --Wild Fire
 74458486 3 --Covering Fire
 94804055 3 --Firewall
-8783685 3 --Hourglass of Life
-42129512 3 --Big Koala
-27288416 3 --Mokey Mokey
-78613627 3 --Des Kangaroo
-18325492 3 --Gyroid
-79407975 3 --Rainbow Dark Dragon
-50896944 3 --Black Brachios
-7171149 3 --Toon Ancient Gear Golem
-27134689 3 --Master of Oz
-84243274 3 --VWXYZ-Dragon Catapult Cannon
-27967615 3 --Fusion Weapon
-1965724 3 --Mokey Mokey Smackdown
-95326659 3 --Crystal Beacon
-90011152 3 --Ojama Country
+90810762 3 --Raging Flame Sprite
+54040221 3 --Royal Firestorm Guards
+32268901 3 --Salamandra
+13522325 3 --Spirit of Flames
+21420702 3 --Tri-Blaze Accelerator
+60806437 3 --UFO Turtle
+81020140 3 --Volcanic Blaster
+54514594 3 --Volcanic Hammerer
+68815401 3 --Wild Fire
 12644061 3 --Advanced Dark
-78211862 3 --Rising Energy
+42129512 3 --Big Koala
+50896944 3 --Black Brachios
+95326659 3 --Crystal Beacon
+78613627 3 --Des Kangaroo
+27967615 3 --Fusion Weapon
+18325492 3 --Gyroid
+8783685 3 --Hourglass of Life
 62271284 3 --Justi-Break
-##SGX2
+27134689 3 --Master of Oz
+1965724 3 --Mokey Mokey Smackdown
+27288416 3 --Mokey Mokey
+90011152 3 --Ojama Country
+78211862 3 --Rising Energy
+7171149 3 --Toon Ancient Gear Golem
+84243274 3 --VWXYZ-Dragon Catapult Cannon
+300304001 3 --Here Goes Something!
+300304002 3 --Powerful Group of Guys
+300304003 3 --Land of the Ojamas
+300304004 3 --Ancient Fusion
+300304005 3 --Cyber Blade Fusion
+300304006 3 --Crystal Transcendance
+300304007 3 --Forbidden Cyber Style Technique
+300304008 3 --Blaze Accelerator Deployment
+300304009 3 --The Right Hero for the Job
+300304010 3 --Looking into the Future
+300304011 3 --Armed and Ready!
+300304012 3 --Middle-Aged Mechs
+300304013 3 --Machine Angel Ascension
+300304015 3 --Cyberdark Style
+300304016 3 --Volcanic Cannon
+300304017 3 --Energizing Elements
+300304018 3 --Room for Growth
+300304019 3 --I've Got Dino DNA!
+300304020 3 --Consumed By Darkness
+#Midterm Paradox
+8949584 3 --A Hero Lives
+93332803 3 --Dogoran, the Mad Flame Kaiju
+71218746 3 --Drillroid
+83121692 3 --Elemental HERO Tempest
+25833572 3 --Gate Guardian
+62340868 3 --Kazejin
+25955164 3 --Sanga of the Thunder
+98434877 3 --Suijin
+36256625 3 --Super Vehicroid Jumbo Drill
+32752319 3 --UFOroid Fighter
+85066822 3 --Water Dragon
+33875961 3 --Dark Catapulter
+63060238 3 --Elemental HERO Blazeman
+29343734 3 --Elemental HERO Electrum
+14225239 3 --Elemental HERO Mariner
+1945387 3 --Elemental HERO Nova Master
+55615891 3 --Elemental HERO Wild Wingman
+74825788 3 --H - Heated Heart
+19024706 3 --Hero Counterattack
+26647858 3 --Hero Ring
+80831721 3 --Sabatiel - The Philosopher's Stone
+47596607 3 --Skyscraper 2 - Hero City
+98927491 3 --Ambulance Rescueroid
+36378213 3 --Ambulanceroid
+45945685 3 --Cycroid
+70628672 3 --Emergeroid Call
+984114 3 --Expressroid
+22512237 3 --Mechanical Hound
+71340250 3 --Mixeroid
+24311595 3 --Rescueroid
+30683373 3 --Shield Crush
+98049038 3 --Stealthroid
+5368615 3 --Steam Gyroid
+44729197 3 --Steamroid
+99861526 3 --Submarineroid
+3897065 3 --Super Vehicroid - Stealth Union
+97705809 3 --Supercharge
+61538782 3 --Truckroid
+23299957 3 --Vehicroid Connection Zone
+10035717 3 --Weapon Change
+50684552 3 --Wonder Garage
+295517 3 --A Legendary Ocean
+79402185 3 --Bonding - D2O
+6890729 3 --Bonding - DHO
+45898858 3 --Bonding - H2O
+15981690 3 --Carboneddon
+58851034 3 --Cursed Seal of the Forbidden Spell
+43017476 3 --Duoterion
+62397231 3 --Hyozanryu
+71106375 3 --Jurrac Iguanon
+23927545 3 --Jurrac Protops
+34959756 3 --Living Fossil
+58071123 3 --Oxygeddon
+10352095 3 --Scroll of Bewitchment
+6022371 3 --Water Dragon Cluster
+93889755 3 --Crass Clown
+43422537 3 --Double Summon
+13215230 3 --Dream Clown
+97687912 3 --Fairy Meteor Crush
+94773007 3 --Jirai Gumo
+17444133 3 --Kaiser Sea Horse
+66526672 3 --Labyrinth of Nightmare
+67284908 3 --Labyrinth Wall
+42647539 3 --Ryu-Kishin Clown
+30778711 3 --Shadow Ghoul
+17444133 3 --Kaiser Sea Horse
+31812496 3 --Stone Statue of the Aztecs
+92084010 3 --Unshaven Angler
+15090429 3 --Whirlwind Prodigy
+69579761 3 --Des Koala
+9637706 3 --Des Wombat
+42149850 3 --Disposable Learner Device
+81003500 3 --Elemental HERO Necroid Shaman
+55428811 3 --Fifth Hope
+55589254 3 --Frost and Flame Dragon
+61465001 3 --Loud Cloud the Storm Serpent
+74270067 3 --Pikeru's Circle of Enchantment
+87685879 3 --Sea Koala
+81383947 3 --White Magician Piker
 300305001 3 --HEROES UNITE - FUSION!!
 300305002 3 --Chemistry in Motion
-300305003 3 --The Roids are Alright
+300305003 3 --The Roids Are Right
 300305004 3 --Behold, Gate Guardian!
 300305005 3 --Under Pressure
 300305006 3 --Chillin' Outback
 300305007 3 --HERO World
-300305008 3 --Power Bond (Skill Card)
-300305009 3 --Beware the Brothers Paradox!
-300305010 3 --Elements of Thunder, Water, and Wind
-300305011 3 --Believe in your Bro
+300305008 3 --Power Bond
+300305009 3 --Beware the Paradox Brothers!
+300305010 3 --Elements of Thunder, Water and Wind
+300305011 3 --Believe in Your Bro
 300305012 3 --Small Roid Big City
-8949584 3 --A Hero Lives
-83121692 3 --Elemental HERO Tempest
-71218746 3 --Drillroid
-36256625 3 --Super Vehicroid Jumbo Drill
-85066822 3 --Water Dragon
-93332803 3 --Dogoran, the Mad Flame Kaiju
-25833572 3 --Gate Guardian
-25955164 3 --Sanga of the Thunder
-62340868 3 --Kazejin
-98434877 3 --Suijin
-32752319 3 --UFOroid Fighter
-33875961 3 --Dark Catapulter
-63060238 3 --Elemental HERO Blazeman
-74825788 3 --H - Heated Heart
-47596607 3 --Skyscraper 2 - Hero City
-80831721 3 --Sabatiel - The Philosopher's Stone
-26647858 3 --Hero Ring
-19024706 3 --Hero Counterattack
-29343734 3 --Elemental HERO Electrum
-55615891 3 --Elemental HERO Wild Wingman
-14225239 3 --Elemental HERO Mariner
-1945387 3 --Elemental HERO Nova Master
-45945685 3 --Cycroid
-44729197 3 --Steamroid
-7602840 3 --UFOroid
-22512237 3 --Mechanical Hound
-984114 3 --Expressroid
-36378213 3 --Ambulanceroid
-99861526 3 --Submarineroid
-98049038 3 --Stealthroid
-61538782 3 --Truckroid
-24311595 3 --Rescueroid
-71340250 3 --Mixeroid
-10035717 3 --Weapon Change
-30683373 3 --Shield Crush
-23299957 3 --Vehicroid Connection Zone
-97705809 3 --Supercharge
-50684552 3 --Wonder Garage
-70628672 3 --Emergeroid Call
-5368615 3 --Steam Gyroid
-98927491 3 --Ambulance Rescueroid
-3897065 3 --Super Vehicroid - Stealth Union
-62397231 3 --Hyozanryu
-58071123 3 --Oxygeddon
-23927545 3 --Jurrac Protops
-71106375 3 --Jurrac Iguanon
-15981690 3 --Carboneddon
-6022371 3 --Water Dragon Cluster
-43017476 3 --Duoterion
-10352095 3 --Scroll of Bewitchment
-295517 3 --A Legendary Ocean
-45898858 3 --Bonding - H2O
-79402185 3 --Bonding - D2O
-34959756 3 --Living Fossil
-58851034 3 --Cursed Seal of the Forbidden Spell
-6890729 3 --Bonding - DHO
-67284908 3 --Labyrinth Wall
-93889755 3 --Crass Clown
-13215230 3 --Dream Clown
-94773007 3 --Jirai Gumo
-30778711 3 --Shadow Ghoul
-31812496 3 --Stone Statue of the Aztecs
-42647539 3 --Ryu-Kishin Clown
-17444133 3 --Kaiser Sea Horse
-92084010 3 --Unshaven Angler
-15090429 3 --Whirlwind Prodigy
-97687912 3 --Fairy Meteor Crush
-43422537 3 --Double Summon
-66526672 3 --Labyrinth of Nightmare
-69579761 3 --Des Koala
-81383947 3 --White Magician Pikeru
-9637706 3 --Des Wombat
-55589254 3 --Frost and Flame Dragon
-87685879 3 --Sea Koala
-61465001 3 --Loud Cloud the Storm Serpent
-55428811 3 --Fifth Hope
-42149850 3 --Disposable Learner Device
-74270067 3 --Pikeru's Circle of Enchantment
-81003500 3 --Elemental HERO Necroid Shaman
-##SGX3
+
+#Duelists of Shadows
+15951532 3 --Amazoness Queen
+95132338 3 --Aqua Chorus
+59464593 3 --Armed Dragon LV10
+94820406 3 --Dark Fusion
+25366484 3 --Elemental HERO Shining Flare Wingman
+86676862 3 --Evil HERO Malicious Fiend
+6614221 3 --Fog King
+27408609 3 --Golden Homunculus
+54493213 3 --Helios - The Primordial Sun
+70595331 3 --Il Blud
+25773409 3 --Legendary Jujitsu Master
+30241314 3 --Macro Cosmos
+96561011 3 --Red-Eyes Darkness Dragon
+61370518 3 --Skull Archfiend of Lightning
+48130397 3 --Super Polymerization
+22056710 3 --Vampire Genesis
+80485722 3 --Vampire Hunter
+12071500 3 --Dark Calling
+65824822 3 --Dark Deal
+93554166 3 --Dark World Lightning
+58332301 3 --Evil HERO Dark Gaia
+95943058 3 --Evil HERO Infernal Gainer
+50304345 3 --Evil HERO Infernal Prodigy
+22160245 3 --Evil HERO Inferno Wing
+21947653 3 --Evil HERO Lightning Golem
+58554959 3 --Evil HERO Malicious Edge
+13293158 3 --Evil HERO Wild Cyclone
+18438874 3 --Evil Mind
+73648243 3 --Sand Moth
+50259460 3 --Versago the Destroyer
+36262024 3 --Black Dragon's Chick
+93969023 3 --Black Metal Dragon
+55991637 3 --Dragon's Gunfire
+54178050 3 --Dragon's Rage
+11091375 3 --Luster Dragon
+15960641 3 --Mirage Dragon
+67300516 3 --Red-Eyes Wyvern
+96765646 3 --Swing of Memories
+564541 3 --Totem Dragon
+77135531 3 --Vanguard of the Dragon
+4861205 3 --Call of the Mummy
+63665875 3 --Goblin Zombie
+34761062 3 --Heavy Knight of the Flame
+55696885 3 --Plague Wolf
+57281778 3 --Ryu Kokki
+31189536 3 --Vampire Awakening
+56387350 3 --Vampire Baby
+34250214 3 --Vampire Familiar
+26495087 3 --Vampire Lady
+70645913 3 --Vampire Retainer
+88728507 3 --Vampire Sorcerer
+34294855 3 --Vampire's Curse
+69700783 3 --Vampire's Desire
+55821894 3 --Amazoness Fighter
+36100154 3 --Amazoness Fighting Spirit
+47480070 3 --Amazoness Paladin
+71209500 3 --Amazoness Scouts
+81325903 3 --Amazoness Spellcaster
+10979723 3 --Amazoness Tiger
+22082163 3 --Amazoness Willpower
+64178868 3 --Battle Survivor
+80193355 3 --Dramatic Rescue
+6799227 3 --Half Counter
+58477767 3 --Queen's Pawn
+29603180 3 --Annihilator Archfiend
+48675364 3 --Archfiend General
+49881766 3 --Archfiend Soldier
+56246017 3 --Archfiend's Roar
+40619825 3 --Axe of Despair
+94463200 3 --Battle-Scarred
+69313735 3 --Checkmate
+35798491 3 --Darkbishop Archfiend
+72192100 3 --Desrook Archfiend
+24096228 3 --Double Spell
+73698349 3 --Giant Orc
+8581705 3 --Infernalqueen Archfiend
+28601770 3 --Mist Archfiend
+94585852 3 --Pandemonium
+9603356 3 --Shadowknight Archfiend
+35975813 3 --Terrorking Archfiend
+73219648 3 --Vilepawn Archfiend
+47829960 3 --Chaosrider Gustaph
+41398771 3 --Curse of Aging
+44792253 3 --D.D. Destroyer
+3773196 3 --D.D. Scout Plane
+48092532 3 --D.D. Survivor
+82112775 3 --D.D.M. - Different Dimension Master
+39900763 3 --Different Dimension Encounter
+56460688 3 --Different Dimension Gate
+41113025 3 --Diskblade Rider
+5133471 3 --Galaxy Cyclone
+38430673 3 --Grand Convergence
+36584821 3 --Gren Maju Da Eiza
+86361354 3 --Tribe-Shocking Virus
+47060347 3 --Aegis of Gaia
+53701259 3 --Awakening of the Sacred Beasts
+54828837 3 --Cerulean Skyfire
+79279397 3 --D-Boyz
+87917187 3 -Dark Summoning Beast
+13301895 3 --Fallen Paradise
+18590133 3 --Goblin King
+11448373 3 --Grave Protector
+29216198 3 --Gravitic Orb
+32491822 3 --Hamon, Lord of Striking Thunder
+69890967 3 --Raviel, Lord of Phantasms
+69452756 3 --Unending Nightmare
+6007213 3 --Uria, Lord of Searing Flames
+17810268 3 -Cloudian - Acid Cloud
+79703905 3 --Cloudian - Altus
+43318266 3 --Cloudian - Cirrostratus
+57610714 3 --Cloudian - Eye of the Typhoon
+83604828 3 --Cloudian - Ghost Fog
+20003527 3 --Cloudian - Nimbusman
+80825553 3 --Cloudian - Smoke Ball
+13474291 3 --Cloudian - Storm Dragon
+16197610 3 --Cloudian - Turbulence
+88210105 3 --Cloudian Aerosol
+90135989 3 --Cloudian Squall
+19980975 3 --Diamond-Dust Cyclone
+63741331 3 --Fog Control
+57839750 3 --Mother Grizzly
+23639291 3 --Raging Cloudian
+45653036 3 --Rain Storm
+553756843 --Summon Cloud
+7736719 3 --Vortex Trooper
+40916023 3 --Aqua Spirit
+44702857 3 --Bitelon
+6214884 3 --Brron, Mad King of Dark World
+11593137 3 --Chaos Trap Hole
+56597272 3 --Cloudian - Sheep Cloud
+38834303 3 --Counter Cleaner
+61587183 3 --Dark Scorpion - Chick the Yellow
+6967870 3 --Dark Scorpion - Cliff the Trap Remove
+39956951 3 --Flash of the Forbidden Spell
+49003308 3 --Gagagigo
+12800777 3 --Garuda the Wind Spirit
+17286057 3 --Helios Trice Megistus
+80887952 3 --Helios Duo Megistus
+30353551 3 --Human-Wave Tactics
+52248570 3 --Imprisoned Queen Archfiend
+90464188 3 --Obsidian Dragon
+52550973 3 --Pharaoh's Servant
+89959682 3 --Pharaonic Protector
+99458769 3 --Reign-Beaux, Overlord of Dark World
+25343280 3 --Spirit of the Pharaoh
+78060096 3 --Terrorking Salmon
+31076103 3 --The First Sarcophagus
+4081094 3 --The Second Sarcophagus
+78697395 3 --The Third Sarcophagus
+1371589 3 --Vampiric Koala
+7459013 3 --Zure, Knight of Dark World
 300306001 3 --Ruthless Means
 300306002 3 --Forged Steel
-300306003 3 --Vampiric Aristocracy
+300306003 3 --Vampire Aristocracy
 300306004 3 --Welcome to the Jungle
 300306005 3 --Archfiend's Conscription
 300306006 3 --Professor of Alchemy
@@ -985,7 +1163,7 @@ $whitelist
 300306008 3 --Fog Warning
 300306009 3 --Dark Unity
 300306010 3 --Dragon Force
-300306011 3 --Delicious Morsel!
+300306011 3 --Delicious Morsel
 300306012 3 --Order of the Queen
 300306013 3 --Archfiend's Promotion
 300306014 3 --Setting Sun
@@ -995,293 +1173,3 @@ $whitelist
 300306018 3 --Ancient Ruler Rises
 300306019 3 --Cold-Blooded Tactician
 300306020 3 --Dark Creation
-58554959 3 --Evil HERO Malicious Edge
-95943058 3 --Evil HERO Infernal Gainer
-50304345 3 --Evil HERO Infernal Prodigy
-73648243 3 --Sand Moth
-50259460 3 --Versago the Destroyer
-94820406 3 --Dark Fusion
-12071500 3 --Dark Calling
-18438874 3 --Evil Mind
-93554166 3 --Dark World Lightning
-48130397 3 --Super Polymerization
-65824822 3 --Dark Deal
-86676862 3 --Evil HERO Malicious Fiend
-22160245 3 --Evil HERO Inferno Wing
-13293158 3 --Evil HERO Wild Cyclone
-58332301 3 --Evil HERO Dark Gaia
-21947653 3 --Evil HERO Lightning Golem
-96561011 3 --Red-Eyes Darkness Dragon
-11091375 3 --Luster Dragon
-36262024 3 --Black Dragon's Chick
-67300516 3 --Red-Eyes Wyvern
-93969023 3 --Black Metal Dragon
-15960641 3 --Mirage Dragon
-77135531 3 --Vanguard of the Dragon
-564541 3 --Totem Dragon
-55991637 3 --Dragon's Gunfire
-96765646 3 --Swing of Memories
-54178050 3 --Dragon's Rage
-22056710 3 --Vampire Genesis
-56387350 3 --Vampire Baby
-34250214 3 --Vampire Familiar
-26495087 3 --Vampire Lady
-70645913 3 --Vampire Retainer
-88728507 3 --Vampire Sorcerer
-34294855 3 --Vampire's Curse
-55696885 3 --Plague Wolf
-34761062 3 --Heavy Knight of the Flame
-57281778 3 --Ryu Kokki
-4861205 3 --Call of the Mummy
-69700783 3 --Vampire's Desire
-31189536 3 --Vampire Awakening
-15951532 3 --Amazoness Queen
-10979723 3 --Amazoness Tiger
-47480070 3 --Amazoness Paladin
-55821894 3 --Amazoness Fighter
-71209500 3 --Amazoness Scouts
-64178868 3 --Battle Survivor
-36100154 3 --Amazoness Fighting Spirit
-81325903 3 --Amazoness Spellcaster
-22082163 3 --Amazoness Willpower
-80193355 3 --Dramatic Rescue
-58477767 3 --Queen's Pawn
-6799227 3 --Half Counter
-61370518 3 --Skull Archfiend of Lightning
-49881766 3 --Archfiend Soldier
-35975813 3 --Terrorking Archfiend
-8581705 3 --Infernalqueen Archfiend
-73219648 3 --Vilepawn Archfiend
-9603356 3 --Shadowknight Archfiend
-35798491 3 --Darkbishop Archfiend
-72192100 3 --Desrook Archfiend
-73698349 3 --Giant Orc
-28601770 3 --Mist Archfiend
-29603180 3 --Annihilator Archfiend
-48675364 3 --Archfiend General
-94585852 3 --Pandemonium
-69313735 3 --Checkmate
-40619825 3 --Axe of Despair
-24096228 3 --Double Spell
-56246017 3 --Archfiend's Roar
-94463200 3 --Battle-Scarred
-54493213 3 --Helios - The Primordial Sun
-27408609 3 --Golden Homunculus
-47829960 3 --Chaosrider Gustaph
-41113025 3 --Diskblade Rider
-48092532 3 --D.D. Survivor
-3773196 3 --D.D. Scout Plane
-82112775 3 --D.D.M. - Different Dimension Master
-44792253 3 --D.D. Destroyer
-36584821 3 --Gren Maju Da Eiza
-86361354 3 --Tribe-Shocking Virus
-5133471 3 --Galaxy Cyclone
-38430673 3 --Grand Convergence
-56460688 3 --Different Dimension Gate
-39900763 3 --Different Dimension Encounter
-30241314 3 --Macro Cosmos
-41398771 3 --Curse of Aging
-6007213 3 --Uria, Lord of Searing Flames
-32491822 3 --Hamon, Lord of Striking Thunder
-69890967 3 --Raviel, Lord of Phantasms
-87917187 3 --Dark Summoning Beast
-79279397 3 --D-Boyz
-29216198 3 --Gravitic Orb
-18590133 3 --Goblin King
-11448373 3 --Grave Protector
-13301895 3 --Fallen Paradise
-54828837 3 --Cerulean Skyfire
-53701259 3 --Awakening of the Sacred Beasts
-69452756 3 --Unending Nightmare
-47060347 3 --Aegis of Gaia
-6614221 3 --Fog King
-57610714 3 --Cloudian - Eye of the Typhoon
-17810268 3 --Cloudian - Acid Cloud
-79703905 3 --Cloudian - Altus
-43318266 3 --Cloudian - Cirrostratus
-83604828 3 --Cloudian - Ghost Fog
-16197610 3 --Cloudian - Turbulence
-80825553 3 --Cloudian - Smoke Ball
-20003527 3 --Cloudian - Nimbusman
-13474291 3 --Cloudian - Storm Dragon
-7736719 3 --Vortex Trooper
-57839750 3 --Mother Grizzly
-88210105 3 --Cloudian Aerosol
-90135989 3 --Cloudian Squall
-55375684 3 --Summon Cloud
-19980975 3 --Diamond-Dust Cyclone
-63741331 3 --Fog Control
-23639291 3 --Raging Cloudian
-45653036 3 --Rain Storm
-61587183 3 --Dark Scorpion - Chick the Yellow
-6967870 3 --Dark Scorpion - Cliff the Trap Remover
-52550973 3 --Pharaoh's Servant
-89959682 3 --Pharaonic Protector
-25343280 3 --Spirit of the Pharaoh
-31076103 3 --The First Sarcophagus
-4081094 3 --The Second Sarcophagus
-78697395 3 --The Third Sarcophagus
-49003308 3 --Gagagigo
-44702857 3 --Bitelon
-90464188 3 --Obsidian Dragon
-7459013 3 --Zure, Knight of Dark World
-6214884 3 --Brron, Mad King of Dark World
-99458769 3 --Reign-Beaux, Overlord of Dark World
-25773409 3 --Legendary Jujitsu Master
-52248570 3 --Imprisoned Queen Archfiend
-70595331 3 --Il Blud
-80485722 3 --Vampire Hunter
-40916023 3 --Aqua Spirit
-12800777 3 --Garuda the Wind Spirit
-80887952 3 --Helios Duo Megistus
-17286057 3 --Helios Trice Megistus
-56597272 3 --Cloudian - Sheep Cloud
-25366484 3 --Elemental HERO Shining Flare Wingman
-78060096 3 --Terrorking Salmon
-59464593 3 --Armed Dragon LV10
-1371589 3 --Vampiric Koala
-38834303 3 --Counter Cleaner
-39956951 3 --Flash of the Forbidden Spell
-95132338 3 --Aqua Chorus
-11593137 3 --Chaos Trap Hole
-30353551 3 --Human-Wave Tactics
-##SBC1
-300307001 3 --Ultimate Wizardry
-300307002 3 --Iron Grit
-300307003 3 --Whale of a Tale
-300307004 3 --Insect Infestation
-300307005 3 --Intel from the "Cosmos"
-300307006 3 --Stalked by the Rare Hunters
-300307007 3 --Now You See Them...
-300307008 3 --Slimey Slimes
-300307009 3 --The Dragon Hunting Swordsman
-300307010 3 --Heart of a Warrior
-300307011 3 --A Bountiful Ocean
-300307012 3 --My Precious Queen!
-300307013 3 --The Machine Menace
-300307014 3 --Collector
-300307015 3 --A Terrible Fate
-300307016 3 --Slimey Disposition
-300307017 3 --Malicious Motivation
-300307018 3 --KaibaCorp Research
-300307019 3 --Battle City Siren
-300307020 3 --Premature Material
-73752131 3 --Skilled Dark Magician
-78121572 3 --Alchemist of Black Spells
-21051146 3 --Blast Magician
-13626450 3 --Malice Dispersion
-68334074 3 --Miracle Restoring
-34029630 3 --Pitch-Black Power Stone
-2460565 3 --Marauding Captain
-36708764 3 --Roulette Spider
-98239899 3 --Blast with Chain
-54541900 3 --Karbonala Warrior
-51828629 3 --Giltia the D. Knight
-84747429 3 --Airorca
-11954712 3 --Flyfang
-56223084 3 --Needle Sunfish
-83239739 3 --Oyster Meister
-69846323 3 --Piercing Moray
-17214465 3 --Maiden of the Aqua
-77456781 3 --Fiend Kraken
-23771716 3 --7 Colored Fish
-96947648 3 --Salvage
-18605135 3 --Tornado Wall
-58873391 3 --Fish Depth Charge
-2376209 3 --Paleozoic Eldonia
-27911549 3 --Parasite Paracide
-77252217 3 --Chainsaw Insect
-50074522 3 --Magnetic Mosquito
-91559748 3 --Prickle Fairy
-93107608 3 --Howling Insect
-96938986 3 --Resonance Insect
-15367030 3 --Gokibore
-22493811 3 --Multiplication of Ants
-23615409 3 --Insect Barrier
-74701381 3 --DNA Surgery
-35803249 3 --Jinzo - Lord
-9418534 3 --Jinzo - Returner
-2851070 3 --Reflect Bounder
-11232355 3 --Destructotron
-27995943 3 --Dr. Frankenderp
-7526150 3 --Golgoil
-38265153 3 --Cyber Energy Shock
-91654806 3 --Cosmos Channelling
-98792570 3 --Gift of the Martyr
-30190809 3 --Gear Golem the Moving Fortress
-93151201 3 --Voltic Kong
-56256517 3 --Ledger of Legerdemain
-90669991 3 --Pineapple Blast
-38412161 3 --Chow Sai the Ghost Stopper
-95905259 3 --Chow Len the Prophet
-58324930 3 --Anarchist Monk Ranshin
-47731128 3 --Mei-Kou, Master of Barriers
-2468169 3 --Sealmaster Meisei
-97120394 3 --Anti-Magic Arrows
-19312169 3 --Talisman of Trap Sealing
-71983925 3 --Talisman of Spell Sealing
-35539880 3 --Birthright
-9287078 3 --Dark Renewal
-31709826 3 --Revival Jam
-46821314 3 --Humanoid Slime
-73216412 3 --Worm Drake
-79387392 3 --Reactor Slime
-46657337 3 --Muka Muka
-91862578 3 --Enraged Muka Muka
-3918345 3 --Magical Reflect Slime
-21770260 3 --Jam Breeding Machine
-53046408 3 --Emergency Provisions
-94163677 3 --Infinite Cards
-52971673 3 --Token Sundae
-21558682 3 --Jam Defender
-35346968 3 --Solemn Wishes
-14342283 3 --Token Stampede
-5600127 3 --Humanoid Worm Drake
-70781052 3 --Summoned Skull
-81919143 3 --Brain Crusher
-72630549 3 --Chaos Command Magician
-74976215 3 --Cross-Sword Beetle
-85651167 3 --Gearfried the Red-Eyes Iron Knight
-78658564 3 --Goblin Attack Force
-84055227 3 --Maiden of Macabre
-8034697 3 --Magical Marionette
-17601919 3 --Pumprincess the Princess of Ghosts
-58257569 3 --Red-Eyes Baby Dragon
-45702357 3 --Reversible Beetle
-43797906 3 --Warrior of Atlantis
-69123138 3 --Zera the Mant
-21323861 3 --Acid Rain
-38699854 3 --Book of Taiyou
-5556668 3 --Exchange
-90330453 3 --Last Day of Witch
-32062913 3 --Mega Ton Magical Cannon
-81756897 3 --Zera Ritual
-78783370 3 --Barrel Behind the Door
-95451366 3 --Exhausting Spell
-96008713 3 --Magical Arm Shield
-##Note that the Speed Duel banlist system is currently not supported, this is so that there are some limitations and reference for later
-#Limited 1
-300303012 1 --I'm Just Gonna Attack!
-300205004 1 --Twisted Personality (Skill Card)
-87102774 1 --Golden Ladybug
-19230408 1 --Offerings to the Doomed
-69599136 1 --Floodgate Trap Hole
-54704216 1 --Nightmare Wheel
-79852326 1 --Zoma the Spirit
-#Limited 2
-300104004 2 --Cocoon of Ultra Evolution (Skill Card)
-77585513 2 --Jinzo
-14457896 2 --Parasite Paranoid
-33365932 2 --Volcanic Shell
-1475311 2 --Allure of Darkness
-81439173 2 --Foolish Burial
-39996157 2 --Machine Angel Ritual
-32807846 2 --Reinforcement of the Army
-#Limited 3
-77235086 3 --Cyber Angel Benten
-71413901 3 --Breaker the Magical Warrior
-70095154 3 --Cyber Dragon
-7572887 3 --D.D. Warrior Lady
-14087893 3 --Book of Moon
-8267140 3 --Cosmic Cyclone
-58169731 3 --Wall of Disruption


### PR DESCRIPTION
updated April 01 banlists for OCG and Rush Duel, also Speed Duel for January