### PR TITLE
Speed Duel SGX4 + 2024-01 Banlist (sans Skill Cards)

### DIFF
--- a/Speed.lflist.conf
+++ b/Speed.lflist.conf
@@ -1259,6 +1259,101 @@ $whitelist
 78783370 3 --Barrel Behind the Door
 95451366 3 --Exhausting Spell
 96008713 3 --Magical Arm Shield
+##SGX4
+89943723 3 --Elemental HERO Neos
+69884162 3 --Elemental HERO Neos Alius
+85087012 3 --Card Trooper
+15341821 3 --Dandylion
+17955766 3 --Neo-Spacian Aqua Dolphin
+80344569 3 --Neo-Spacian Grand Mole
+23846921 3 --Arcana Force XXI - The World
+05861892 3 --Arcana Force EX - The Light Ruler
+49010598 3 --Divine Wrath
+15894048 3 --Ultimate Tyranno
+36042004 3 --Babycerasaurus
+47325505 3 --Fossil Dig
+14258627 3 --Gaia Plate the Earth Giant
+42009836 3 --Fossil Dyna Pachycephalo
+67169062 3 --Pot of Avarice
+05318639 3 --Mystical Space Typhoon
+56120475 3 --Sakuretsu Armor
+84425220 3 --Armed Dragon LV10 White
+89312388 3 --Elemental HERO Prisma
+45906428 3 --Miracle Fusion
+73146473 3 --Cross Porter
+54959865 3 --Neo-Spacian Air Hummingbird
+43237273 3 --Neo-Spacian Dark Panther
+17732278 3 --Neo-Spacian Glow Moss
+42015635 3 --Neo Space
+85787173 3 --Generation Next
+63703130 3 --O - Oversoul
+41933425 3 --Contact Gate
+82639107 3 --Convert Contact
+10186633 3 --EN Shuffle
+74414885 3 --NEXT
+37412656 3 --Hero Blast
+00027551 3 --Limit Reverse
+55171412 3 --Elemental HERO Aqua Neos
+85507811 3 --Elemental HERO Glow Neos
+28677304 3 --Elemental HERO Dark Neos
+48996569 3 --Elemental HERO Grand Neos
+49352945 3 --Elemental HERO Storm Neos
+64655485 3 --Elemental HERO Brave Neos
+62892347 3 --Arcana Force 0 - The Fool
+08396952 3 --Arcana Force I - The Magician
+35781051 3 --Arcana Force III - The Empress
+61175706 3 --Arcana Force IV - The Emperor
+97574404 3 --Arcana Force VI - The Lovers
+34568403 3 --Arcana Force VII - The Chariot
+60953118 3 --Arcana Force XIV - Temperance
+97452817 3 --Arcana Force XVIII - The Moon
+11819473 3 --Arcana Reading
+73206827 3 --Light Barrier
+37812118 3 --Cup of Ace
+92223641 3 --The Fountain in the Sky
+99189322 3 --Arcana Call
+36690018 3 --Reversal of Fate
+35011819 3 --By Order of the Emperor
+79161790 3 --Inverse Universe
+41753322 3 --Sauropod Brachion
+37265642 3 --Sabersaurus
+98022050 3 --Animadorned Archosaur
+52319752 3 --Black Veloci
+83235263 3 --Tyranno Infinity
+80186010 3 --Destroyersaurus
+39396763 3 --Dyna Base
+84808313 3 --Big Evolution Pill
+83682725 3 --Tail Swipe
+10080320 3 --Jurassic World
+14883228 3 --Typhoon
+58419204 3 --Survival Instinct
+42175079 3 --Volcanic Eruption
+98414735 3 --Paleozoic Canadia
+75780818 3 --Dyna Tank
+84778110 3 --Flint Cragger
+71544954 3 --Megarock Dragon
+10163855 3 --Shell Knight
+23147658 3 --Weathering Soldier
+87347365 3 --Revival Golem
+59380081 3 --Big-Tusked Mammoth
+17706537 3 --Fossil Tusker
+02694423 3 --Medusa Worm
+85808813 3 --Time Stream
+74694807 3 --Re-Fusion
+26956670 3 --Release from Stone
+68170903 3 --A Feint Plan
+99788587 3 --Blasting Fuse
+70156997 3 --Spiritual Earth Art - Kurogane
+21225115 3 --Fossil Dragon Skullgios
+10040267 3 --Fossil Machine Skull Buggy
+86520461 3 --Fossil Warrior Skull Bone
+59531356 3 --Fossil Warrior Skull Knight
+99910751 3 --Mokey Mokey Adrift
+45078193 3 --Cyberdark Cannon
+49306994 3 --White Veil
+44612603 3 --Survival's End
+13803864 3 --Mokey Mokey King
+10526791 3 --Elemental HERO Wildedge
 ##Note that the Speed Duel banlist system is currently not supported, this is so that there are some limitations and reference for later
 #Limited 1
 300303012 1 --I'm Just Gonna Attack!

--- a/Speed.lflist.conf
+++ b/Speed.lflist.conf
@@ -1,5 +1,5 @@
-#[2023.09 Speed Duel]
-!2023.09 Speed Duel
+#[2024.01 Speed Duel]
+!2024.01 Speed Duel
 $whitelist
 #Unlimited
 86198326 3 --7 Completed
@@ -1367,7 +1367,6 @@ $whitelist
 300104004 2 --Cocoon of Ultra Evolution (Skill Card)
 77585513 2 --Jinzo
 14457896 2 --Parasite Paranoid
-33365932 2 --Volcanic Shell
 1475311 2 --Allure of Darkness
 81439173 2 --Foolish Burial
 39996157 2 --Machine Angel Ritual


### PR DESCRIPTION
Heya! Me and some friends were trying to fool around with the EDOPro Speed Duel stuff, but noticed it hasn't been updated for Midterm Destruction yet.

This commit does the following:
- Updates banlist header
- [Puts Volcanic Shell to 3](https://yugipedia.com/wiki/January_2024_Limited_List_(Speed_Duel))
- [https://yugipedia.com/wiki/Speed_Duel_GX:_Midterm_Destruction](Adds debuts from SGX4)

It's missing the Skill Cards, as it seems you handle the passwords for those in a different way.

Hope this is all ok! 